### PR TITLE
Add unsupported device screen for devices without Apple Intelligence

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		AABB000000000000000077AA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000076AA /* Localizable.xcstrings */; };
 		AABB000000000000000078AA /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000079AA /* WelcomeView.swift */; };
 		AABB000000000000000086AA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000087AA /* SettingsView.swift */; };
-		AABB000000000000000088AA /* UnsupportedDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000089AA /* UnsupportedDeviceView.swift */; };
+		AABB0000000000000000C2DE /* UnsupportedDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,7 +73,7 @@
 		AABB000000000000000076AA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		AABB000000000000000079AA /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		AABB000000000000000087AA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		AABB000000000000000089AA /* UnsupportedDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedDeviceView.swift; sourceTree = "<group>"; };
+		AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedDeviceView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,7 +163,7 @@
 				AABB000000000000000073AA /* ImportLandingView.swift */,
 				AABB000000000000000079AA /* WelcomeView.swift */,
 				AABB000000000000000087AA /* SettingsView.swift */,
-				AABB000000000000000089AA /* UnsupportedDeviceView.swift */,
+				AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -291,7 +291,7 @@
 				AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */,
 				AABB000000000000000078AA /* WelcomeView.swift in Sources */,
 				AABB000000000000000086AA /* SettingsView.swift in Sources */,
-				AABB000000000000000088AA /* UnsupportedDeviceView.swift in Sources */,
+				AABB0000000000000000C2DE /* UnsupportedDeviceView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		AABB000000000000000077AA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000076AA /* Localizable.xcstrings */; };
 		AABB000000000000000078AA /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000079AA /* WelcomeView.swift */; };
 		AABB000000000000000086AA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000087AA /* SettingsView.swift */; };
+		AABB000000000000000088AA /* UnsupportedDeviceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000089AA /* UnsupportedDeviceView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +73,7 @@
 		AABB000000000000000076AA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		AABB000000000000000079AA /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		AABB000000000000000087AA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		AABB000000000000000089AA /* UnsupportedDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedDeviceView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +163,7 @@
 				AABB000000000000000073AA /* ImportLandingView.swift */,
 				AABB000000000000000079AA /* WelcomeView.swift */,
 				AABB000000000000000087AA /* SettingsView.swift */,
+				AABB000000000000000089AA /* UnsupportedDeviceView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */,
 				AABB000000000000000078AA /* WelcomeView.swift in Sources */,
 				AABB000000000000000086AA /* SettingsView.swift in Sources */,
+				AABB000000000000000088AA /* UnsupportedDeviceView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LabImporter/LabImporterApp.swift
+++ b/LabImporter/LabImporterApp.swift
@@ -4,7 +4,11 @@ import SwiftUI
 struct LabImporterApp: App {
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            if DeviceSupport.isSupported {
+                HomeView()
+            } else {
+                UnsupportedDeviceView()
+            }
         }
     }
 }

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -44,23 +44,11 @@ struct ParseResult {
 actor LabParserService {
 
     func parseLabValues(from text: String) async throws -> ParseResult {
-        let entries: [AILabEntry]
-        var reportDate: Date?
-        var patientName: String?
-        var authorName: String?
-
-        if SystemLanguageModel.default.isAvailable {
-            let report = try await parseWithFoundationModels(text: text)
-            entries = report.entries
-            reportDate = parseDate(report.reportDate)
-            patientName = report.patientName.isEmpty ? nil : report.patientName
-            authorName = report.authorName.isEmpty ? nil : report.authorName
-        } else {
-            entries = parseWithRegex(text: text)
-            reportDate = extractDate(from: text)
-            patientName = extractPatientName(from: text)
-            authorName = extractAuthorName(from: text)
-        }
+        let report = try await parseWithFoundationModels(text: text)
+        let entries = report.entries
+        let reportDate = parseDate(report.reportDate)
+        let patientName = report.patientName.isEmpty ? nil : report.patientName
+        let authorName = report.authorName.isEmpty ? nil : report.authorName
 
         let values = entries.map { entry in
             let normalizedValue = entry.rawValue
@@ -103,62 +91,7 @@ actor LabParserService {
         return response.content
     }
 
-    // MARK: - Regex fallback
-
-    // Handles: "CODE: value unit;" or "CODE: - ;" patterns from semicolon-separated German lab reports
-    private func parseWithRegex(text: String) -> [AILabEntry] {
-        let segments = text.components(separatedBy: ";")
-        let entryPattern = /([A-Z][A-Z0-9\-]+)\s*:\s*(-|[\d]+[,\.]?[\d]*)\s*(.*)/
-
-        return segments.compactMap { segment in
-            let trimmed = segment.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let match = trimmed.firstMatch(of: entryPattern) else { return nil }
-
-            let code = String(match.1)
-            let rawValue = String(match.2)
-            let unit = String(match.3).trimmingCharacters(in: .whitespacesAndNewlines)
-
-            return AILabEntry(code: code, rawValue: rawValue, unit: unit)
-        }
-    }
-
-    // MARK: - Name extraction helpers
-
-    private func extractPatientName(from text: String) -> String? {
-        let pattern = /Patientin?\s*:\s*([^\n;,]{3,60})/
-        guard let match = text.firstMatch(of: pattern) else { return nil }
-        let name = String(match.1).trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.isEmpty ? nil : name
-    }
-
-    private func extractAuthorName(from text: String) -> String? {
-        let pattern = /(?:Labor|Arzt(?:praxis)?)\s*:\s*([^\n;]{3,60})/
-        guard let match = text.firstMatch(of: pattern) else { return nil }
-        let name = String(match.1).trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.isEmpty ? nil : name
-    }
-
     // MARK: - Date helpers
-
-    private func extractDate(from text: String) -> Date? {
-        let germanPattern = /\b(\d{1,2})\.(\d{1,2})\.(\d{4})\b/
-        if let match = text.firstMatch(of: germanPattern) {
-            let day = Int(match.1) ?? 0
-            let month = Int(match.2) ?? 0
-            let year = Int(match.3) ?? 0
-            return makeDate(year: year, month: month, day: day)
-        }
-
-        let isoPattern = /\b(\d{4})-(\d{2})-(\d{2})\b/
-        if let match = text.firstMatch(of: isoPattern) {
-            let year = Int(match.1) ?? 0
-            let month = Int(match.2) ?? 0
-            let day = Int(match.3) ?? 0
-            return makeDate(year: year, month: month, day: day)
-        }
-
-        return nil
-    }
 
     private func parseDate(_ string: String) -> Date? {
         guard !string.isEmpty else { return nil }
@@ -166,14 +99,5 @@ actor LabParserService {
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter.date(from: string)
-    }
-
-    private func makeDate(year: Int, month: Int, day: Int) -> Date? {
-        guard year > 1900, (1...12).contains(month), (1...31).contains(day) else { return nil }
-        var components = DateComponents()
-        components.year = year
-        components.month = month
-        components.day = day
-        return Calendar.current.date(from: components)
     }
 }

--- a/LabImporter/Views/UnsupportedDeviceView.swift
+++ b/LabImporter/Views/UnsupportedDeviceView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import FoundationModels
+
+/// Determines whether the current device can run LabImporter's on-device AI parsing.
+enum DeviceSupport {
+    /// LabImporter relies on Apple Intelligence (Foundation Models) for lab value
+    /// extraction. The hardware is only truly unsupported when the system model
+    /// reports the device itself as ineligible — other unavailable reasons
+    /// (Apple Intelligence switched off, model still downloading) are recoverable
+    /// on supported hardware, so we don't block the app for those.
+    static var isSupported: Bool {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return true
+        case .unavailable(.deviceNotEligible):
+            return false
+        case .unavailable:
+            return true
+        }
+    }
+}
+
+struct UnsupportedDeviceView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 20) {
+                ZStack {
+                    Circle()
+                        .fill(Color.orange.opacity(0.13))
+                        .frame(width: 110, height: 110)
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.orange)
+                }
+
+                VStack(spacing: 8) {
+                    Text("Device Not Supported")
+                        .font(.largeTitle.bold())
+                        .multilineTextAlignment(.center)
+                    Text("LabImporter needs Apple Intelligence to read your lab reports privately on-device.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 32)
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 24) {
+                RequirementRow(
+                    icon: "iphone",
+                    color: .blue,
+                    title: "Apple Intelligence Device",
+                    description: "An iPhone with an A17 Pro or M-series chip is required."
+                )
+                RequirementRow(
+                    icon: "arrow.up.circle",
+                    color: .green,
+                    title: "iOS 26 or Later",
+                    description: "Make sure your device is running the latest version of iOS."
+                )
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+        }
+        .padding(.bottom, 48)
+    }
+}
+
+// MARK: - Requirement row
+
+private struct RequirementRow: View {
+    let icon: String
+    let color: Color
+    let title: LocalizedStringKey
+    let description: LocalizedStringKey
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(color.opacity(0.13))
+                    .frame(width: 58, height: 58)
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundStyle(color)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.body.bold())
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    UnsupportedDeviceView()
+}

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After the first manual run succeeds, builds are triggered automatically on the *
 
 4. Build and run on a connected device or simulator (iOS 26+).
 
-> **Note:** The on-device Foundation Models framework requires a physical device with Apple Intelligence support. The OCR and review UI work in the simulator, but AI-powered parsing falls back to the regex parser when the model is unavailable.
+> **Note:** The on-device Foundation Models framework requires a physical device with Apple Intelligence support. On unsupported hardware the app shows a "Device Not Supported" screen, since lab value parsing depends entirely on the on-device model.
 
 ---
 
@@ -116,7 +116,6 @@ After the first manual run succeeds, builds are triggered automatically on the *
 | PDF rendering | `PDFKit` — extracts embedded text or renders pages for OCR |
 | Text extraction | `Vision` — `VNRecognizeTextRequest` (German + English) |
 | Lab value parsing | `FoundationModels` — `@Generable` structured output via `LanguageModelSession` |
-| Parsing fallback | Swift regex, splits on `;` separators common in German lab reports |
 | Health import | `HealthKit` — `HKCDADocumentSample` (CDA R2 clinical document) |
 
 ---
@@ -131,7 +130,7 @@ All processing happens entirely on-device. No lab data is sent to any server. Th
 
 ### On-device AI inside the app
 
-Lab value extraction is powered by Apple's on-device Foundation Models framework (`LanguageModelSession` / `@Generable`). The language model runs entirely on the device — no lab data is transmitted to any external server or API. An Apple Intelligence-capable device (A17 Pro / M1 chip or later, iOS 26+) is required for AI-assisted parsing; the app falls back to a regex parser on unsupported hardware.
+Lab value extraction is powered by Apple's on-device Foundation Models framework (`LanguageModelSession` / `@Generable`). The language model runs entirely on the device — no lab data is transmitted to any external server or API. An Apple Intelligence-capable device (A17 Pro / M1 chip or later, iOS 26+) is required for parsing; on unsupported hardware the app shows a "Device Not Supported" screen.
 
 ### Built with AI assistance
 


### PR DESCRIPTION
Gate the app entry point so devices ineligible for Apple Intelligence
(Foundation Models) see a dedicated screen explaining the requirements
instead of a broken parsing experience.

https://claude.ai/code/session_01JF2CWtnSmASowA4AzYu1uW