### PR TITLE
Add more menu with confirmable hide in trends and trend arrows on dashboard

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -4590,6 +4590,38 @@
         }
       }
     },
+    "Hide": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ausblenden" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Ocultar" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Masquer" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Nascondi" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "非表示" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Verberg" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Ukryj" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Ocultar" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скрыть" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Gizle" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Приховати" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "隐藏" } }
+      }
+    },
+    "Hide %@?": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "%@ ausblenden?" } },
+        "es": { "stringUnit": { "state": "translated", "value": "¿Ocultar %@?" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Masquer %@ ?" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Nascondere %@?" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@を非表示にしますか？" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "%@ verbergen?" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Ukryć %@?" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Ocultar %@?" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скрыть %@?" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "%@ gizlensin mi?" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Приховати %@?" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "隐藏 %@？" } }
+      }
+    },
     "Hidden": {
       "localizations": {
         "de": {
@@ -7325,6 +7357,22 @@
             "value": "名称"
           }
         }
+      }
+    },
+    "No change": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Unverändert" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Sin cambios" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Stable" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Nessuna variazione" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "変化なし" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Geen verandering" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Bez zmian" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Sem alteração" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Без изменений" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Değişiklik yok" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Без змін" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无变化" } }
       }
     },
     "No LOINC code — excluded from CDA export": {
@@ -10824,6 +10872,22 @@
         }
       }
     },
+    "This metric will no longer appear on your dashboard. You can show it again from Settings.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Dieser Wert wird nicht mehr im Dashboard angezeigt. Du kannst ihn in den Einstellungen wieder einblenden." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Esta métrica ya no aparecerá en tu panel. Puedes volver a mostrarla desde Ajustes." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Cette mesure n'apparaîtra plus sur votre tableau de bord. Vous pouvez l'afficher à nouveau depuis les Réglages." } },
+        "it": { "stringUnit": { "state": "translated", "value": "Questo valore non apparirà più nella dashboard. Puoi mostrarlo di nuovo dalle Impostazioni." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "この指標はダッシュボードに表示されなくなります。設定から再表示できます。" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Deze meting verschijnt niet langer op je dashboard. Je kunt deze opnieuw tonen via Instellingen." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Ten wskaźnik nie będzie już wyświetlany na pulpicie. Możesz go ponownie pokazać w Ustawieniach." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Esta métrica não aparecerá mais no seu painel. Você pode exibi-la novamente nos Ajustes." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Этот показатель больше не будет отображаться на панели. Вы можете снова показать его в Настройках." } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bu ölçüm artık panonuzda görünmeyecek. Ayarlar'dan tekrar gösterebilirsiniz." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Цей показник більше не відображатиметься на панелі. Ви можете знову показати його в Налаштуваннях." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此指标将不再显示在仪表板上。你可以在“设置”中重新显示它。" } }
+      }
+    },
     "This report will be permanently removed from Apple Health.": {
       "localizations": {
         "de": {
@@ -11278,6 +11342,38 @@
             "value": "单位"
           }
         }
+      }
+    },
+    "Trending down": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Fallend" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Tendencia a la baja" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "En baisse" } },
+        "it": { "stringUnit": { "state": "translated", "value": "In diminuzione" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "下降傾向" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Dalend" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Trend malejący" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Em baixa" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Снижается" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Düşüyor" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Спадає" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "下降趋势" } }
+      }
+    },
+    "Trending up": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Steigend" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Tendencia al alza" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "En hausse" } },
+        "it": { "stringUnit": { "state": "translated", "value": "In aumento" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "上昇傾向" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Stijgend" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Trend rosnący" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Em alta" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Растёт" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Yükseliyor" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Зростає" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "上升趋势" } }
       }
     },
     "Unpin": {

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -302,14 +302,6 @@ private struct MetricCard: View {
             }
         }
 
-        var color: Color {
-            switch self {
-            case .rising: return .orange
-            case .falling: return .blue
-            case .steady: return .secondary
-            }
-        }
-
         var accessibilityLabel: Text {
             switch self {
             case .rising: return Text("Trending up")
@@ -331,9 +323,9 @@ private struct MetricCard: View {
     private func trendBadge(_ trend: Trend) -> some View {
         Image(systemName: trend.symbol)
             .font(.caption2.weight(.bold))
-            .foregroundStyle(trend.color)
+            .foregroundStyle(categoryColor)
             .padding(4)
-            .background(trend.color.opacity(0.15), in: Circle())
+            .background(categoryColor.opacity(0.15), in: Circle())
             .accessibilityLabel(trend.accessibilityLabel)
     }
 

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -288,6 +288,53 @@ private struct MetricCard: View {
         LabCategory.forCode(metric.entry.code).color
     }
 
+    /// Direction of the latest reading relative to the previous one, used to show
+    /// a small trend arrow in the overview. `nil` when there is no prior value to
+    /// compare against.
+    private enum Trend {
+        case rising, falling, steady
+    }
+
+    private var trend: Trend? {
+        guard metric.history.count > 1 else { return nil }
+        let latest = metric.history[metric.history.count - 1].value
+        let previous = metric.history[metric.history.count - 2].value
+        if latest > previous { return .rising }
+        if latest < previous { return .falling }
+        return .steady
+    }
+
+    @ViewBuilder
+    private func trendBadge(_ trend: Trend) -> some View {
+        let symbol: String
+        let color: Color
+        switch trend {
+        case .rising:
+            symbol = "arrow.up.right"
+            color = .orange
+        case .falling:
+            symbol = "arrow.down.right"
+            color = .blue
+        case .steady:
+            symbol = "arrow.right"
+            color = .secondary
+        }
+        Image(systemName: symbol)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(color)
+            .padding(4)
+            .background(color.opacity(0.15), in: Circle())
+            .accessibilityLabel(accessibilityLabel(for: trend))
+    }
+
+    private func accessibilityLabel(for trend: Trend) -> Text {
+        switch trend {
+        case .rising: return Text("Trending up")
+        case .falling: return Text("Trending down")
+        case .steady: return Text("No change")
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 5) {
@@ -319,6 +366,10 @@ private struct MetricCard: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+                if let trend {
+                    trendBadge(trend)
                 }
             }
 

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -293,6 +293,30 @@ private struct MetricCard: View {
     /// compare against.
     private enum Trend {
         case rising, falling, steady
+
+        var symbol: String {
+            switch self {
+            case .rising: return "arrow.up.right"
+            case .falling: return "arrow.down.right"
+            case .steady: return "arrow.right"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .rising: return .orange
+            case .falling: return .blue
+            case .steady: return .secondary
+            }
+        }
+
+        var accessibilityLabel: Text {
+            switch self {
+            case .rising: return Text("Trending up")
+            case .falling: return Text("Trending down")
+            case .steady: return Text("No change")
+            }
+        }
     }
 
     private var trend: Trend? {
@@ -304,35 +328,13 @@ private struct MetricCard: View {
         return .steady
     }
 
-    @ViewBuilder
     private func trendBadge(_ trend: Trend) -> some View {
-        let symbol: String
-        let color: Color
-        switch trend {
-        case .rising:
-            symbol = "arrow.up.right"
-            color = .orange
-        case .falling:
-            symbol = "arrow.down.right"
-            color = .blue
-        case .steady:
-            symbol = "arrow.right"
-            color = .secondary
-        }
-        Image(systemName: symbol)
+        Image(systemName: trend.symbol)
             .font(.caption2.weight(.bold))
-            .foregroundStyle(color)
+            .foregroundStyle(trend.color)
             .padding(4)
-            .background(color.opacity(0.15), in: Circle())
-            .accessibilityLabel(accessibilityLabel(for: trend))
-    }
-
-    private func accessibilityLabel(for trend: Trend) -> Text {
-        switch trend {
-        case .rising: return Text("Trending up")
-        case .falling: return Text("Trending down")
-        case .steady: return Text("No change")
-        }
+            .background(trend.color.opacity(0.15), in: Circle())
+            .accessibilityLabel(trend.accessibilityLabel)
     }
 
     var body: some View {

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -17,6 +17,7 @@ struct TrendsView: View {
     @State private var selectedDate: Date?
     @State private var selectedTerm: LoincTerm?
     @State private var valueColor: Color = .accentColor
+    @State private var showHideConfirmation = false
     private let selectionFeedback = UISelectionFeedbackGenerator()
     private let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
 
@@ -97,9 +98,19 @@ struct TrendsView: View {
             }
             if !selectedCode.isEmpty {
                 ToolbarItem(placement: .topBarTrailing) {
-                    pinButton
+                    moreMenu
                 }
             }
+        }
+        .confirmationDialog(
+            "Hide \(selectedName)?",
+            isPresented: $showHideConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Hide", role: .destructive) { hideSelected() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This metric will no longer appear on your dashboard. You can show it again from Settings.")
         }
         .onAppear {
             let codes = availableCodes.map(\.code)
@@ -119,18 +130,28 @@ struct TrendsView: View {
 
     // MARK: - Toolbar
 
-    private var pinButton: some View {
-        Button {
-            togglePin(selectedCode)
+    private var moreMenu: some View {
+        Menu {
+            Button {
+                togglePin(selectedCode)
+            } label: {
+                Label(
+                    isPinned ? "Unpin" : "Pin to Top",
+                    systemImage: isPinned ? "pin.slash" : "pin"
+                )
+            }
+            Button(role: .destructive) {
+                showHideConfirmation = true
+            } label: {
+                Label("Hide", systemImage: "eye.slash")
+            }
         } label: {
-            Image(systemName: isPinned ? "pin.fill" : "pin")
+            Image(systemName: "ellipsis")
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(isPinned ? Color.yellow : .primary)
+                .foregroundStyle(.primary)
                 .frame(width: 32, height: 32)
                 .glassEffect(in: Circle())
         }
-        .buttonStyle(.plain)
-        .animation(.spring(duration: 0.2), value: isPinned)
     }
 
     // MARK: - Subviews
@@ -296,8 +317,11 @@ struct TrendsView: View {
             .shadow(color: valueColor.opacity(0.45), radius: 6, x: 0, y: 0)
     }
 
-    // MARK: - Helpers
+}
 
+// MARK: - Helpers
+
+extension TrendsView {
     private func clampedX(_ xPos: CGFloat, in frame: CGRect) -> CGFloat {
         let halfBubble: CGFloat = 60
         return min(max(xPos, frame.minX + halfBubble), frame.maxX - halfBubble)
@@ -318,6 +342,20 @@ struct TrendsView: View {
         }
         prefs = updated
         impactFeedback.impactOccurred()
+    }
+
+    /// Hides the selected metric from the dashboard and dismisses the trend view,
+    /// since the value is no longer surfaced in the overview after hiding.
+    private func hideSelected() {
+        var updated = prefs
+        if !updated.hiddenCodes.contains(selectedCode) {
+            updated.hiddenCodes.append(selectedCode)
+        }
+        // Keep a hidden metric from also occupying a pinned slot.
+        updated.pinnedCodes.removeAll { $0 == selectedCode }
+        prefs = updated
+        impactFeedback.impactOccurred()
+        onDismiss?()
     }
 }
 


### PR DESCRIPTION
- Replace the pin toolbar button in TrendsView with an ellipsis 'more' menu
  containing Pin/Unpin and a Hide action
- Make hiding a metric confirmable via a confirmation dialog; hiding also
  removes any pin and dismisses the trend view
- Show a directional trend arrow on each dashboard metric card based on the
  latest reading versus the previous one
- Add localized strings for the new UI across all shipped languages