### PR TITLE
Use consistent X close button across all sheets

### DIFF
--- a/LabImporter/Views/CodePickerSheet.swift
+++ b/LabImporter/Views/CodePickerSheet.swift
@@ -107,7 +107,7 @@ struct CodePickerSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Button("Cancel") { dismiss() }
+                        Button(role: .close) { dismiss() }
                     }
                 }
         }

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -67,7 +67,7 @@ struct ReviewView: View {
         .toolbar {
             keyboardDoneButton
             ToolbarItem(placement: .topBarLeading) {
-                Button("Cancel") { showDiscardAlert = true }
+                Button(role: .close) { showDiscardAlert = true }
             }
         }
         .alert("Discard Report?", isPresented: $showDiscardAlert) {
@@ -292,7 +292,7 @@ private extension ReviewView {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") {
+                    Button(role: .close) {
                         showAddValue = false
                         resetAddForm()
                     }

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -143,9 +143,8 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { dismiss() }
-                        .fontWeight(.semibold)
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(role: .close) { dismiss() }
                 }
             }
             .sheet(item: $browserURL) { item in

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -92,7 +92,7 @@ struct TrendsView: View {
         .toolbar {
             if let onDismiss {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Close", action: onDismiss)
+                    Button(role: .close, action: onDismiss)
                 }
             }
             if !selectedCode.isEmpty {


### PR DESCRIPTION
Replace the mix of text 'Close'/'Done'/'Cancel' dismiss buttons in the
sheet toolbars with the native iOS 26 `Button(role: .close)`, which
renders the standard circular X glyph with a system-provided, localized
accessibility label and Liquid Glass styling. Standardize placement to
.topBarLeading (moving Settings' former 'Done' button from trailing).

Affected sheets: trends, settings, code picker, review, and the add-value
sub-sheet. Alert buttons, the keyboard 'Done', and the onboarding 'Get
Started' CTA are intentionally left as labeled buttons.