### PR TITLE
Fix SwiftLint line-length violations in HomeView

### DIFF
--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -199,7 +199,7 @@ struct HomeView: View {
 
         do {
             let text = try await ocrService.extractText(fromPDFAt: url)
-            try await handleExtractedText(text, emptyMessage: String(localized: "No lab values were found in this document. Make sure the report is clearly visible."))
+            try await handleExtractedText(text, emptyMessage: documentEmptyMessage)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -212,10 +212,14 @@ struct HomeView: View {
 
         do {
             let text = try await ocrService.extractText(from: images)
-            try await handleExtractedText(text, emptyMessage: String(localized: "No lab values were found in this document. Make sure the report is clearly visible."))
+            try await handleExtractedText(text, emptyMessage: documentEmptyMessage)
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private var documentEmptyMessage: String {
+        String(localized: "No lab values were found in this document. Make sure the report is clearly visible.")
     }
 
     private func processText(_ text: String) async {


### PR DESCRIPTION
## Summary

The merge of #2 picked up the original commit but not the follow-up lint fix, so `main` currently has two 167-character lines in `HomeView.swift` that fail SwiftLint `--strict` on CI.

This cherry-picks the fix: extracts the duplicated localized "No lab values were found in this document" string into a `documentEmptyMessage` computed property so both call sites drop well under the 160-char limit.

## Test plan

- [ ] CI SwiftLint job passes on this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_012DFubvk7HcaKie5EaGiTwS)_