### PR TITLE
Add SwiftLint workflow that runs on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/realm/swiftlint:latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v5
+
+      - name: Run SwiftLint
+        run: swiftlint lint --strict --reporter github-actions-logging


### PR DESCRIPTION
Runs SwiftLint in strict mode against every PR targeting main so lint
violations block the merge instead of being caught later in the build
job. Uses the official SwiftLint container on Ubuntu to keep PR checks
fast and avoid macOS runner minutes for a pure lint pass.

https://claude.ai/code/session_013ab1sBg9p9JVuzH5i9S5kR