### PR TITLE
Remove drag and drop reordering from Overview

### DIFF
--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -22,7 +22,6 @@ struct DashboardView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showSettings = false
     @State private var trendSheet: TrendSheet?
-    @State private var dropTargetCode: String?
 
     private struct TrendSheet: Identifiable {
         var id: String { code }
@@ -127,24 +126,6 @@ struct DashboardView: View {
             MetricCard(metric: metric, isPinned: pinned)
         }
         .buttonStyle(.plain)
-        .overlay {
-            if dropTargetCode == code {
-                RoundedRectangle(cornerRadius: 20)
-                    .stroke(Color.accentColor, lineWidth: 2)
-            }
-        }
-        .draggable(code) {
-            MetricCard(metric: metric, isPinned: pinned)
-                .frame(width: 180)
-        }
-        .dropDestination(for: String.self) { items, _ in
-            dropTargetCode = nil
-            guard let dragged = items.first else { return false }
-            moveMetric(dragged, before: code)
-            return true
-        } isTargeted: { isTargeted in
-            dropTargetCode = isTargeted ? code : (dropTargetCode == code ? nil : dropTargetCode)
-        }
         .contextMenu {
             Button { togglePin(code) } label: {
                 Label(
@@ -236,34 +217,6 @@ struct DashboardView: View {
             }
         }
         return result
-    }
-
-    // MARK: - Drag & drop reordering
-
-    /// Moves `dragged` to sit immediately before `target` in the dashboard order,
-    /// then persists the new sequence. Pinned cards still float to the top per the
-    /// `sortedMetrics` rules, so reordering effectively sorts within the pin groups.
-    private func moveMetric(_ dragged: String, before target: String) {
-        guard dragged != target else { return }
-        var order = sortedMetrics.map(\.entry.code)
-        guard let from = order.firstIndex(of: dragged) else { return }
-        order.remove(at: from)
-        guard let targetIndex = order.firstIndex(of: target) else { return }
-        order.insert(dragged, at: targetIndex)
-        persistOrder(order)
-    }
-
-    /// Persists `codes` as the leading entries of `orderedCodes`, preserving any
-    /// previously ordered codes that aren't currently shown (e.g. hidden metrics).
-    private func persistOrder(_ codes: [String]) {
-        var result = codes
-        var seen = Set(codes)
-        for code in prefs.orderedCodes where seen.insert(code).inserted {
-            result.append(code)
-        }
-        var updated = prefs
-        updated.orderedCodes = result
-        prefs = updated
     }
 
     // MARK: - Pin helpers


### PR DESCRIPTION
Remove the draggable/dropDestination metric-card reordering from the
dashboard, along with the drop-target overlay and the now-unused
moveMetric/persistOrder helpers and dropTargetCode state.