### PR TITLE
Trends: add liquid-glass bubble on chart selection

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# SessionStart hook: install SwiftLint so the pre-push lint hook can run.
+# Only runs in Claude Code on the web (Linux containers); local macOS dev
+# installs SwiftLint via brew.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+SWIFTLINT_VERSION="0.63.2"
+SWIFTLINT_BIN="/usr/local/bin/swiftlint"
+
+if [ -x "$SWIFTLINT_BIN" ] \
+    && "$SWIFTLINT_BIN" --version 2>/dev/null | grep -qx "$SWIFTLINT_VERSION"; then
+    echo "SwiftLint $SWIFTLINT_VERSION already installed; skipping."
+    exit 0
+fi
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64) ASSET="swiftlint_linux_amd64.zip" ;;
+    aarch64|arm64) ASSET="swiftlint_linux_arm64.zip" ;;
+    *)
+        echo "Unsupported architecture '$ARCH'; skipping SwiftLint install." >&2
+        exit 0
+        ;;
+esac
+
+URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/${ASSET}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Installing SwiftLint $SWIFTLINT_VERSION ($ARCH)…"
+curl -fsSL -o "$TMPDIR/swiftlint.zip" "$URL"
+unzip -o -q "$TMPDIR/swiftlint.zip" -d "$TMPDIR"
+
+SUDO=""
+if [ "$(id -u)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+$SUDO install -m 0755 "$TMPDIR/swiftlint-static" "$SWIFTLINT_BIN"
+
+"$SWIFTLINT_BIN" --version
+echo "SwiftLint installed at $SWIFTLINT_BIN"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "if ! command -v swiftlint >/dev/null 2>&1; then echo 'swiftlint not installed locally; skipping pre-push lint (CI will still run it)' >&2; exit 0; fi; swiftlint lint --strict --quiet >&2 || { echo 'SwiftLint failed — fix violations before pushing' >&2; exit 2; }",
+            "timeout": 90,
+            "statusMessage": "Running SwiftLint before push…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -175,13 +175,6 @@ struct TrendsView: View {
                 RuleMark(x: .value(String(localized: "Date"), selected.date))
                     .foregroundStyle(.secondary.opacity(0.5))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
-                    .annotation(
-                        position: .top,
-                        spacing: 8,
-                        overflowResolution: .init(x: .fit(to: .chart), y: .disabled)
-                    ) {
-                        scrubCallout(selected)
-                    }
 
                 PointMark(
                     x: .value(String(localized: "Date"), selected.date),
@@ -194,6 +187,20 @@ struct TrendsView: View {
             }
         }
         .chartXSelection(value: $selectedDate)
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                if let selected = selectedDataPoint,
+                   let plotFrame = proxy.plotFrame.map({ geo[$0] }),
+                   let xPos = proxy.position(forX: selected.date) {
+                    scrubCallout(selected)
+                        .position(
+                            x: clampedX(xPos, in: plotFrame),
+                            y: plotFrame.minY + 22
+                        )
+                        .allowsHitTesting(false)
+                }
+            }
+        }
         .onChange(of: selectedDataPoint?.date) { _, newDate in
             if newDate != nil { selectionFeedback.selectionChanged() }
         }
@@ -261,6 +268,11 @@ struct TrendsView: View {
     }
 
     // MARK: - Helpers
+
+    private func clampedX(_ x: CGFloat, in frame: CGRect) -> CGFloat {
+        let halfBubble: CGFloat = 60
+        return min(max(x, frame.minX + halfBubble), frame.maxX - halfBubble)
+    }
 
     private func formatValue(_ value: Double) -> String {
         value.truncatingRemainder(dividingBy: 1) == 0

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -269,9 +269,9 @@ struct TrendsView: View {
 
     // MARK: - Helpers
 
-    private func clampedX(_ x: CGFloat, in frame: CGRect) -> CGFloat {
+    private func clampedX(_ xPos: CGFloat, in frame: CGRect) -> CGFloat {
         let halfBubble: CGFloat = 60
-        return min(max(x, frame.minX + halfBubble), frame.maxX - halfBubble)
+        return min(max(xPos, frame.minX + halfBubble), frame.maxX - halfBubble)
     }
 
     private func formatValue(_ value: Double) -> String {

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -236,14 +236,15 @@ struct TrendsView: View {
                 }
             }
         }
+        .fixedSize()
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
-        .glassEffect(.regular.tint(Color.accentColor.opacity(0.18)).interactive(), in: Capsule())
+        .glassEffect(.regular, in: Capsule())
         .overlay(
             Capsule()
-                .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
+                .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
         )
-        .shadow(color: Color.black.opacity(0.18), radius: 8, x: 0, y: 3)
+        .shadow(color: Color.black.opacity(0.2), radius: 8, x: 0, y: 3)
     }
 
     private var selectedPointBubble: some View {

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -177,11 +177,20 @@ struct TrendsView: View {
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
                     .annotation(
                         position: .top,
-                        spacing: 6,
+                        spacing: 8,
                         overflowResolution: .init(x: .fit(to: .chart), y: .disabled)
                     ) {
                         scrubCallout(selected)
                     }
+
+                PointMark(
+                    x: .value(String(localized: "Date"), selected.date),
+                    y: .value(currentUnit, selected.value)
+                )
+                .symbolSize(0)
+                .annotation(position: .overlay, spacing: 0) {
+                    selectedPointBubble
+                }
             }
         }
         .chartXSelection(value: $selectedDate)
@@ -212,13 +221,14 @@ struct TrendsView: View {
     }
 
     private func scrubCallout(_ point: DataPoint) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .center, spacing: 1) {
             Text(point.date.formatted(date: .abbreviated, time: .omitted))
                 .font(.caption2)
                 .foregroundStyle(.secondary)
             HStack(alignment: .firstTextBaseline, spacing: 3) {
                 Text(formatValue(point.value))
-                    .font(.caption.bold())
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
                 if !point.unit.isEmpty {
                     Text(point.unit)
                         .font(.caption2)
@@ -226,9 +236,27 @@ struct TrendsView: View {
                 }
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .glassEffect(in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .glassEffect(.regular.tint(Color.accentColor.opacity(0.18)).interactive(), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
+        )
+        .shadow(color: Color.black.opacity(0.18), radius: 8, x: 0, y: 3)
+    }
+
+    private var selectedPointBubble: some View {
+        Circle()
+            .fill(Color.accentColor)
+            .frame(width: 10, height: 10)
+            .padding(4)
+            .glassEffect(.regular.interactive(), in: Circle())
+            .overlay(
+                Circle()
+                    .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
+            )
+            .shadow(color: Color.accentColor.opacity(0.45), radius: 6, x: 0, y: 0)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Make the selected value unmistakable: the scrub callout becomes a tinted,
shadowed capsule using the iOS 26 liquid glass material, and the selected
data point gets a matching glass-ringed bubble so the selection reads on
the chart itself rather than relying on the dashed rule alone.