### PR TITLE
docs: correct stale lab-data claims in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ LabImporter/
 ├── Models/
 │   ├── LabValue.swift          # editable in-memory value (used in Review flow)
 │   ├── LabReport.swift         # a saved report (Codable); .asLabValues bridges to LabValue
-│   ├── LabMapping.swift        # CODE ↔ display name ↔ LOINC ↔ reference range tables
+│   ├── LabMapping.swift        # thin catalog adapter: LOINC code ↔ display name ↔ CDA export / loinc.org URL
 │   └── LabDisplayPreferences.swift  # pinned/ordered/hidden codes (RawRepresentable for @AppStorage)
 ├── Services/
 │   ├── OCRService.swift        # actor; Vision text recognition + PDFKit rendering

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scan, import, or paste your lab report — the app uses Vision OCR and the on-de
 - **Import** by scanning multi-page documents with the camera, picking PDFs or images from Files, or pasting from the clipboard
 - **On-device AI parsing** — Foundation Models + Vision OCR extract lab values without sending any data to a server
 - **Review & correct** — edit values, change codes, add or remove entries before saving
-- **Dashboard** — metric cards with current value, sparkline trend, and normal / borderline / elevated status
+- **Dashboard** — metric cards with current value, sparkline, and a trend-direction indicator (rising / falling / steady)
 - **Trend charts** — interactive per-metric chart with finger-scrubbing to inspect individual values
 - **History** — full list of imported reports with edit and delete
 - **Customise** — pin metrics to the top, reorder, or hide them from the dashboard


### PR DESCRIPTION
## Summary

Fixes two stale documentation claims discovered while reviewing what TrendsView could display.

- **`CLAUDE.md`** — `LabMapping` no longer holds "reference range tables"; it's a thin catalog adapter (LOINC code ↔ display name ↔ CDA export / loinc.org URL). Updated the repository-layout description to match.
- **`README.md`** — the dashboard surfaces a trend-direction arrow (rising / falling / steady), not a "normal / borderline / elevated status" — no reference-range data exists in the model. Corrected the feature bullet.

Docs-only change; no code touched.

https://claude.ai/code/session_013qmsQdSJ3YQevAnbhmFRrL

---
_Generated by [Claude Code](https://claude.ai/code/session_013qmsQdSJ3YQevAnbhmFRrL)_