### PR TITLE
Fix ITMS-90737: add LSSupportsOpeningDocumentsInPlace to Info.plist

### DIFF
--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -63,6 +63,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
The app declares CFBundleDocumentTypes (image and PDF) but is not a
UIDocumentBrowserViewController-based app. App Store validation requires
document-based apps to declare either UISupportsDocumentBrowser or
LSSupportsOpeningDocumentsInPlace.

LabImporter imports files to extract lab values rather than editing the
user's originals in place, so it receives a copy in its Inbox. Setting
LSSupportsOpeningDocumentsInPlace to NO reflects that behavior.