### PR TITLE
Resolve LOINC codes from the catalog instead of a static switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,14 +90,18 @@ Config.xcconfig  # BUNDLE_IDENTIFIER = dev.idoodler.$(DEVELOPMENT_TEAM).labimpor
   git); only the source zip is committed. `LabMapping` falls back to
   `LoincDirectory` for any code that is already a raw LOINC number (e.g. picked in
   `CodePickerSheet`).
-- **`LabMapping`** is the single source of truth for the curated German abbreviations:
-  - `displayName(for:)` — human name (localized), tolerant of OCR variants (e.g. `DIAB0L`/`DIABOL`).
-  - `loincCode(for:)` — LOINC code + display for CDA export; **returns nil → value is not exportable**.
-  - `internalCode(forLoinc:)` — reverse lookup used when parsing CDA back from Health.
-  - `referenceRange(for:)` — clinical normal/borderline/abnormal bands (drives dashboard status colors).
-  - When adding a new lab metric, update **all** relevant switch statements here
-    (and `allKnownCodes` so it appears in the code picker). Several use
-    `// swiftlint:disable:next cyclomatic_complexity` — keep that pattern.
+- **`LabMapping`** is a thin, data-driven adapter over `LoincDirectory` (no curated
+  tables of its own):
+  - `displayName(for:)` — localized human name for a LOINC code from the catalog.
+  - `loincCode(for:)` — validates the code + returns an English display for CDA
+    export; **returns nil → value is not exportable** (unknown/unmapped code).
+  - `loincURL(for:)` — the loinc.org details page for a code.
+- **Import resolution (printed report → LOINC)** lives in
+  `LabParserService.resolveLoinc`: an already-valid LOINC code passes through;
+  otherwise the AI's test name is matched against the catalog **in the report's
+  own language** (`LoincDirectory.search(_:language:…)`, English as fallback) and
+  the top hit is offered as a suggestion (`isSuggestedCode`). There is no static
+  abbreviation table — resolution is entirely catalog/FTS driven.
 
 ### CDA round-trip
 - **Export:** `CDAExportService.generateCDA` emits a C-CDA R2.1 Lab Report. Only
@@ -182,13 +186,14 @@ Required secrets: `GH_PAT`, `TEAMID`, `FASTLANE_ISSUER_ID`, `FASTLANE_KEY_ID`,
 - **Branch & commits:** never push to `main` unless explicitly told. Commit with
   clear messages; push with `git push -u origin <branch>`.
 - **Adding a lab metric:** LOINC is the canonical identity, and names come from
-  the bundled catalog (`LoincDirectory`) — there is no per-metric name curation.
-  To teach the parser a printed abbreviation, add a `case` to
-  `LabMapping.loinc(forPrinted:)` returning the LOINC code (which must exist in
-  the catalog). To give a metric dashboard status colours, add a
-  `LOINC: ReferenceRange` entry to `LabMapping.referenceRanges` (LOINC carries no
-  ranges, so these are hand-tuned). No `Localizable.xcstrings` change is needed —
-  the catalog supplies localized names.
+  the bundled catalog (`LoincDirectory`) — there is no per-metric name curation
+  and no abbreviation table to extend. The parser resolves any test the catalog
+  knows by matching the AI's test name (in the report's language) against the FTS
+  index, so a metric is "supported" as soon as its LOINC term is in `loinc.db`.
+  If a real-world report consistently mis-resolves, prefer improving the
+  `@Guide`/instructions in `LabParserService` (or widening the catalog) over
+  reintroducing a hard-coded mapping. No `Localizable.xcstrings` change is needed
+  — the catalog supplies localized names.
 - **Touching the AI parse:** prompts and `@Generable`/`@Guide` schemas live in
   `LabParserService.swift`. Keep `@Guide` descriptions concrete and example-driven —
   they directly steer extraction quality.

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -638,6 +638,158 @@
         }
       }
     },
+    "Reading document…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokument wird gelesen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo el documento…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture du document…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettura del documento…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書類を読み取り中…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Document lezen…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odczytywanie dokumentu…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lendo o documento…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтение документа…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belge okunuyor…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Читання документа…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在读取文稿…"
+          }
+        }
+      }
+    },
+    "Extracting text on device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text wird auf dem Gerät extrahiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extrayendo texto en el dispositivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extraction du texte sur l'appareil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estrazione del testo sul dispositivo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス上でテキストを抽出中"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tekst lokaal extraheren"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyodrębnianie tekstu na urządzeniu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extraindo texto no dispositivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Извлечение текста на устройстве"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metin cihazda çıkarılıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Витягування тексту на пристрої"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在设备上提取文本"
+          }
+        }
+      }
+    },
     "Analyzing lab report…": {
       "localizations": {
         "de": {

--- a/LabImporter/Models/LabMapping.swift
+++ b/LabImporter/Models/LabMapping.swift
@@ -2,10 +2,11 @@ import Foundation
 
 // LOINC is the canonical identity for every lab value in the app: the parser
 // resolves printed report codes to LOINC, and storage and display names all key
-// off the LOINC code. The German abbreviations that lab reports actually print
-// (KREA, HB-A1C, …) only appear here as *import-time* resolver inputs — see
-// `loinc(forPrinted:)`. Names come entirely from the bundled catalog
-// (`LoincDirectory`); this type holds no curated clinical data.
+// off the LOINC code. Resolution is fully data-driven — the parser matches the
+// AI's test name against the bundled catalog (`LoincDirectory`) in the report's
+// language (see `LabParserService.resolveLoinc`) — so this type holds no curated
+// abbreviation tables or clinical data; it only adapts catalog lookups for
+// display and CDA export.
 enum LabMapping {
 
     // MARK: - LOINC lookups
@@ -32,36 +33,5 @@ enum LabMapping {
         let trimmed = code.trimmingCharacters(in: .whitespaces)
         guard let term = LoincDirectory.shared.term(for: trimmed) else { return nil }
         return (term.code, term.englishName)
-    }
-
-    // MARK: - Import resolution (printed report code -> LOINC)
-
-    // Maps the codes/abbreviations a lab report actually prints to LOINC, so the
-    // rest of the app only ever deals in LOINC. Returns nil when the printed code
-    // is neither a known abbreviation nor an existing LOINC code, in which case
-    // the user maps it manually in the review sheet.
-    // swiftlint:disable:next cyclomatic_complexity
-    static func loinc(forPrinted printed: String) -> String? {
-        switch printed.uppercased().trimmingCharacters(in: .whitespaces) {
-        case "DIABOL", "DIAB0L":            return "1558-6"
-        case "KREA", "CREATININE":          return "2160-0"
-        case "MDRD", "EGFR":                return "77147-7"
-        case "KREA-GFR", "CKD-EPI":         return "62238-1"
-        case "CHOL", "TC":                  return "2093-3"
-        case "HDL":                          return "2085-9"
-        case "NONHDL", "NON-HDL":           return "43396-1"
-        case "LDL":                          return "2089-1"
-        case "TRIG", "TG":                  return "2571-8"
-        case "GPT", "ALT":                  return "1742-6"
-        case "G-GT", "GGT", "GGTP":         return "2324-2"
-        case "HB-A1C", "HBAIC", "HBA1C", "HBA1C%": return "4548-4"
-        case "HB-A1", "HBA1":               return "59261-8"
-        case "TSH-0", "TSH":                return "3016-3"
-        case "BZ", "GLUCOSE", "GLU":        return "2345-7"
-        default:
-            // Already a LOINC code (e.g. pasted in, or chosen from the catalog)?
-            let trimmed = printed.trimmingCharacters(in: .whitespaces)
-            return LoincDirectory.shared.isKnownLoinc(trimmed) ? trimmed : nil
-        }
     }
 }

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -16,6 +16,9 @@ struct AILabReport {
 
     @Guide(description: "Lab or doctor name as printed on the report. Empty string if not visible.")
     var authorName: String
+
+    @Guide(description: "BCP-47 language code of the report text, e.g. 'de' or 'en'. Empty string if unsure.")
+    var reportLanguage: String
 }
 
 @Generable
@@ -24,7 +27,7 @@ struct AILabEntry {
     var code: String
 
     // swiftlint:disable:next line_length
-    @Guide(description: "The test's standard name in English, translated from the printed language (e.g. 'Creatinine', 'Ferritin', 'Vitamin D 25-Hydroxy', 'Thyroid stimulating hormone'). Used to look up the standard LOINC code.")
+    @Guide(description: "The test's standard name in the report's own language — do NOT translate (e.g. for a German report 'Kreatinin', 'Ferritin', 'Vitamin D 25-Hydroxy', 'Thyreotropin'). Used to look up the standard LOINC code in that language.")
     var name: String
 
     @Guide(description: "Value exactly as printed — use '-' for negative/not-detected results")
@@ -62,7 +65,7 @@ actor LabParserService {
             let numericValue: Double? = entry.rawValue == "-" ? nil : Double(normalizedValue)
 
             // Resolve the printed code to LOINC, the app's canonical identity.
-            let (code, suggested) = resolveLoinc(printed: entry.code, name: entry.name)
+            let (code, suggested) = resolveLoinc(printed: entry.code, name: entry.name, language: report.reportLanguage)
 
             return LabValue(
                 code: code,
@@ -77,18 +80,25 @@ actor LabParserService {
         return ParseResult(values: values, reportDate: reportDate, patientName: patientName, authorName: authorName)
     }
 
-    // Resolves a parsed entry to a LOINC code. A confident curated/abbreviation
-    // match (or an already-LOINC code) is returned as-is; otherwise the AI's
-    // normalized English name is looked up in the catalog and the top hit is
+    // Resolves a parsed entry to a LOINC code entirely from the bundled catalog.
+    // An already-valid LOINC code (pasted in or printed verbatim) is canonical and
+    // returned as-is; otherwise the AI's test name is matched against the catalog
+    // in the report's own language (with English as a fallback) and the top hit is
     // returned as a *suggestion* the user confirms. Unresolved entries keep the
     // printed text so they can be mapped manually in the review sheet.
-    private func resolveLoinc(printed: String, name: String) -> (code: String, suggested: Bool) {
-        if let loinc = LabMapping.loinc(forPrinted: printed) {
-            return (loinc, false)
+    private func resolveLoinc(printed: String, name: String, language: String) -> (code: String, suggested: Bool) {
+        let directory = LoincDirectory.shared
+        let trimmedPrinted = printed.trimmingCharacters(in: .whitespaces)
+        if directory.isKnownLoinc(trimmedPrinted) {
+            return (trimmedPrinted, false)
         }
-        let query = (name.isEmpty ? printed : name).trimmingCharacters(in: .whitespaces)
-        if !query.isEmpty, let match = LoincDirectory.shared.search(query, limit: 1).first {
-            return (match.code, true)
+        let resolvedLanguage = directory.resolvedLanguage(for: language)
+        for query in [name, printed] {
+            let trimmed = query.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            if let match = directory.search(trimmed, language: resolvedLanguage, limit: 1).first {
+                return (match.code, true)
+            }
         }
         return (printed, false)
     }
@@ -100,8 +110,9 @@ actor LabParserService {
             instructions: """
             You are a medical lab report parser. Extract every lab test entry from the provided text.
             Lab reports follow the pattern: CODE: value unit; CODE2: value2 unit2; ...
-            Preserve codes exactly as printed. For each entry, also give the test's standard name in English
-            (translate from the report's language) so it can be matched to a coding system.
+            Preserve codes exactly as printed. For each entry, also give the test's standard name in the
+            report's own language (do NOT translate it) so it can be matched to a coding system in that language.
+            Detect the language of the report and return it as a BCP-47 code (e.g. 'de', 'en') in reportLanguage.
             Use '-' as rawValue when the result is negative or not detected.
             If you can see a report date or blood draw date, return it in yyyy-MM-dd format; otherwise return an empty string.
             Extract the patient's full name if visible; otherwise return an empty string for patientName.

--- a/LabImporter/Services/LoincDirectory.swift
+++ b/LabImporter/Services/LoincDirectory.swift
@@ -52,6 +52,10 @@ final class LoincDirectory: @unchecked Sendable {
     let version: String
     let count: Int
     let license: String
+    /// The app-language keys the catalog actually carries localized labels for
+    /// (e.g. "en", "de", "pt-BR"); used to normalize a parsed report language to
+    /// one the database can match. English is always available as a fallback.
+    let languages: [String]
 
     private let database: OpaquePointer?
     private let language: String
@@ -66,11 +70,11 @@ final class LoincDirectory: @unchecked Sendable {
         language = Bundle.main.preferredLocalizations.first ?? "en"
 
         guard let url = Bundle.main.url(forResource: "loinc", withExtension: "db") else {
-            database = nil; version = ""; count = 0; license = ""; return
+            database = nil; version = ""; count = 0; license = ""; languages = []; return
         }
         var handle: OpaquePointer?
         guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            sqlite3_close(handle); database = nil; version = ""; count = 0; license = ""; return
+            sqlite3_close(handle); database = nil; version = ""; count = 0; license = ""; languages = []; return
         }
         database = handle
 
@@ -122,6 +126,25 @@ final class LoincDirectory: @unchecked Sendable {
         version = LoincDirectory.scalar(handle, "SELECT value FROM meta WHERE key = 'version'") ?? ""
         count = Int(LoincDirectory.scalar(handle, "SELECT count(*) FROM term") ?? "0") ?? 0
         license = LoincDirectory.scalar(handle, "SELECT value FROM meta WHERE key = 'license'") ?? ""
+        languages = (LoincDirectory.scalar(handle, "SELECT value FROM meta WHERE key = 'languages'") ?? "")
+            .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+    }
+
+    // Maps a free-form/BCP-47 language tag (e.g. the parser's detected report
+    // language, "de" / "de-DE" / "DE") to a language the catalog actually carries
+    // labels for, falling back to the app's language. English is always searched
+    // alongside whatever this returns, so an unmatched tag still resolves via en.
+    func resolvedLanguage(for tag: String) -> String {
+        let lower = tag.lowercased()
+        guard !lower.isEmpty else { return language }
+        if let exact = languages.first(where: { $0.lowercased() == lower }) { return exact }
+        let base = lower.split(separator: "-").first.map(String.init) ?? lower
+        if let match = languages.first(where: {
+            ($0.lowercased().split(separator: "-").first.map(String.init) ?? $0.lowercased()) == base
+        }) {
+            return match
+        }
+        return language
     }
 
     // MARK: - Lookups
@@ -183,7 +206,14 @@ final class LoincDirectory: @unchecked Sendable {
         )
     }
 
+    // Searches the catalog in the app's UI language (plus English).
     func search(_ query: String, limit: Int = 80, offset: Int = 0) -> [LoincTerm] {
+        search(query, language: language, limit: limit, offset: offset)
+    }
+
+    // Searches the catalog in an explicit language (plus English) — used by the
+    // parser to resolve a test name against the report's own localized labels.
+    func search(_ query: String, language: String, limit: Int = 80, offset: Int = 0) -> [LoincTerm] {
         guard database != nil else { return [] }
         if let match = ftsQuery(query) {
             guard let statement = searchStatement else { return [] }

--- a/LabImporter/Views/LabImportEngine.swift
+++ b/LabImporter/Views/LabImportEngine.swift
@@ -24,6 +24,11 @@ final class LabImportEngine {
 
     private(set) var isProcessing = false
 
+    /// The stage the current import is in, surfaced by the processing HUD as a
+    /// description + coarse progress. There is no fine-grained progress to report
+    /// (OCR and the on-device model are opaque), so this advances by phase.
+    private(set) var phase: ImportPhase = .extractingText
+
     fileprivate var errorMessage: String?
     fileprivate var showScanner = false
     fileprivate var showFileImporter = false
@@ -76,6 +81,7 @@ final class LabImportEngine {
 
     func processImages(_ images: [UIImage]) async {
         guard !images.isEmpty else { return }
+        phase = .extractingText
         isProcessing = true
         defer { isProcessing = false }
 
@@ -88,6 +94,7 @@ final class LabImportEngine {
     }
 
     func processText(_ text: String) async {
+        phase = .analyzing
         isProcessing = true
         defer { isProcessing = false }
 
@@ -99,6 +106,7 @@ final class LabImportEngine {
     }
 
     private func processPDF(at url: URL) async {
+        phase = .extractingText
         isProcessing = true
         defer { isProcessing = false }
 
@@ -111,6 +119,8 @@ final class LabImportEngine {
     }
 
     private func handleExtractedText(_ text: String) async throws {
+        // Text is in hand; the remaining (and longest) work is the AI parse.
+        phase = .analyzing
         let result = try await parserService.parseLabValues(from: text)
         if result.values.isEmpty {
             errorMessage = emptyMessage
@@ -164,8 +174,11 @@ private struct LabImportModifier: ViewModifier {
                 Text(engine.errorMessage ?? "")
             }
             .overlay {
-                if engine.isProcessing { ProcessingHUD() }
+                if engine.isProcessing {
+                    ProcessingHUD(phase: engine.phase)
+                }
             }
+            .animation(.easeInOut(duration: 0.25), value: engine.isProcessing)
     }
 }
 
@@ -178,25 +191,99 @@ extension View {
     }
 }
 
+// MARK: - Import phases
+
+/// The coarse stages an import passes through, used to label the processing HUD
+/// and drive its progress bar. OCR and the on-device model expose no real
+/// progress, so each phase maps to an indicative fraction rather than a measured
+/// one — enough to show motion and tell the user what's happening.
+enum ImportPhase: CaseIterable {
+    case extractingText
+    case analyzing
+
+    var title: LocalizedStringKey {
+        switch self {
+        case .extractingText: "Reading document…"
+        case .analyzing: "Analyzing lab report…"
+        }
+    }
+
+    var detail: LocalizedStringKey {
+        switch self {
+        case .extractingText: "Extracting text on device"
+        case .analyzing: "Using on-device AI"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .extractingText: "doc.text.viewfinder"
+        case .analyzing: "sparkles"
+        }
+    }
+
+    var fraction: Double {
+        switch self {
+        case .extractingText: 0.45
+        case .analyzing: 0.9
+        }
+    }
+}
+
 // MARK: - Processing HUD
 
 struct ProcessingHUD: View {
+    let phase: ImportPhase
+
     var body: some View {
-        Color.clear
-            .ignoresSafeArea()
-            .overlay {
-                VStack(spacing: 16) {
-                    ProgressView()
-                        .controlSize(.large)
-                    Text("Analyzing lab report…")
+        ZStack {
+            // Dimming scrim: focuses attention on the card and, being an opaque
+            // hit-testable shape, swallows every touch so the content behind the
+            // HUD can't be interacted with while an import is in flight.
+            Rectangle()
+                .fill(.black.opacity(0.28))
+                .ignoresSafeArea()
+                .transition(.opacity)
+
+            VStack(spacing: 18) {
+                Image(systemName: phase.systemImage)
+                    .font(.system(size: 40, weight: .semibold))
+                    .foregroundStyle(.tint)
+                    .symbolEffect(.pulse, options: .repeating)
+                    .contentTransition(.symbolEffect(.replace))
+
+                VStack(spacing: 6) {
+                    Text(phase.title)
                         .font(.headline)
-                    Text("Using on-device AI")
+                    Text(phase.detail)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                .padding(32)
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24))
+                .multilineTextAlignment(.center)
+
+                ProgressView(value: phase.fraction)
+                    .progressViewStyle(.linear)
+                    .tint(.accentColor)
+                    .frame(width: 200)
+                    .animation(.easeInOut(duration: 0.5), value: phase.fraction)
             }
-            .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+            .padding(28)
+            .frame(maxWidth: 280)
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 28))
+            .transition(.scale(scale: 0.92).combined(with: .opacity))
+        }
+        .animation(.easeInOut(duration: 0.3), value: phase)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.updatesFrequently)
     }
+}
+
+#Preview("Reading") {
+    Color(.systemGroupedBackground)
+        .overlay { ProcessingHUD(phase: .extractingText) }
+}
+
+#Preview("Analyzing") {
+    Color(.systemGroupedBackground)
+        .overlay { ProcessingHUD(phase: .analyzing) }
 }

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -488,10 +488,10 @@ private extension ReviewView {
     NavigationStack {
         ReviewView(
             labValues: [
-                LabValue(code: "BZ", name: "Blood Glucose", displayValue: "95", numericValue: 95, unit: "mg/dl"),
-                LabValue(code: "KREA", name: "Creatinine", displayValue: "0.91", numericValue: 0.91, unit: "mg/dl"),
-                LabValue(code: "HB-A1C", name: "HbA1c (%)", displayValue: "6.5", numericValue: 6.5, unit: "%"),
-                LabValue(code: "CHOL", name: "Total Cholesterol", displayValue: "162", numericValue: 162, unit: "mg/dl"),
+                LabValue(code: "2345-7", name: "Blood Glucose", displayValue: "95", numericValue: 95, unit: "mg/dl"),
+                LabValue(code: "2160-0", name: "Creatinine", displayValue: "0.91", numericValue: 0.91, unit: "mg/dl"),
+                LabValue(code: "4548-4", name: "HbA1c (%)", displayValue: "6.5", numericValue: 6.5, unit: "%"),
+                LabValue(code: "2093-3", name: "Total Cholesterol", displayValue: "162", numericValue: 162, unit: "mg/dl"),
             ],
             extractedPatientName: "Max Mustermann"
         )


### PR DESCRIPTION
Replace the hard-coded German abbreviation -> LOINC table in
LabMapping.loinc(forPrinted:) with fully data-driven resolution against
the bundled LOINC catalog, accounting for the report's language.

- LabParserService now asks the on-device model to detect the report
  language (BCP-47) and to return each test's standard name in that
  language (no English translation), then resolves via the catalog.
- LoincDirectory gains a language-aware search(_:language:) and a
  resolvedLanguage(for:) normalizer so a report's language maps to one
  the catalog ships labels for, with English always as a fallback.
- resolveLoinc passes already-valid LOINC codes through unchanged and
  offers catalog matches as suggestions the user confirms in review.
- Drop the now-unused switch from LabMapping; refresh CLAUDE.md and the
  ReviewView preview to use real LOINC codes.