### PR TITLE
Match plain category dot size to trend arrow circle

### DIFF
--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -290,8 +290,9 @@ private struct MetricCard: View {
 
     /// The colored category "dock" at the card's top-left. When a trend is
     /// available it doubles as the trend indicator and hosts a directional
-    /// arrow; otherwise it is a simple category-color dot. Both variants reserve
-    /// the same footprint so the title alignment stays put.
+    /// arrow; otherwise it is a simple category-color dot filling the same
+    /// circle. Both variants share an 18×18 footprint so the title alignment —
+    /// and the dot/arrow size — stays consistent across cards.
     @ViewBuilder
     private var dock: some View {
         if let trend {
@@ -303,8 +304,7 @@ private struct MetricCard: View {
                 .accessibilityLabel(trend.accessibilityLabel)
         } else {
             Circle()
-                .fill(categoryColor)
-                .frame(width: 9, height: 9)
+                .fill(categoryColor.gradient)
                 .frame(width: 18, height: 18)
                 .accessibilityHidden(true)
         }


### PR DESCRIPTION
Lab cards without a trend arrow rendered the category dot at 9×9 inside
an 18×18 frame, leaving a much smaller circle than the 18×18 trend-arrow
circle on cards with a trend. Fill the dot at the full 18×18 footprint
(with a matching gradient) so both variants are visually identical.