### PR TITLE
Add GitHub repo and new-issue buttons to Settings

### DIFF
--- a/.github/workflows/build_labimporter.yml
+++ b/.github/workflows/build_labimporter.yml
@@ -40,6 +40,20 @@ jobs:
             exit 1
           fi
 
+      - name: Stamp Git metadata into Info.plist
+        run: |
+          PLIST="LabImporter/Info.plist"
+          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+          for entry in \
+            "GitBranch:${{ github.ref_name }}" \
+            "GitCommit:${GITHUB_SHA:0:7}" \
+            "GitRepositoryURL:${REPO_URL}"; do
+            key="${entry%%:*}"
+            value="${entry#*:}"
+            /usr/libexec/PlistBuddy -c "Set :${key} ${value}" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :${key} string ${value}" "$PLIST"
+          done
+
       - name: Install Project Dependencies
         run: bundle install
 

--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -25,7 +25,7 @@
 	<key>GitCommit</key>
 	<string>unknown</string>
 	<key>GitRepositoryURL</key>
-	<string>https://github.com/idoodler-s-Diabetes-Management/LabImporter</string>
+	<string></string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -24,6 +24,8 @@
 	<string>unknown</string>
 	<key>GitCommit</key>
 	<string>unknown</string>
+	<key>GitRepositoryURL</key>
+	<string>https://github.com/idoodler-s-Diabetes-Management/LabImporter</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -8314,6 +8314,82 @@
         }
       }
     },
+    "Version %@ (%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@ (%2$@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %1$@ (%2$@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@ (%2$@)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione %1$@ (%2$@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %1$@ (%2$@)"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versie %1$@ (%2$@)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wersja %1$@ (%2$@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão %1$@ (%2$@)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %1$@ (%2$@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sürüm %1$@ (%2$@)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версія %1$@ (%2$@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %1$@ (%2$@)"
+          }
+        }
+      }
+    },
     "View All Trends": {
       "localizations": {
         "de": {

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -6338,6 +6338,82 @@
         }
       }
     },
+    "Project": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projekt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyecto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Progetto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロジェクト"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Project"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projekt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projeto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проект"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proje"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проєкт"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "项目"
+          }
+        }
+      }
+    },
     "Report Date": {
       "localizations": {
         "de": {
@@ -6410,6 +6486,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "报告日期"
+          }
+        }
+      }
+    },
+    "Report an Issue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem melden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar de un problema"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segnala un problema"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題を報告"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Probleem melden"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgłoś problem"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatar um problema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить о проблеме"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sorun Bildir"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повідомити про проблему"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告问题"
           }
         }
       }
@@ -8234,6 +8386,82 @@
           "stringUnit": {
             "state": "translated",
             "value": "查看所有趋势"
+          }
+        }
+      }
+    },
+    "View on GitHub": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf GitHub ansehen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver en GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir sur GitHub"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizza su GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub で表示"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekijk op GitHub"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zobacz na GitHubie"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver no GitHub"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть на GitHub"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub'da Görüntüle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переглянути на GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上查看"
           }
         }
       }

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -78,21 +78,7 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Project") {
-                    if let repository = AppInfo.repositoryURL {
-                        externalLink("View on GitHub",
-                                     systemImage: "chevron.left.forwardslash.chevron.right",
-                                     url: repository)
-                    }
-                    if let newIssue = AppInfo.newIssueURL {
-                        externalLink("Report an Issue",
-                                     systemImage: "exclamationmark.bubble",
-                                     url: newIssue)
-                    }
-                }
-
                 Section("About") {
-                    LabeledContent("Version", value: "\(AppInfo.version) (\(AppInfo.build))")
                     LabeledContent("Branch", value: AppInfo.branch)
                     LabeledContent("Commit", value: AppInfo.commit)
                     NavigationLink {
@@ -100,6 +86,29 @@ struct SettingsView: View {
                     } label: {
                         Label("License", systemImage: "doc.text")
                     }
+                }
+
+                Section {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 28) {
+                            if let repository = AppInfo.repositoryURL {
+                                roundButton("chevron.left.forwardslash.chevron.right",
+                                            label: "View on GitHub",
+                                            url: repository)
+                            }
+                            if let newIssue = AppInfo.newIssueURL {
+                                roundButton("exclamationmark.bubble",
+                                            label: "Report an Issue",
+                                            url: newIssue)
+                            }
+                        }
+                        Text("Version \(AppInfo.version) (\(AppInfo.build))")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
                 }
             }
             .navigationTitle("Settings")
@@ -117,20 +126,19 @@ struct SettingsView: View {
         }
     }
 
-    /// A row that opens a web URL in an in-app browser, with a trailing affordance.
-    private func externalLink(_ titleKey: LocalizedStringKey, systemImage: String, url: URL) -> some View {
+    /// A circular icon button that opens a web URL in an in-app browser.
+    private func roundButton(_ systemImage: String, label: LocalizedStringKey, url: URL) -> some View {
         Button {
             browserURL = IdentifiedURL(url: url)
         } label: {
-            HStack {
-                Label(titleKey, systemImage: systemImage)
-                Spacer()
-                Image(systemName: "arrow.up.right")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
+            Image(systemName: systemImage)
+                .font(.title2)
+                .frame(width: 56, height: 56)
         }
+        .buttonStyle(.bordered)
+        .buttonBorderShape(.circle)
         .tint(.primary)
+        .accessibilityLabel(label)
     }
 }
 

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import SafariServices
 import SwiftUI
 
 // MARK: - App info
@@ -64,6 +65,7 @@ struct SettingsView: View {
     @Binding var prefs: LabDisplayPreferences
     let allCodes: [CodeName]
     @Environment(\.dismiss) private var dismiss
+    @State private var browserURL: IdentifiedURL?
 
     var body: some View {
         NavigationStack {
@@ -108,12 +110,18 @@ struct SettingsView: View {
                         .fontWeight(.semibold)
                 }
             }
+            .sheet(item: $browserURL) { item in
+                SafariView(url: item.url)
+                    .ignoresSafeArea()
+            }
         }
     }
 
-    /// A row that opens an external web URL, with a trailing affordance.
+    /// A row that opens a web URL in an in-app browser, with a trailing affordance.
     private func externalLink(_ titleKey: LocalizedStringKey, systemImage: String, url: URL) -> some View {
-        Link(destination: url) {
+        Button {
+            browserURL = IdentifiedURL(url: url)
+        } label: {
             HStack {
                 Label(titleKey, systemImage: systemImage)
                 Spacer()
@@ -122,7 +130,27 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .tint(.primary)
     }
+}
+
+// MARK: - In-app browser
+
+/// Wraps a `URL` so it can drive a `.sheet(item:)` presentation.
+private struct IdentifiedURL: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+/// SwiftUI wrapper around `SFSafariViewController` for in-app web browsing.
+private struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ controller: SFSafariViewController, context: Context) {}
 }
 
 // MARK: - CodeName

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -14,14 +14,13 @@ enum AppInfo {
     static var branch: String { string("GitBranch") ?? "unknown" }
     static var commit: String { string("GitCommit") ?? "unknown" }
 
-    /// Canonical upstream repository, used as a fallback when no build-time URL is stamped.
-    static let fallbackRepository = "https://github.com/idoodler-s-Diabetes-Management/LabImporter"
-
-    /// Web URL of the repository this build came from. Stamped into `Info.plist`
-    /// at build time (`GitRepositoryURL`) so forks open their own repo, with the
-    /// upstream as a fallback.
+    /// Web URL of the repository this build came from, stamped into `Info.plist`
+    /// at build time (`GitRepositoryURL`) so forks open their own repo. Returns
+    /// `nil` when the build did not stamp a URL (e.g. local Xcode builds), in
+    /// which case the GitHub buttons are hidden.
     static var repositoryURL: URL? {
-        webURL(from: string("GitRepositoryURL") ?? fallbackRepository)
+        guard let value = string("GitRepositoryURL") else { return nil }
+        return webURL(from: value)
     }
 
     /// URL that opens the "new issue" composer for `repositoryURL`.

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -145,7 +145,7 @@ struct SettingsView: View {
         }
         .buttonStyle(.bordered)
         .buttonBorderShape(.capsule)
-        .controlSize(.small)
+        .controlSize(.regular)
         .tint(.primary)
     }
 }

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -23,9 +23,21 @@ enum AppInfo {
         return webURL(from: value)
     }
 
-    /// URL that opens the "new issue" composer for `repositoryURL`.
+    /// URL that opens the "new issue" composer for `repositoryURL`, pre-filling
+    /// the body with build metadata to help triage reports.
     static var newIssueURL: URL? {
-        repositoryURL?.appendingPathComponent("issues/new")
+        guard let base = repositoryURL?.appendingPathComponent("issues/new"),
+              var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        let body = """
+
+
+        ---
+        Version: \(version) (\(build))
+        Branch: \(branch)
+        Commit: \(commit)
+        """
+        components.queryItems = [URLQueryItem(name: "body", value: body)]
+        return components.url
     }
 
     /// Normalizes a git remote string (`https`, `.git` suffix, or `git@host:owner/repo`

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -110,6 +110,7 @@ struct SettingsView: View {
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                 }
+                .listSectionSpacing(8)
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -90,16 +90,16 @@ struct SettingsView: View {
 
                 Section {
                     VStack(spacing: 16) {
-                        HStack(spacing: 28) {
+                        HStack(spacing: 12) {
                             if let repository = AppInfo.repositoryURL {
-                                roundButton("chevron.left.forwardslash.chevron.right",
-                                            label: "View on GitHub",
-                                            url: repository)
+                                pillButton("View on GitHub",
+                                           systemImage: "chevron.left.forwardslash.chevron.right",
+                                           url: repository)
                             }
                             if let newIssue = AppInfo.newIssueURL {
-                                roundButton("exclamationmark.bubble",
-                                            label: "Report an Issue",
-                                            url: newIssue)
+                                pillButton("Report an Issue",
+                                           systemImage: "exclamationmark.bubble",
+                                           url: newIssue)
                             }
                         }
                         Text("Version \(AppInfo.version) (\(AppInfo.build))")
@@ -126,19 +126,18 @@ struct SettingsView: View {
         }
     }
 
-    /// A circular icon button that opens a web URL in an in-app browser.
-    private func roundButton(_ systemImage: String, label: LocalizedStringKey, url: URL) -> some View {
+    /// A pill-shaped button that opens a web URL in an in-app browser.
+    private func pillButton(_ titleKey: LocalizedStringKey, systemImage: String, url: URL) -> some View {
         Button {
             browserURL = IdentifiedURL(url: url)
         } label: {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .frame(width: 56, height: 56)
+            Label(titleKey, systemImage: systemImage)
+                .font(.subheadline)
         }
         .buttonStyle(.bordered)
-        .buttonBorderShape(.circle)
+        .buttonBorderShape(.capsule)
+        .controlSize(.small)
         .tint(.primary)
-        .accessibilityLabel(label)
     }
 }
 

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -79,8 +79,16 @@ struct SettingsView: View {
                 }
 
                 Section("About") {
-                    LabeledContent("Branch", value: AppInfo.branch)
-                    LabeledContent("Commit", value: AppInfo.commit)
+                    LabeledContent {
+                        Text(AppInfo.branch)
+                    } label: {
+                        Label("Branch", systemImage: "arrow.triangle.branch")
+                    }
+                    LabeledContent {
+                        Text(AppInfo.commit)
+                    } label: {
+                        Label("Commit", systemImage: "number")
+                    }
                     NavigationLink {
                         LicenseView()
                     } label: {

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -13,6 +13,38 @@ enum AppInfo {
     static var build: String { string("CFBundleVersion") ?? "—" }
     static var branch: String { string("GitBranch") ?? "unknown" }
     static var commit: String { string("GitCommit") ?? "unknown" }
+
+    /// Canonical upstream repository, used as a fallback when no build-time URL is stamped.
+    static let fallbackRepository = "https://github.com/idoodler-s-Diabetes-Management/LabImporter"
+
+    /// Web URL of the repository this build came from. Stamped into `Info.plist`
+    /// at build time (`GitRepositoryURL`) so forks open their own repo, with the
+    /// upstream as a fallback.
+    static var repositoryURL: URL? {
+        webURL(from: string("GitRepositoryURL") ?? fallbackRepository)
+    }
+
+    /// URL that opens the "new issue" composer for `repositoryURL`.
+    static var newIssueURL: URL? {
+        repositoryURL?.appendingPathComponent("issues/new")
+    }
+
+    /// Normalizes a git remote string (`https`, `.git` suffix, or `git@host:owner/repo`
+    /// SSH form) into a browsable `https` web URL.
+    private static func webURL(from remote: String) -> URL? {
+        var value = remote.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        if let range = value.range(of: "git@") {
+            // git@github.com:owner/repo(.git) -> https://github.com/owner/repo
+            let hostAndPath = value[range.upperBound...].replacingOccurrences(of: ":", with: "/")
+            value = "https://" + hostAndPath
+        }
+        if value.hasSuffix(".git") {
+            value = String(value.dropLast(4))
+        }
+        return URL(string: value)
+    }
 }
 
 // MARK: - SettingsView
@@ -30,6 +62,19 @@ struct SettingsView: View {
                         LabSortEditor(prefs: $prefs, allCodes: allCodes)
                     } label: {
                         Label("Sort & Visibility", systemImage: "arrow.up.arrow.down")
+                    }
+                }
+
+                Section("Project") {
+                    if let repository = AppInfo.repositoryURL {
+                        externalLink("View on GitHub",
+                                     systemImage: "chevron.left.forwardslash.chevron.right",
+                                     url: repository)
+                    }
+                    if let newIssue = AppInfo.newIssueURL {
+                        externalLink("Report an Issue",
+                                     systemImage: "exclamationmark.bubble",
+                                     url: newIssue)
                     }
                 }
 
@@ -51,6 +96,19 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                         .fontWeight(.semibold)
                 }
+            }
+        }
+    }
+
+    /// A row that opens an external web URL, with a trailing affordance.
+    private func externalLink(_ titleKey: LocalizedStringKey, systemImage: String, url: URL) -> some View {
+        Link(destination: url) {
+            HStack {
+                Label(titleKey, systemImage: systemImage)
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
         }
     }


### PR DESCRIPTION
Add a "Project" section in Settings with two icon-labelled links:
"View on GitHub" and "Report an Issue".

To always open the correct repository when the project is forked, the
repo URL is read from a new `GitRepositoryURL` Info.plist key that is
stamped at build time from the GitHub Actions context
(`github.server_url`/`github.repository`), alongside the existing
GitBranch/GitCommit metadata. A canonical upstream URL is used as a
fallback for local/unstamped builds. The new-issue link is derived from
the resolved repository URL.

Localized the new strings across all shipped languages.