### PR TITLE
Fix GitHub icon contrast in dark mode and Trend axis date format

### DIFF
--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -127,7 +127,7 @@ struct SettingsView: View {
                     if let repository = AppInfo.repositoryURL {
                         linkRow("View on GitHub",
                                 systemImage: "chevron.left.forwardslash.chevron.right",
-                                color: .primary, url: repository)
+                                color: .gray, url: repository)
                     }
                     if let newIssue = AppInfo.newIssueURL {
                         linkRow("Report an Issue",

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -249,7 +249,7 @@ struct TrendsView: View {
         .chartXAxis {
             AxisMarks(values: .automatic) { _ in
                 AxisGridLine().foregroundStyle(valueColor.opacity(0.12))
-                AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                AxisValueLabel(format: .dateTime.day().month(.abbreviated))
                     .foregroundStyle(valueColor.opacity(0.8))
             }
         }


### PR DESCRIPTION
## Summary

Two small UI fixes.

**1. GitHub icon legibility in dark mode** (`SettingsView.swift`)
The "View on GitHub" row passed `color: .primary` to its icon tile. Since the glyph is rendered with `foregroundStyle(.white)`, in dark mode the `.primary` tile turns white → white-on-white and the icon is invisible. Changed to `.gray`, matching the LOINC "Version" row, so it stays legible in both appearances.

**2. Trend graph date format** (`TrendsView.swift`)
The X-axis used `.dateTime.month(.abbreviated).day()` → "May 31" (forced month-first, awkward in German). Switched to `.dateTime.day().month(.abbreviated)` → "31 May" / "31. Mai" — a shorter, more naturally ordered human-readable label for both shipped locales.

## Testing
- `swiftlint lint --strict` passes clean on both changed files.

https://claude.ai/code/session_014KK4j6QZwQQnmY7tczDy8X

---
_Generated by [Claude Code](https://claude.ai/code/session_014KK4j6QZwQQnmY7tczDy8X)_