### PR TITLE
Allow adding values to an open report via scan/file/paste

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		AABB0000000000000000C0DE /* CodePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000C1DE /* CodePickerSheet.swift */; };
 		AABB000000000000000095AA /* LoincBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000094AA /* LoincBrowserView.swift */; };
 		AABB000000000000000080AA /* DocumentScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000081AA /* DocumentScannerView.swift */; };
+		AABB0000000000000000F1AA /* LabImportEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000F2AA /* LabImportEngine.swift */; };
+		AABB0000000000000000F3AA /* AddValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000F4AA /* AddValueSheet.swift */; };
 		AABB000000000000000082AA /* VisionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000083AA /* VisionKit.framework */; };
 		AABB000000000000000084AA /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000085AA /* PDFKit.framework */; };
 		AABB000000000000000093AA /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000092AA /* libsqlite3.tbd */; };
@@ -60,6 +62,8 @@
 		AABB0000000000000000C1DE /* CodePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePickerSheet.swift; sourceTree = "<group>"; };
 		AABB000000000000000094AA /* LoincBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoincBrowserView.swift; sourceTree = "<group>"; };
 		AABB000000000000000081AA /* DocumentScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentScannerView.swift; sourceTree = "<group>"; };
+		AABB0000000000000000F2AA /* LabImportEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabImportEngine.swift; sourceTree = "<group>"; };
+		AABB0000000000000000F4AA /* AddValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddValueSheet.swift; sourceTree = "<group>"; };
 		AABB000000000000000083AA /* VisionKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VisionKit.framework; path = System/Library/Frameworks/VisionKit.framework; sourceTree = SDKROOT; };
 		AABB000000000000000085AA /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = System/Library/Frameworks/PDFKit.framework; sourceTree = SDKROOT; };
 		AABB000000000000000092AA /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -168,6 +172,8 @@
 				AABB0000000000000000C1DE /* CodePickerSheet.swift */,
 				AABB000000000000000094AA /* LoincBrowserView.swift */,
 				AABB000000000000000081AA /* DocumentScannerView.swift */,
+				AABB0000000000000000F2AA /* LabImportEngine.swift */,
+				AABB0000000000000000F4AA /* AddValueSheet.swift */,
 				AABB000000000000000065AA /* HistoryView.swift */,
 				AABB000000000000000067AA /* ReportDetailView.swift */,
 				AABB000000000000000069AA /* TrendsView.swift */,
@@ -314,6 +320,8 @@
 				AABB0000000000000000C0DE /* CodePickerSheet.swift in Sources */,
 				AABB000000000000000095AA /* LoincBrowserView.swift in Sources */,
 				AABB000000000000000080AA /* DocumentScannerView.swift in Sources */,
+				AABB0000000000000000F1AA /* LabImportEngine.swift in Sources */,
+				AABB0000000000000000F3AA /* AddValueSheet.swift in Sources */,
 				AABB000000000000000060AA /* LabReport.swift in Sources */,
 				AABB000000000000000064AA /* HistoryView.swift in Sources */,
 				AABB000000000000000066AA /* ReportDetailView.swift in Sources */,

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -4210,6 +4210,82 @@
         }
       }
     },
+    "Enter Manually": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuell eingeben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introducir manualmente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisir manuellement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci manualmente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動で入力"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Handmatig invoeren"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wprowadź ręcznie"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserir manualmente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввести вручную"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elle gir"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввести вручну"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动输入"
+          }
+        }
+      }
+    },
     "Error": {
       "localizations": {
         "de": {

--- a/LabImporter/Views/AddValueSheet.swift
+++ b/LabImporter/Views/AddValueSheet.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Manual single-value entry, presented from the review/edit screen's "Add Value"
+/// menu. Assembles a `LabValue` from the form and hands it back to the caller; the
+/// form resets on its own because SwiftUI recreates the sheet on each presentation.
+struct AddValueSheet: View {
+    let onAdd: (LabValue) -> Void
+
+    @State private var name = ""
+    @State private var code = ""
+    @State private var displayValue = ""
+    @State private var unit = ""
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Name", text: $name)
+                        .autocorrectionDisabled()
+                    NavigationLink {
+                        AddCodePickerPage(code: $code, name: $name)
+                    } label: {
+                        HStack {
+                            Text("Lab Test")
+                            Spacer()
+                            Text(code.isEmpty ? "Any" : code)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Section {
+                    TextField("Value", text: $displayValue)
+                        .keyboardType(.decimalPad)
+                    TextField("Unit (optional)", text: $unit)
+                        .autocorrectionDisabled()
+                }
+            }
+            .navigationTitle("Add Value")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(role: .close) { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Add") { commit() }
+                        .fontWeight(.semibold)
+                        .disabled(name.isEmpty || displayValue.isEmpty)
+                }
+            }
+        }
+    }
+
+    private func commit() {
+        let resolvedCode = code.isEmpty
+            ? "MANUAL"
+            : code.uppercased().trimmingCharacters(in: .whitespaces)
+        let normalized = displayValue.replacingOccurrences(of: ",", with: ".")
+        let value = LabValue(
+            code: resolvedCode,
+            name: name.trimmingCharacters(in: .whitespaces),
+            displayValue: displayValue,
+            numericValue: Double(normalized),
+            unit: unit.trimmingCharacters(in: .whitespaces)
+        )
+        onAdd(value)
+        dismiss()
+    }
+}

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UniformTypeIdentifiers
 import VisionKit
 
 struct HomeView: View {
@@ -8,53 +7,19 @@ struct HomeView: View {
     @State private var isLoaded = false
 
     // Import flow state
-    @State private var showScanner = false
-    @State private var showFileImporter = false
-    @State private var isProcessing = false
+    @State private var importEngine = LabImportEngine()
     @State private var labValues: [LabValue] = []
     @State private var parsedReportDate: Date?
     @State private var parsedPatientName: String?
     @State private var parsedAuthorName: String?
     @State private var showReview = false
-    @State private var errorMessage: String?
     @State private var clipboardHasContent = false
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
-
-    private let ocrService = OCRService()
-    private let parserService = LabParserService()
 
     var body: some View {
         NavigationStack {
             content
-                .fullScreenCover(isPresented: $showScanner) {
-                    DocumentScannerView(
-                        onComplete: { images in
-                            Task { await processImages(images) }
-                        },
-                        onError: { error in
-                            errorMessage = error.localizedDescription
-                        }
-                    )
-                    .ignoresSafeArea()
-                }
-                .fileImporter(
-                    isPresented: $showFileImporter,
-                    allowedContentTypes: [.pdf, .image],
-                    allowsMultipleSelection: false
-                ) { result in
-                    switch result {
-                    case .success(let urls):
-                        guard let url = urls.first else { return }
-                        Task { await processFile(at: url) }
-                    case .failure:
-                        errorMessage = String(localized: "Could not load the selected file.")
-                    }
-                }
-                .alert("Error", isPresented: .constant(errorMessage != nil)) {
-                    Button("OK") { errorMessage = nil }
-                } message: {
-                    Text(errorMessage ?? "")
-                }
+                .labImport(engine: importEngine)
         }
         .sheet(isPresented: $showReview) {
             NavigationStack {
@@ -67,9 +32,6 @@ struct HomeView: View {
             }
             .interactiveDismissDisabled()
         }
-        .overlay {
-            if isProcessing { ProcessingHUD() }
-        }
         .task { await loadReports() }
         .onChange(of: showReview) { _, showing in
             if !showing { Task { await loadReports() } }
@@ -77,9 +39,12 @@ struct HomeView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
             Task { await loadReports() }
         }
-        .onAppear { refreshClipboardState() }
+        .onAppear {
+            refreshClipboardState()
+            configureImportEngine()
+        }
         .onOpenURL { url in
-            Task { await processSharedURL(url) }
+            Task { await importEngine.processFile(at: url) }
         }
         .fullScreenCover(isPresented: Binding(
             get: { !hasSeenWelcome },
@@ -98,25 +63,37 @@ struct HomeView: View {
                 .scaleEffect(1.4)
         } else if reports.isEmpty {
             ImportLandingView(
-                onScan: openScanner,
-                onPickFile: { showFileImporter = true },
-                onPaste: pasteFromClipboard,
+                onScan: { importEngine.scan() },
+                onPickFile: { importEngine.pickFile() },
+                onPaste: { importEngine.paste() },
                 onManual: createManually,
                 scannerAvailable: VNDocumentCameraViewController.isSupported,
                 clipboardAvailable: clipboardHasContent,
-                isProcessing: isProcessing
+                isProcessing: importEngine.isProcessing
             )
         } else {
             DashboardView(
                 reports: reports,
-                onScan: openScanner,
-                onPickFile: { showFileImporter = true },
-                onPaste: pasteFromClipboard,
+                onScan: { importEngine.scan() },
+                onPickFile: { importEngine.pickFile() },
+                onPaste: { importEngine.paste() },
                 onManual: createManually,
                 scannerAvailable: VNDocumentCameraViewController.isSupported,
                 clipboardAvailable: clipboardHasContent,
-                isProcessing: isProcessing
+                isProcessing: importEngine.isProcessing
             )
+        }
+    }
+
+    // MARK: - Import engine
+
+    private func configureImportEngine() {
+        importEngine.onParsed = { result in
+            labValues = result.values
+            parsedReportDate = result.reportDate
+            parsedPatientName = result.patientName
+            parsedAuthorName = result.authorName
+            showReview = true
         }
     }
 
@@ -138,25 +115,6 @@ struct HomeView: View {
         clipboardHasContent = pasteboard.hasImages || pasteboard.hasStrings
     }
 
-    private func pasteFromClipboard() {
-        let pasteboard = UIPasteboard.general
-        if let image = pasteboard.image {
-            Task { await processImages([image]) }
-        } else if let text = pasteboard.string, !text.isEmpty {
-            Task { await processText(text) }
-        }
-    }
-
-    // MARK: - Scanner
-
-    private func openScanner() {
-        guard VNDocumentCameraViewController.isSupported else {
-            errorMessage = String(localized: "Document scanning isn't available on this device.")
-            return
-        }
-        showScanner = true
-    }
-
     // MARK: - Manual creation
 
     private func createManually() {
@@ -165,110 +123,6 @@ struct HomeView: View {
         parsedPatientName = nil
         parsedAuthorName = nil
         showReview = true
-    }
-
-    // MARK: - Shared URL (share sheet / open with)
-
-    private func processSharedURL(_ url: URL) async {
-        await processFile(at: url)
-    }
-
-    private func processFile(at url: URL) async {
-        let accessing = url.startAccessingSecurityScopedResource()
-        defer {
-            if accessing { url.stopAccessingSecurityScopedResource() }
-        }
-
-        let isPDF = url.pathExtension.lowercased() == "pdf"
-            || (try? url.resourceValues(forKeys: [.contentTypeKey]).contentType?.conforms(to: .pdf)) == true
-
-        if isPDF {
-            await processPDF(at: url)
-        } else if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
-            await processImages([image])
-        } else {
-            errorMessage = String(localized: "Could not load the selected file.")
-        }
-    }
-
-    // MARK: - Processing
-
-    private func processPDF(at url: URL) async {
-        isProcessing = true
-        defer { isProcessing = false }
-
-        do {
-            let text = try await ocrService.extractText(fromPDFAt: url)
-            try await handleExtractedText(text, emptyMessage: documentEmptyMessage)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func processImages(_ images: [UIImage]) async {
-        guard !images.isEmpty else { return }
-        isProcessing = true
-        defer { isProcessing = false }
-
-        do {
-            let text = try await ocrService.extractText(from: images)
-            try await handleExtractedText(text, emptyMessage: documentEmptyMessage)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private var documentEmptyMessage: String {
-        String(localized: "No lab values were found in this document. Make sure the report is clearly visible.")
-    }
-
-    private func processText(_ text: String) async {
-        isProcessing = true
-        defer { isProcessing = false }
-
-        do {
-            try await handleExtractedText(text, emptyMessage: String(localized: "No lab values were found in the clipboard text."))
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func handleExtractedText(_ text: String, emptyMessage: String) async throws {
-        let result = try await parserService.parseLabValues(from: text)
-
-        if result.values.isEmpty {
-            errorMessage = emptyMessage
-            return
-        }
-
-        labValues = result.values
-        parsedReportDate = result.reportDate
-        parsedPatientName = result.patientName
-        parsedAuthorName = result.authorName
-        showReview = true
-    }
-}
-
-// MARK: - Processing HUD
-
-private struct ProcessingHUD: View {
-    var body: some View {
-        Color.clear
-            .ignoresSafeArea()
-            .overlay {
-                VStack(spacing: 16) {
-                    ProgressView()
-                        .controlSize(.large)
-                    Text("Analyzing lab report…")
-                        .font(.headline)
-                    Text("Using on-device AI")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(32)
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24))
-            }
-            .transition(.opacity.animation(.easeInOut(duration: 0.2)))
     }
 }
 

--- a/LabImporter/Views/LabImportEngine.swift
+++ b/LabImporter/Views/LabImportEngine.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import VisionKit
+
+/// Shared driver for the "known" import methods — scan, file, paste — that turn a
+/// document or clipboard content into parsed `LabValue`s via OCR + the on-device AI.
+///
+/// Both the home screen (creating a brand-new report) and the review/edit sheet
+/// (adding more values to an already-open report) use this. Callers hold one as
+/// `@State`, set `onParsed`, attach `.labImport(engine:)`, and call `scan()` /
+/// `pickFile()` / `paste()` from their own buttons. The engine owns the scanner,
+/// file importer, error alert and processing HUD so each call site stays small.
+@MainActor
+@Observable
+final class LabImportEngine {
+    /// Invoked on the main actor with the parsed result of a successful import.
+    /// Home replaces its working set with `result.values`; review appends to it.
+    var onParsed: ((ParseResult) -> Void)?
+
+    /// Shown when an import yields no usable values.
+    var emptyMessage = String(
+        localized: "No lab values were found in this document. Make sure the report is clearly visible."
+    )
+
+    private(set) var isProcessing = false
+
+    fileprivate var errorMessage: String?
+    fileprivate var showScanner = false
+    fileprivate var showFileImporter = false
+
+    private let ocrService = OCRService()
+    private let parserService = LabParserService()
+
+    // MARK: - Method entry points
+
+    func scan() {
+        guard VNDocumentCameraViewController.isSupported else {
+            errorMessage = String(localized: "Document scanning isn't available on this device.")
+            return
+        }
+        showScanner = true
+    }
+
+    func pickFile() {
+        showFileImporter = true
+    }
+
+    func paste() {
+        let pasteboard = UIPasteboard.general
+        if let image = pasteboard.image {
+            Task { await processImages([image]) }
+        } else if let text = pasteboard.string, !text.isEmpty {
+            Task { await processText(text) }
+        }
+    }
+
+    // MARK: - Processing
+
+    func processFile(at url: URL) async {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessing { url.stopAccessingSecurityScopedResource() }
+        }
+
+        let isPDF = url.pathExtension.lowercased() == "pdf"
+            || (try? url.resourceValues(forKeys: [.contentTypeKey]).contentType?.conforms(to: .pdf)) == true
+
+        if isPDF {
+            await processPDF(at: url)
+        } else if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
+            await processImages([image])
+        } else {
+            errorMessage = String(localized: "Could not load the selected file.")
+        }
+    }
+
+    func processImages(_ images: [UIImage]) async {
+        guard !images.isEmpty else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            let text = try await ocrService.extractText(from: images)
+            try await handleExtractedText(text)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func processText(_ text: String) async {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            try await handleExtractedText(text)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func processPDF(at url: URL) async {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            let text = try await ocrService.extractText(fromPDFAt: url)
+            try await handleExtractedText(text)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func handleExtractedText(_ text: String) async throws {
+        let result = try await parserService.parseLabValues(from: text)
+        if result.values.isEmpty {
+            errorMessage = emptyMessage
+            return
+        }
+        onParsed?(result)
+    }
+
+    fileprivate func reportError(_ message: String) {
+        errorMessage = message
+    }
+}
+
+// MARK: - View wiring
+
+private struct LabImportModifier: ViewModifier {
+    @Bindable var engine: LabImportEngine
+
+    func body(content: Content) -> some View {
+        content
+            .fullScreenCover(isPresented: $engine.showScanner) {
+                DocumentScannerView(
+                    onComplete: { images in
+                        Task { await engine.processImages(images) }
+                    },
+                    onError: { error in
+                        engine.reportError(error.localizedDescription)
+                    }
+                )
+                .ignoresSafeArea()
+            }
+            .fileImporter(
+                isPresented: $engine.showFileImporter,
+                allowedContentTypes: [.pdf, .image],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let url = urls.first else { return }
+                    Task { await engine.processFile(at: url) }
+                case .failure:
+                    engine.reportError(String(localized: "Could not load the selected file."))
+                }
+            }
+            .alert("Error", isPresented: Binding(
+                get: { engine.errorMessage != nil },
+                set: { if !$0 { engine.errorMessage = nil } }
+            )) {
+                Button("OK") { engine.errorMessage = nil }
+            } message: {
+                Text(engine.errorMessage ?? "")
+            }
+            .overlay {
+                if engine.isProcessing { ProcessingHUD() }
+            }
+    }
+}
+
+extension View {
+    /// Wires up the scanner, file importer, error alert and processing HUD that
+    /// back a `LabImportEngine`. Pair with `engine.scan()` / `pickFile()` /
+    /// `paste()` from your own controls.
+    func labImport(engine: LabImportEngine) -> some View {
+        modifier(LabImportModifier(engine: engine))
+    }
+}
+
+// MARK: - Processing HUD
+
+struct ProcessingHUD: View {
+    var body: some View {
+        Color.clear
+            .ignoresSafeArea()
+            .overlay {
+                VStack(spacing: 16) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Analyzing lab report…")
+                        .font(.headline)
+                    Text("Using on-device AI")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(32)
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24))
+            }
+            .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+    }
+}

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VisionKit
 
 struct ReviewView: View {
     @State var labValues: [LabValue]
@@ -18,10 +19,7 @@ struct ReviewView: View {
     @State private var replacingReport: LabReport?
 
     @State private var showAddValue = false
-    @State private var addName = ""
-    @State private var addCode = ""
-    @State private var addDisplayValue = ""
-    @State private var addUnit = ""
+    @State private var importEngine = LabImportEngine()
 
     @FocusState private var anyFieldFocused: Bool
     @Environment(\.dismiss) private var dismiss
@@ -79,7 +77,9 @@ struct ReviewView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             bottomButtons
         }
+        .labImport(engine: importEngine)
         .task { await loadHKCharacteristics() }
+        .onAppear { configureImportEngine() }
         .sheet(isPresented: Binding(
             get: { cdaShareURL != nil },
             set: { if !$0 { cdaShareURL = nil } }
@@ -90,7 +90,7 @@ struct ReviewView: View {
             }
         }
         .sheet(isPresented: $showAddValue) {
-            addValueSheet
+            AddValueSheet { labValues.append($0) }
         }
         .alert("Export Error", isPresented: .constant(cdaError != nil)) {
             Button("OK") { cdaError = nil }
@@ -207,12 +207,7 @@ struct ReviewView: View {
                         }
                     }
             }
-            Button {
-                showAddValue = true
-            } label: {
-                Label("Add Value", systemImage: "plus.circle")
-            }
-            .foregroundStyle(Color.accentColor)
+            addValueMenu
         } header: {
             Text("Lab Values — tap values to correct them")
         }
@@ -264,48 +259,42 @@ struct ReviewView: View {
 
 private extension ReviewView {
 
-    var addValueSheet: some View {
-        NavigationStack {
-            Form {
-                Section {
-                    TextField("Name", text: $addName)
-                        .autocorrectionDisabled()
-                    NavigationLink {
-                        AddCodePickerPage(code: $addCode, name: $addName)
-                    } label: {
-                        HStack {
-                            Text("Lab Test")
-                            Spacer()
-                            Text(addCode.isEmpty ? "Any" : addCode)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-                Section {
-                    TextField("Value", text: $addDisplayValue)
-                        .keyboardType(.decimalPad)
-                    TextField("Unit (optional)", text: $addUnit)
-                        .autocorrectionDisabled()
-                }
+    /// Lets the user grow the open report with the same "known methods" used to
+    /// create one — scan, file, paste — plus manual entry. Imported values are
+    /// appended to the current set (see `configureImportEngine`).
+    var addValueMenu: some View {
+        Menu {
+            Button {
+                importEngine.scan()
+            } label: {
+                Label("Scan Document", systemImage: "doc.viewfinder")
             }
-            .navigationTitle("Add Value")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(role: .close) {
-                        showAddValue = false
-                        resetAddForm()
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Add") {
-                        commitAddValue()
-                    }
-                    .fontWeight(.semibold)
-                    .disabled(addName.isEmpty || addDisplayValue.isEmpty)
-                }
+            .disabled(!VNDocumentCameraViewController.isSupported)
+
+            Button {
+                importEngine.pickFile()
+            } label: {
+                Label("Choose File", systemImage: "folder")
             }
+
+            Button {
+                importEngine.paste()
+            } label: {
+                Label("Paste from Clipboard", systemImage: "doc.on.clipboard")
+            }
+            .disabled(!clipboardHasContent)
+
+            Divider()
+
+            Button {
+                showAddValue = true
+            } label: {
+                Label("Enter Manually", systemImage: "square.and.pencil")
+            }
+        } label: {
+            Label("Add Value", systemImage: "plus.circle")
         }
+        .foregroundStyle(Color.accentColor)
     }
 
     var bottomButtons: some View {
@@ -361,6 +350,19 @@ private extension ReviewView {
 
 private extension ReviewView {
 
+    var clipboardHasContent: Bool {
+        let pasteboard = UIPasteboard.general
+        return pasteboard.hasImages || pasteboard.hasStrings
+    }
+
+    /// Appends freshly parsed values to the open report rather than replacing it,
+    /// so scan/file/paste add to what the user is already reviewing or editing.
+    func configureImportEngine() {
+        importEngine.onParsed = { result in
+            labValues.append(contentsOf: result.values)
+        }
+    }
+
     var birthdateBinding: Binding<Date> {
         Binding(
             get: { Date(timeIntervalSinceReferenceDate: birthdateInterval) },
@@ -388,31 +390,6 @@ private extension ReviewView {
         guard let chars = try? await HealthKitService.shared.readPatientCharacteristics() else { return }
         hkBirthdate = chars.dateOfBirth
         hkSex = chars.biologicalSexRaw
-    }
-
-    func resetAddForm() {
-        addName = ""
-        addCode = ""
-        addDisplayValue = ""
-        addUnit = ""
-    }
-
-    func commitAddValue() {
-        let code = addCode.isEmpty
-            ? "MANUAL"
-            : addCode.uppercased().trimmingCharacters(in: .whitespaces)
-        let normalized = addDisplayValue.replacingOccurrences(of: ",", with: ".")
-        let num = Double(normalized)
-        let newValue = LabValue(
-            code: code,
-            name: addName.trimmingCharacters(in: .whitespaces),
-            displayValue: addDisplayValue,
-            numericValue: num,
-            unit: addUnit.trimmingCharacters(in: .whitespaces)
-        )
-        labValues.append(newValue)
-        showAddValue = false
-        resetAddForm()
     }
 
     func shareCDA() {


### PR DESCRIPTION
The review/verify screen (also used when editing a saved report) could
only add a single value through manual entry. Extend it to support all the
known import methods — scan, choose file, paste — so users can grow an
open report the same way they create one.

Extract the scan/file/paste → OCR → AI parse pipeline out of HomeView into
a reusable LabImportEngine + .labImport(engine:) modifier, then drive it
from both HomeView (replaces working set) and ReviewView (appends to the
open report). The manual entry form moves into its own AddValueSheet.

https://claude.ai/code/session_014MyXJNT7FjP446zLLN4EmK