### PR TITLE
Polish cards, settings, trends and LOINC screens

### DIFF
--- a/LabImporter/Views/AddValueSheet.swift
+++ b/LabImporter/Views/AddValueSheet.swift
@@ -48,7 +48,21 @@ struct AddValueSheet: View {
                         .disabled(name.isEmpty || displayValue.isEmpty)
                 }
             }
+            .onChange(of: code) { _, newCode in
+                fillUnit(for: newCode)
+            }
         }
+    }
+
+    /// Prefills the unit from the LOINC catalog's example UCUM unit when a lab
+    /// test is chosen, so manual entries inherit the canonical unit. A previously
+    /// entered unit is kept when the catalog has no example unit for the code.
+    private func fillUnit(for code: String) {
+        let trimmed = code.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty,
+              let term = LoincDirectory.shared.term(for: trimmed),
+              !term.ucum.isEmpty else { return }
+        unit = term.ucum
     }
 
     private func commit() {

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -12,8 +12,14 @@ struct DashboardView: View {
     let scannerAvailable: Bool
     let clipboardAvailable: Bool
     let isProcessing: Bool
+    /// When the dashboard is the detail pane of an iPad sidebar, the sidebar
+    /// already hosts the Reports/Settings/Import entry points, so the dashboard
+    /// hides its own toolbar chrome to avoid duplicating them. Defaults to `true`
+    /// so the standalone (iPhone) presentation is unchanged.
+    var showsLibraryToolbarItems = true
 
     @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showSettings = false
     @State private var trendSheet: TrendSheet?
     @State private var dropTargetCode: String?
@@ -37,21 +43,23 @@ struct DashboardView: View {
         .navigationTitle("Lab Results")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                NavigationLink(destination: HistoryView()) {
-                    Image(systemName: "doc.text")
+            if showsLibraryToolbarItems {
+                ToolbarItem(placement: .topBarLeading) {
+                    NavigationLink(destination: HistoryView()) {
+                        Image(systemName: "doc.text")
+                    }
+                    .accessibilityLabel("Reports")
                 }
-                .accessibilityLabel("Reports")
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    showSettings = true
-                } label: {
-                    Image(systemName: "gearshape")
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
                 }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                importMenu
+                ToolbarItem(placement: .topBarTrailing) {
+                    importMenu
+                }
             }
         }
         .sheet(isPresented: $showSettings) {
@@ -94,14 +102,21 @@ struct DashboardView: View {
     // MARK: - Metrics grid
 
     private var metricsGrid: some View {
-        LazyVGrid(
-            columns: [GridItem(.flexible()), GridItem(.flexible())],
-            spacing: 14
-        ) {
+        LazyVGrid(columns: gridColumns, spacing: 14) {
             ForEach(sortedMetrics) { metric in
                 metricCard(for: metric)
             }
         }
+    }
+
+    /// Two fixed columns on compact widths (iPhone); on regular widths (iPad) the
+    /// cards flow to fill the wider canvas with a sensible minimum so they don't
+    /// stretch into a sparse two-up grid.
+    private var gridColumns: [GridItem] {
+        if horizontalSizeClass == .regular {
+            return [GridItem(.adaptive(minimum: 200, maximum: 280), spacing: 14)]
+        }
+        return [GridItem(.flexible()), GridItem(.flexible())]
     }
 
     @ViewBuilder

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -320,27 +320,38 @@ private struct MetricCard: View {
         return .steady
     }
 
-    private func trendBadge(_ trend: Trend) -> some View {
-        Image(systemName: trend.symbol)
-            .font(.caption2.weight(.bold))
-            .foregroundStyle(categoryColor)
-            .padding(4)
-            .background(categoryColor.opacity(0.15), in: Circle())
-            .accessibilityLabel(trend.accessibilityLabel)
+    /// The colored category "dock" at the card's top-left. When a trend is
+    /// available it doubles as the trend indicator and hosts a directional
+    /// arrow; otherwise it is a simple category-color dot. Both variants reserve
+    /// the same footprint so the title alignment stays put.
+    @ViewBuilder
+    private var dock: some View {
+        if let trend {
+            Image(systemName: trend.symbol)
+                .font(.system(size: 9, weight: .heavy))
+                .foregroundStyle(.white)
+                .frame(width: 18, height: 18)
+                .background(categoryColor.gradient, in: Circle())
+                .accessibilityLabel(trend.accessibilityLabel)
+        } else {
+            Circle()
+                .fill(categoryColor)
+                .frame(width: 9, height: 9)
+                .frame(width: 18, height: 18)
+                .accessibilityHidden(true)
+        }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .top, spacing: 5) {
-                Circle()
-                    .fill(categoryColor)
-                    .frame(width: 8, height: 8)
-                    .padding(.top, 3)
+            HStack(alignment: .top, spacing: 7) {
+                dock
                 Text(metric.entry.resolvedName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 1)
                 Spacer(minLength: 0)
                 if isPinned {
                     Image(systemName: "pin.fill")
@@ -362,9 +373,6 @@ private struct MetricCard: View {
                         .lineLimit(1)
                 }
                 Spacer(minLength: 0)
-                if let trend {
-                    trendBadge(trend)
-                }
             }
 
             if metric.history.count > 1 {

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -16,13 +16,51 @@ struct HomeView: View {
     @State private var clipboardHasContent = false
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
 
-    var body: some View {
-        NavigationStack {
-            content
+    // iPad sidebar state
+    @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
+    @State private var sidebarSelection: SidebarSection? = .dashboard
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    /// Sections shown in the iPad sidebar. On compact widths (iPhone) these are
+    /// reached through the dashboard's own toolbar instead, so the sidebar is
+    /// only built when the layout is regular-width.
+    private enum SidebarSection: String, CaseIterable, Identifiable {
+        case dashboard, reports, settings
+        var id: String { rawValue }
+
+        var title: LocalizedStringKey {
+            switch self {
+            case .dashboard: return "Lab Results"
+            case .reports: return "Reports"
+            case .settings: return "Settings"
+            }
         }
-        // Attach the import overlay outside the NavigationStack so the processing
-        // HUD's scrim also covers the navigation bar — otherwise the toolbar
-        // buttons (history/settings/import) stay tappable behind the HUD.
+
+        var icon: String {
+            switch self {
+            case .dashboard: return "square.grid.2x2"
+            case .reports: return "doc.text"
+            case .settings: return "gearshape"
+            }
+        }
+    }
+
+    var body: some View {
+        // The layout adapts to width — a sidebar split view on regular-width
+        // devices (iPad, large iPhones in landscape) and the original stack on
+        // compact widths — while the import overlay, review sheet, report
+        // loading and onboarding stay shared across both so behavior is
+        // identical no matter how the content is presented.
+        Group {
+            if horizontalSizeClass == .regular {
+                splitRoot
+            } else {
+                compactRoot
+            }
+        }
+        // Attach the import overlay outside the navigation containers so the
+        // processing HUD's scrim also covers the navigation bar — otherwise the
+        // toolbar buttons (history/settings/import) stay tappable behind the HUD.
         .labImport(engine: importEngine)
         .sheet(isPresented: $showReview) {
             NavigationStack {
@@ -57,10 +95,58 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Content routing
+    // MARK: - Compact layout (iPhone)
+
+    private var compactRoot: some View {
+        NavigationStack {
+            mainContent(showsLibraryToolbarItems: true)
+        }
+    }
+
+    // MARK: - Regular layout (iPad)
+
+    private var splitRoot: some View {
+        NavigationSplitView {
+            List(selection: $sidebarSelection) {
+                ForEach(SidebarSection.allCases) { section in
+                    Label(section.title, systemImage: section.icon)
+                        .tag(section)
+                }
+            }
+            .navigationTitle("Lab Importer")
+            .navigationSplitViewColumnWidth(min: 240, ideal: 280)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    importMenu
+                }
+            }
+        } detail: {
+            detailColumn
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
 
     @ViewBuilder
-    private var content: some View {
+    private var detailColumn: some View {
+        switch sidebarSelection ?? .dashboard {
+        case .dashboard:
+            NavigationStack {
+                mainContent(showsLibraryToolbarItems: false)
+            }
+        case .reports:
+            NavigationStack {
+                HistoryView()
+            }
+        case .settings:
+            SettingsView(prefs: $prefs, allCodes: allCodeNames, isModal: false)
+        }
+    }
+
+    /// The landing-or-dashboard content shared by both layouts. `showsLibraryToolbarItems`
+    /// hides the dashboard's History/Settings toolbar buttons when the sidebar
+    /// already provides those destinations.
+    @ViewBuilder
+    private func mainContent(showsLibraryToolbarItems: Bool) -> some View {
         if !isLoaded {
             ProgressView()
                 .scaleEffect(1.4)
@@ -83,9 +169,48 @@ struct HomeView: View {
                 onManual: createManually,
                 scannerAvailable: VNDocumentCameraViewController.isSupported,
                 clipboardAvailable: clipboardHasContent,
-                isProcessing: importEngine.isProcessing
+                isProcessing: importEngine.isProcessing,
+                showsLibraryToolbarItems: showsLibraryToolbarItems
             )
         }
+    }
+
+    // MARK: - Sidebar import menu
+
+    private var importMenu: some View {
+        Menu {
+            Button { importEngine.scan() } label: {
+                Label("Scan Document", systemImage: "doc.viewfinder")
+            }
+            .disabled(!VNDocumentCameraViewController.isSupported)
+            Button { importEngine.pickFile() } label: {
+                Label("Choose File", systemImage: "folder")
+            }
+            Button { importEngine.paste() } label: {
+                Label("Paste from Clipboard", systemImage: "doc.on.clipboard")
+            }
+            .disabled(!clipboardHasContent)
+            Button(action: createManually) {
+                Label("Create Report Manually", systemImage: "square.and.pencil")
+            }
+        } label: {
+            Image(systemName: "plus")
+                .fontWeight(.semibold)
+        }
+        .accessibilityLabel("Import Report")
+    }
+
+    /// Distinct lab codes across all reports, used to populate the Settings
+    /// sort/visibility editor when Settings is shown as a sidebar detail.
+    private var allCodeNames: [CodeName] {
+        var seen = Set<String>()
+        var result: [CodeName] = []
+        for report in reports {
+            for entry in report.entries where seen.insert(entry.code).inserted {
+                result.append(CodeName(code: entry.code, name: entry.resolvedName))
+            }
+        }
+        return result
     }
 
     // MARK: - Import engine

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -15,6 +15,9 @@ struct ImportLandingView: View {
             heroSection
             Spacer()
             importCard
+                // Keep the card from stretching across an iPad's width — it stays
+                // a centered, readable column on large screens.
+                .frame(maxWidth: 480)
                 .padding(.horizontal, 24)
                 .opacity(isProcessing ? 0.4 : 1)
                 .allowsHitTesting(!isProcessing)

--- a/LabImporter/Views/ReportDetailView.swift
+++ b/LabImporter/Views/ReportDetailView.swift
@@ -302,8 +302,21 @@ private struct ShareSheet: UIViewControllerRepresentable {
     let url: URL
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        // On iPad the activity controller is presented as a popover and requires a
+        // non-nil source or it traps. Anchoring to its own view (which is in the
+        // window once SwiftUI presents it) centers the popover and keeps it valid.
+        if let popover = controller.popoverPresentationController {
+            popover.sourceView = controller.view
+            popover.permittedArrowDirections = []
+        }
+        return controller
     }
 
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        if let popover = uiViewController.popoverPresentationController,
+           let source = popover.sourceView {
+            popover.sourceRect = CGRect(x: source.bounds.midX, y: source.bounds.midY, width: 0, height: 0)
+        }
+    }
 }

--- a/LabImporter/Views/ReviewHeaderCard.swift
+++ b/LabImporter/Views/ReviewHeaderCard.swift
@@ -6,10 +6,22 @@ struct CDAShareSheet: UIViewControllerRepresentable {
     let url: URL
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        // On iPad the share sheet is a popover and requires a non-nil source view
+        // or it traps; anchor it to its own view so it presents centered.
+        if let popover = controller.popoverPresentationController {
+            popover.sourceView = controller.view
+            popover.permittedArrowDirections = []
+        }
+        return controller
     }
 
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        if let popover = uiViewController.popoverPresentationController,
+           let source = popover.sourceView {
+            popover.sourceRect = CGRect(x: source.bounds.midX, y: source.bounds.midY, width: 0, height: 0)
+        }
+    }
 }
 
 /// The pinned bottom action bar on the review screen: a prominent "save to

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -74,7 +74,8 @@ struct SettingsView: View {
                     NavigationLink {
                         LabSortEditor(prefs: $prefs, allCodes: allCodes)
                     } label: {
-                        Label("Sort & Visibility", systemImage: "arrow.up.arrow.down")
+                        SettingsRowLabel("Sort & Visibility",
+                                         systemImage: "arrow.up.arrow.down", color: .blue)
                     }
                 }
 
@@ -82,18 +83,19 @@ struct SettingsView: View {
                     NavigationLink {
                         LoincCatalogView()
                     } label: {
-                        Label("Browse Catalog", systemImage: "magnifyingglass")
+                        SettingsRowLabel("Browse Catalog",
+                                         systemImage: "magnifyingglass", color: .indigo)
                     }
                     NavigationLink {
                         LoincLicenseView()
                     } label: {
-                        Label("LOINC License", systemImage: "doc.text")
+                        SettingsRowLabel("LOINC License", systemImage: "doc.text", color: .teal)
                     }
                     if !LoincDirectory.shared.version.isEmpty {
                         LabeledContent {
                             Text(verbatim: LoincDirectory.shared.version)
                         } label: {
-                            Label("Version", systemImage: "number.square")
+                            SettingsRowLabel("Version", systemImage: "number.square", color: .gray)
                         }
                     }
                 }
@@ -102,46 +104,40 @@ struct SettingsView: View {
                     LabeledContent {
                         Text(AppInfo.branch)
                     } label: {
-                        Label("Branch", systemImage: "arrow.triangle.branch")
+                        SettingsRowLabel("Branch",
+                                         systemImage: "arrow.triangle.branch", color: .orange)
                     }
                     LabeledContent {
                         Text(AppInfo.commit)
                     } label: {
-                        Label("Commit", systemImage: "number")
+                        SettingsRowLabel("Commit", systemImage: "number", color: .purple)
                     }
                     NavigationLink {
                         LicenseView()
                     } label: {
-                        Label("License", systemImage: "doc.text")
+                        SettingsRowLabel("License", systemImage: "doc.text", color: .pink)
                     }
                 }
 
                 Section {
-                    VStack(spacing: 16) {
-                        HStack(spacing: 12) {
-                            if let repository = AppInfo.repositoryURL {
-                                pillButton("View on GitHub",
-                                           systemImage: "chevron.left.forwardslash.chevron.right",
-                                           url: repository)
-                            }
-                            if let newIssue = AppInfo.newIssueURL {
-                                pillButton("Report an Issue",
-                                           systemImage: "exclamationmark.bubble",
-                                           url: newIssue)
-                            }
-                        }
-                        Text("Version \(AppInfo.version) (\(AppInfo.build))")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+                    if let repository = AppInfo.repositoryURL {
+                        linkRow("View on GitHub",
+                                systemImage: "chevron.left.forwardslash.chevron.right",
+                                color: .primary, url: repository)
                     }
-                    .frame(maxWidth: .infinity)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
+                    if let newIssue = AppInfo.newIssueURL {
+                        linkRow("Report an Issue",
+                                systemImage: "exclamationmark.bubble",
+                                color: .red, url: newIssue)
+                    }
+                } footer: {
+                    Text("Version \(AppInfo.version) (\(AppInfo.build))")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.top, 8)
                 }
-                .listSectionSpacing(8)
             }
             .navigationTitle("Settings")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(role: .close) { dismiss() }
@@ -154,24 +150,52 @@ struct SettingsView: View {
         }
     }
 
-    /// A pill-shaped button that opens a web URL in an in-app browser.
-    private func pillButton(_ titleKey: LocalizedStringKey, systemImage: String, url: URL) -> some View {
+    /// A standard settings row that opens a web URL in the in-app browser, with a
+    /// trailing external-link glyph to signal it leaves the app.
+    private func linkRow(_ titleKey: LocalizedStringKey,
+                         systemImage: String,
+                         color: Color,
+                         url: URL) -> some View {
         Button {
             browserURL = IdentifiedURL(url: url)
         } label: {
-            Label(titleKey, systemImage: systemImage)
-                .font(.subheadline)
-                // Keep both pills the same size regardless of title length: split the
-                // row evenly and shrink-to-fit on one line so a longer localized title
-                // never wraps to two lines and leaves the buttons mismatched in height.
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-                .frame(maxWidth: .infinity)
+            HStack {
+                SettingsRowLabel(titleKey, systemImage: systemImage, color: color)
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
         }
-        .buttonStyle(.bordered)
-        .buttonBorderShape(.capsule)
-        .controlSize(.regular)
-        .tint(.primary)
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - SettingsRowLabel
+
+/// A list-row label with a rounded, color-filled icon tile in the style of the
+/// iOS Settings app — used to give the otherwise plain settings screens some life.
+struct SettingsRowLabel: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+    let color: Color
+
+    init(_ title: LocalizedStringKey, systemImage: String, color: Color) {
+        self.title = title
+        self.systemImage = systemImage
+        self.color = color
+    }
+
+    var body: some View {
+        Label {
+            Text(title)
+        } icon: {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+                .background(color.gradient, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
     }
 }
 
@@ -259,6 +283,9 @@ struct LabSortEditor: View {
                             .frame(width: 20)
                     }
                     .buttonStyle(.plain)
+                    Circle()
+                        .fill(LabCategory.forCode(item.code).color.gradient)
+                        .frame(width: 9, height: 9)
                     Text(item.name)
                     Spacer()
                     Button { hideCode(item.code) } label: {
@@ -278,7 +305,10 @@ struct LabSortEditor: View {
         if !hiddenItems.isEmpty {
             Section("Hidden") {
                 ForEach(hiddenItems) { item in
-                    HStack {
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(LabCategory.forCode(item.code).color.opacity(0.4))
+                            .frame(width: 9, height: 9)
                         Text(item.name)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -64,6 +64,10 @@ enum AppInfo {
 struct SettingsView: View {
     @Binding var prefs: LabDisplayPreferences
     let allCodes: [CodeName]
+    /// `true` when presented as a sheet (iPhone) — shows a Close button. `false`
+    /// when hosted as the detail pane of the iPad sidebar, where the split view
+    /// owns dismissal and a Close button would be out of place.
+    var isModal = true
     @Environment(\.dismiss) private var dismiss
     @State private var browserURL: IdentifiedURL?
 
@@ -139,8 +143,10 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(role: .close) { dismiss() }
+                if isModal {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(role: .close) { dismiss() }
+                    }
                 }
             }
             .sheet(item: $browserURL) { item in

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -102,13 +102,9 @@ struct TrendsView: View {
                 }
             }
         }
-        .confirmationDialog(
-            "Hide \(selectedName)?",
-            isPresented: $showHideConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button("Hide", role: .destructive) { hideSelected() }
+        .alert("Hide \(selectedName)?", isPresented: $showHideConfirmation) {
             Button("Cancel", role: .cancel) {}
+            Button("Hide", role: .destructive) { hideSelected() }
         } message: {
             Text("This metric will no longer appear on your dashboard. You can show it again from Settings.")
         }
@@ -146,11 +142,7 @@ struct TrendsView: View {
                 Label("Hide", systemImage: "eye.slash")
             }
         } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.primary)
-                .frame(width: 32, height: 32)
-                .glassEffect(in: Circle())
+            Label("More", systemImage: "ellipsis")
         }
     }
 
@@ -256,18 +248,20 @@ struct TrendsView: View {
         }
         .chartXAxis {
             AxisMarks(values: .automatic) { _ in
-                AxisGridLine().foregroundStyle(Color.primary.opacity(0.15))
+                AxisGridLine().foregroundStyle(valueColor.opacity(0.12))
                 AxisValueLabel(format: .dateTime.month(.abbreviated).day())
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(valueColor.opacity(0.8))
             }
         }
         .chartYAxis {
             AxisMarks { _ in
-                AxisGridLine().foregroundStyle(Color.primary.opacity(0.15))
-                AxisValueLabel().foregroundStyle(.secondary)
+                AxisGridLine().foregroundStyle(valueColor.opacity(0.12))
+                AxisValueLabel().foregroundStyle(valueColor.opacity(0.8))
             }
         }
-        .chartYAxisLabel(currentUnit)
+        .chartYAxisLabel {
+            Text(currentUnit).foregroundStyle(valueColor.opacity(0.8))
+        }
         .frame(minHeight: 260)
         .padding()
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))

--- a/LabImporter/Views/UnsupportedDeviceView.swift
+++ b/LabImporter/Views/UnsupportedDeviceView.swift
@@ -52,16 +52,16 @@ struct UnsupportedDeviceView: View {
 
             VStack(alignment: .leading, spacing: 24) {
                 RequirementRow(
-                    icon: "iphone",
+                    icon: "cpu",
                     color: .blue,
                     title: "Apple Intelligence Device",
-                    description: "An iPhone with an A17 Pro or M-series chip is required."
+                    description: "An iPhone with A17 Pro or an iPad/Mac with Apple silicon (M1 or later) is required."
                 )
                 RequirementRow(
                     icon: "arrow.up.circle",
                     color: .green,
-                    title: "iOS 26 or Later",
-                    description: "Make sure your device is running the latest version of iOS."
+                    title: "Latest OS",
+                    description: "Make sure your device is running iOS or iPadOS 26 or later."
                 )
             }
             .padding(.horizontal, 32)


### PR DESCRIPTION
- Dashboard cards: fold the trend arrow into the colored category "dock"
  at the card's top-left instead of a separate badge by the value.
- Trends chart: tint the X/Y axis labels, gridlines and unit label with
  the metric's category color instead of the default blue/secondary.
- Trends "More" toolbar button: drop the manual glassEffect circle so it
  uses the standard toolbar styling (no odd inner halo).
- Hiding a metric now uses an Alert instead of a confirmation dialog.
- Settings: give every row an iOS-style colored icon tile, switch to a
  large navigation title, and replace the free-floating pill buttons with
  standard link rows plus a centered version footer.
- Sort & Visibility + LOINC catalog/detail: add category color accents and
  a colored category header on the LOINC detail screen.