### PR TITLE
Add settings modal with sorting, app version, license and build branch

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000075AA /* LabDisplayPreferences.swift */; };
 		AABB000000000000000077AA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000076AA /* Localizable.xcstrings */; };
 		AABB000000000000000078AA /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000079AA /* WelcomeView.swift */; };
+		AABB000000000000000086AA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000087AA /* SettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		AABB000000000000000075AA /* LabDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabDisplayPreferences.swift; sourceTree = "<group>"; };
 		AABB000000000000000076AA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		AABB000000000000000079AA /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
+		AABB000000000000000087AA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +160,7 @@
 				AABB000000000000000071AA /* DashboardView.swift */,
 				AABB000000000000000073AA /* ImportLandingView.swift */,
 				AABB000000000000000079AA /* WelcomeView.swift */,
+				AABB000000000000000087AA /* SettingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -185,6 +188,7 @@
 				AABB000000000000000016AA /* Sources */,
 				AABB000000000000000017AA /* Frameworks */,
 				AABB000000000000000018AA /* Resources */,
+				AABB000000000000000088AA /* Embed Git Branch */,
 			);
 			buildRules = (
 			);
@@ -240,6 +244,24 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		AABB000000000000000088AA /* Embed Git Branch */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Git Branch";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -u\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n[ -f \"$INFO_PLIST\" ] || exit 0\nBRANCH=$(cd \"${SRCROOT}\" && git rev-parse --abbrev-ref HEAD 2>/dev/null)\nCOMMIT=$(cd \"${SRCROOT}\" && git rev-parse --short HEAD 2>/dev/null)\n[ -n \"$BRANCH\" ] || BRANCH=unknown\n[ -n \"$COMMIT\" ] || COMMIT=unknown\n/usr/libexec/PlistBuddy -c \"Set :GitBranch $BRANCH\" \"$INFO_PLIST\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Add :GitBranch string $BRANCH\" \"$INFO_PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :GitCommit $COMMIT\" \"$INFO_PLIST\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Add :GitCommit string $COMMIT\" \"$INFO_PLIST\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		AABB000000000000000016AA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -265,6 +287,7 @@
 				AABB000000000000000072AA /* ImportLandingView.swift in Sources */,
 				AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */,
 				AABB000000000000000078AA /* WelcomeView.swift in Sources */,
+				AABB000000000000000086AA /* SettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -401,6 +424,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = LabImporter/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -428,6 +452,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = LabImporter/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;

--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -20,6 +20,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>GitBranch</key>
+	<string>unknown</string>
+	<key>GitCommit</key>
+	<string>unknown</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -14,7 +14,7 @@ struct DashboardView: View {
     let isProcessing: Bool
 
     @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
-    @State private var showOrderSheet = false
+    @State private var showSettings = false
     @State private var trendSheet: TrendSheet?
 
     private struct TrendSheet: Identifiable {
@@ -42,17 +42,17 @@ struct DashboardView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    showOrderSheet = true
+                    showSettings = true
                 } label: {
-                    Image(systemName: "slider.horizontal.3")
+                    Image(systemName: "gearshape")
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
                 importMenu
             }
         }
-        .sheet(isPresented: $showOrderSheet) {
-            LabOrderSheet(prefs: $prefs, allCodes: allCodeNames)
+        .sheet(isPresented: $showSettings) {
+            SettingsView(prefs: $prefs, allCodes: allCodeNames)
         }
         .sheet(item: $trendSheet) { sheet in
             NavigationStack {
@@ -210,142 +210,6 @@ private struct MetricData: Identifiable {
     let entry: LabReport.Entry
     let history: [SparkPoint]
     let status: RangeStatus?
-}
-
-private struct CodeName: Identifiable {
-    var id: String { code }
-    let code: String
-    let name: String
-}
-
-// MARK: - LabOrderSheet
-
-private struct LabOrderSheet: View {
-    @Binding var prefs: LabDisplayPreferences
-    let allCodes: [CodeName]
-    @Environment(\.dismiss) private var dismiss
-
-    @State private var visibleOrdered: [CodeName]
-    @State private var hiddenSet: Set<String>
-    @State private var pinnedSet: Set<String>
-
-    init(prefs: Binding<LabDisplayPreferences>, allCodes: [CodeName]) {
-        _prefs = prefs
-        self.allCodes = allCodes
-
-        let currentPrefs = prefs.wrappedValue
-        let hidden = currentPrefs.hiddenSet
-
-        var seen = Set<String>()
-        var initial: [CodeName] = []
-        for code in currentPrefs.orderedCodes where !hidden.contains(code) {
-            guard let item = allCodes.first(where: { $0.code == code }),
-                  seen.insert(code).inserted else { continue }
-            initial.append(item)
-        }
-        for item in allCodes where !hidden.contains(item.code) && seen.insert(item.code).inserted {
-            initial.append(item)
-        }
-
-        _visibleOrdered = State(initialValue: initial)
-        _hiddenSet = State(initialValue: hidden)
-        _pinnedSet = State(initialValue: currentPrefs.pinnedSet)
-    }
-
-    var body: some View {
-        NavigationStack {
-            List {
-                visibleSection
-                hiddenSection
-            }
-            .environment(\.editMode, .constant(.active))
-            .navigationTitle("Customize")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { save(); dismiss() }
-                        .fontWeight(.semibold)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var visibleSection: some View {
-        Section("Visible") {
-            ForEach(visibleOrdered) { item in
-                HStack(spacing: 12) {
-                    Button { togglePin(item.code) } label: {
-                        Image(systemName: pinnedSet.contains(item.code) ? "pin.fill" : "pin")
-                            .foregroundStyle(pinnedSet.contains(item.code) ? Color.yellow : Color.secondary)
-                            .frame(width: 20)
-                    }
-                    .buttonStyle(.plain)
-                    Text(item.name)
-                    Spacer()
-                    Button { hideCode(item.code) } label: {
-                        Image(systemName: "eye.slash")
-                            .foregroundStyle(Color.secondary)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .onMove { from, dest in visibleOrdered.move(fromOffsets: from, toOffset: dest) }
-        }
-    }
-
-    @ViewBuilder
-    private var hiddenSection: some View {
-        let hiddenItems = allCodes.filter { hiddenSet.contains($0.code) }
-        if !hiddenItems.isEmpty {
-            Section("Hidden") {
-                ForEach(hiddenItems) { item in
-                    HStack {
-                        Text(item.name)
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Button("Restore") { restoreCode(item.code) }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(Color.accentColor)
-                            .fontWeight(.medium)
-                    }
-                    .moveDisabled(true)
-                }
-            }
-        }
-    }
-
-    private func togglePin(_ code: String) {
-        if pinnedSet.contains(code) {
-            pinnedSet.remove(code)
-        } else {
-            pinnedSet.insert(code)
-        }
-    }
-
-    private func hideCode(_ code: String) {
-        hiddenSet.insert(code)
-        visibleOrdered.removeAll { $0.code == code }
-    }
-
-    private func restoreCode(_ code: String) {
-        hiddenSet.remove(code)
-        if let item = allCodes.first(where: { $0.code == code }) {
-            visibleOrdered.append(item)
-        }
-    }
-
-    private func save() {
-        let hiddenOrdered = allCodes.filter { hiddenSet.contains($0.code) }
-        var updated = prefs
-        updated.orderedCodes = visibleOrdered.map(\.code) + hiddenOrdered.map(\.code)
-        updated.pinnedCodes = Array(pinnedSet)
-        updated.hiddenCodes = Array(hiddenSet)
-        prefs = updated
-    }
 }
 
 // MARK: - MetricCard

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+// MARK: - App info
+
+enum AppInfo {
+    private static func string(_ key: String) -> String? {
+        guard let value = Bundle.main.infoDictionary?[key] as? String,
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var version: String { string("CFBundleShortVersionString") ?? "—" }
+    static var build: String { string("CFBundleVersion") ?? "—" }
+    static var branch: String { string("GitBranch") ?? "unknown" }
+    static var commit: String { string("GitCommit") ?? "unknown" }
+}
+
+// MARK: - SettingsView
+
+struct SettingsView: View {
+    @Binding var prefs: LabDisplayPreferences
+    let allCodes: [CodeName]
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Dashboard") {
+                    NavigationLink {
+                        LabSortEditor(prefs: $prefs, allCodes: allCodes)
+                    } label: {
+                        Label("Sort & Visibility", systemImage: "arrow.up.arrow.down")
+                    }
+                }
+
+                Section("About") {
+                    LabeledContent("Version", value: "\(AppInfo.version) (\(AppInfo.build))")
+                    LabeledContent("Branch", value: AppInfo.branch)
+                    LabeledContent("Commit", value: AppInfo.commit)
+                    NavigationLink {
+                        LicenseView()
+                    } label: {
+                        Label("License", systemImage: "doc.text")
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - CodeName
+
+struct CodeName: Identifiable {
+    var id: String { code }
+    let code: String
+    let name: String
+}
+
+// MARK: - LabSortEditor
+
+struct LabSortEditor: View {
+    @Binding var prefs: LabDisplayPreferences
+    let allCodes: [CodeName]
+
+    @State private var visibleOrdered: [CodeName]
+    @State private var hiddenSet: Set<String>
+    @State private var pinnedSet: Set<String>
+
+    init(prefs: Binding<LabDisplayPreferences>, allCodes: [CodeName]) {
+        _prefs = prefs
+        self.allCodes = allCodes
+
+        let currentPrefs = prefs.wrappedValue
+        let hidden = currentPrefs.hiddenSet
+
+        var seen = Set<String>()
+        var initial: [CodeName] = []
+        for code in currentPrefs.orderedCodes where !hidden.contains(code) {
+            guard let item = allCodes.first(where: { $0.code == code }),
+                  seen.insert(code).inserted else { continue }
+            initial.append(item)
+        }
+        for item in allCodes where !hidden.contains(item.code) && seen.insert(item.code).inserted {
+            initial.append(item)
+        }
+
+        _visibleOrdered = State(initialValue: initial)
+        _hiddenSet = State(initialValue: hidden)
+        _pinnedSet = State(initialValue: currentPrefs.pinnedSet)
+    }
+
+    var body: some View {
+        List {
+            visibleSection
+            hiddenSection
+        }
+        .environment(\.editMode, .constant(.active))
+        .navigationTitle("Sort & Visibility")
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: visibleOrdered.map(\.code)) { save() }
+        .onChange(of: hiddenSet) { save() }
+        .onChange(of: pinnedSet) { save() }
+    }
+
+    @ViewBuilder
+    private var visibleSection: some View {
+        Section("Visible") {
+            ForEach(visibleOrdered) { item in
+                HStack(spacing: 12) {
+                    Button { togglePin(item.code) } label: {
+                        Image(systemName: pinnedSet.contains(item.code) ? "pin.fill" : "pin")
+                            .foregroundStyle(pinnedSet.contains(item.code) ? Color.yellow : Color.secondary)
+                            .frame(width: 20)
+                    }
+                    .buttonStyle(.plain)
+                    Text(item.name)
+                    Spacer()
+                    Button { hideCode(item.code) } label: {
+                        Image(systemName: "eye.slash")
+                            .foregroundStyle(Color.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .onMove { from, dest in visibleOrdered.move(fromOffsets: from, toOffset: dest) }
+        }
+    }
+
+    @ViewBuilder
+    private var hiddenSection: some View {
+        let hiddenItems = allCodes.filter { hiddenSet.contains($0.code) }
+        if !hiddenItems.isEmpty {
+            Section("Hidden") {
+                ForEach(hiddenItems) { item in
+                    HStack {
+                        Text(item.name)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Restore") { restoreCode(item.code) }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(Color.accentColor)
+                            .fontWeight(.medium)
+                    }
+                    .moveDisabled(true)
+                }
+            }
+        }
+    }
+
+    private func togglePin(_ code: String) {
+        if pinnedSet.contains(code) {
+            pinnedSet.remove(code)
+        } else {
+            pinnedSet.insert(code)
+        }
+    }
+
+    private func hideCode(_ code: String) {
+        hiddenSet.insert(code)
+        visibleOrdered.removeAll { $0.code == code }
+    }
+
+    private func restoreCode(_ code: String) {
+        hiddenSet.remove(code)
+        if let item = allCodes.first(where: { $0.code == code }) {
+            visibleOrdered.append(item)
+        }
+    }
+
+    private func save() {
+        let hiddenOrdered = allCodes.filter { hiddenSet.contains($0.code) }
+        var updated = prefs
+        updated.orderedCodes = visibleOrdered.map(\.code) + hiddenOrdered.map(\.code)
+        updated.pinnedCodes = Array(pinnedSet)
+        updated.hiddenCodes = Array(hiddenSet)
+        prefs = updated
+    }
+}
+
+// MARK: - LicenseView
+
+struct LicenseView: View {
+    var body: some View {
+        ScrollView {
+            Text(Self.licenseText)
+                .font(.footnote)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .navigationTitle("License")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private static let licenseText = """
+    MIT License
+
+    Copyright (c) 2026 idoodler
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy \
+    of this software and associated documentation files (the "Software"), to deal \
+    in the Software without restriction, including without limitation the rights \
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell \
+    copies of the Software, and to permit persons to whom the Software is \
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all \
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR \
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE \
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER \
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, \
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \
+    SOFTWARE.
+    """
+}


### PR DESCRIPTION
Move the dashboard customize/sort UI into a Settings modal (gear icon)
that also surfaces the app version/build, the MIT license, and the git
branch and commit the app was built from. A build phase embeds the
branch and commit into Info.plist at build time.

https://claude.ai/code/session_01W9FN8e4vwc5tbGg6vS8Fgz