### PR TITLE
Redesign Welcome & import landing around the app's design system

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		AABB000000000000000068AA /* TrendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000069AA /* TrendsView.swift */; };
 		AABB000000000000000070AA /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000071AA /* DashboardView.swift */; };
 		AABB000000000000000072AA /* ImportLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000073AA /* ImportLandingView.swift */; };
+		AABB0000000000000000C0AA /* MorphingCategoryBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */; };
 		AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000075AA /* LabDisplayPreferences.swift */; };
 		AABB000000000000000077AA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000076AA /* Localizable.xcstrings */; };
 		AABB000000000000000078AA /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000079AA /* WelcomeView.swift */; };
@@ -83,6 +84,7 @@
 		AABB000000000000000069AA /* TrendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsView.swift; sourceTree = "<group>"; };
 		AABB000000000000000071AA /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		AABB000000000000000073AA /* ImportLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportLandingView.swift; sourceTree = "<group>"; };
+		AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphingCategoryBackground.swift; sourceTree = "<group>"; };
 		AABB000000000000000075AA /* LabDisplayPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabDisplayPreferences.swift; sourceTree = "<group>"; };
 		AABB000000000000000076AA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		AABB000000000000000079AA /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 				AABB000000000000000069AA /* TrendsView.swift */,
 				AABB000000000000000071AA /* DashboardView.swift */,
 				AABB000000000000000073AA /* ImportLandingView.swift */,
+				AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */,
 				AABB000000000000000079AA /* WelcomeView.swift */,
 				AABB000000000000000087AA /* SettingsView.swift */,
 				AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */,
@@ -332,6 +335,7 @@
 				AABB000000000000000068AA /* TrendsView.swift in Sources */,
 				AABB000000000000000070AA /* DashboardView.swift in Sources */,
 				AABB000000000000000072AA /* ImportLandingView.swift in Sources */,
+				AABB0000000000000000C0AA /* MorphingCategoryBackground.swift in Sources */,
 				AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */,
 				AABB000000000000000078AA /* WelcomeView.swift in Sources */,
 				AABB000000000000000086AA /* SettingsView.swift in Sources */,

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -51,47 +51,55 @@ struct HomeView: View {
         // compact widths — while the import overlay, review sheet, report
         // loading and onboarding stay shared across both so behavior is
         // identical no matter how the content is presented.
-        Group {
-            if horizontalSizeClass == .regular {
-                splitRoot
-            } else {
-                compactRoot
+        //
+        // The outer GeometryReader publishes the window size and a shared
+        // coordinate space so the empty-state wash (painted as each split-view
+        // column's own background) can align into one seamless full-window field.
+        GeometryReader { proxy in
+            Group {
+                if horizontalSizeClass == .regular {
+                    splitRoot
+                } else {
+                    compactRoot
+                }
             }
-        }
-        // The processing HUD is presented in its own top-level UIWindow (see
-        // `labImport`), so it floats above the navigation bar and blocks the
-        // toolbar buttons (history/settings/import) while an import is running.
-        .labImport(engine: importEngine)
-        .sheet(isPresented: $showReview) {
-            NavigationStack {
-                ReviewView(
-                    labValues: labValues,
-                    reportDate: parsedReportDate ?? Date(),
-                    extractedPatientName: parsedPatientName,
-                    extractedAuthorName: parsedAuthorName
-                )
+            .environment(\.appWindowSize, proxy.size)
+            .coordinateSpace(.named(MorphingCategoryBackground.windowSpace))
+            // The processing HUD is presented in its own top-level UIWindow (see
+            // `labImport`), so it floats above the navigation bar and blocks the
+            // toolbar buttons (history/settings/import) while an import is running.
+            .labImport(engine: importEngine)
+            .sheet(isPresented: $showReview) {
+                NavigationStack {
+                    ReviewView(
+                        labValues: labValues,
+                        reportDate: parsedReportDate ?? Date(),
+                        extractedPatientName: parsedPatientName,
+                        extractedAuthorName: parsedAuthorName
+                    )
+                }
+                .interactiveDismissDisabled()
             }
-            .interactiveDismissDisabled()
-        }
-        .task { await loadReports() }
-        .onChange(of: showReview) { _, showing in
-            if !showing { Task { await loadReports() } }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-            Task { await loadReports() }
-        }
-        .onAppear {
-            refreshClipboardState()
-            configureImportEngine()
-        }
-        .onOpenURL { url in
-            Task { await importEngine.processFile(at: url) }
-        }
-        .fullScreenCover(isPresented: Binding(
-            get: { !hasSeenWelcome },
-            set: { _ in }
-        )) {
-            WelcomeView { hasSeenWelcome = true }
+            .task { await loadReports() }
+            .onChange(of: showReview) { _, showing in
+                if !showing { Task { await loadReports() } }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                Task { await loadReports() }
+            }
+            .onAppear {
+                refreshClipboardState()
+                configureImportEngine()
+            }
+            .onOpenURL { url in
+                Task { await importEngine.processFile(at: url) }
+            }
+            .fullScreenCover(isPresented: Binding(
+                get: { !hasSeenWelcome },
+                set: { _ in }
+            )) {
+                WelcomeView { hasSeenWelcome = true }
+            }
         }
     }
 
@@ -101,7 +109,6 @@ struct HomeView: View {
         NavigationStack {
             mainContent(showsLibraryToolbarItems: true)
         }
-        .background { if showsLandingWash { MorphingCategoryBackground() } }
     }
 
     // MARK: - Regular layout (iPad)
@@ -114,11 +121,15 @@ struct HomeView: View {
                         .tag(section)
                 }
             }
-            // In the empty/onboarding state the morphing wash sits behind the
-            // whole split view, so the sidebar's own list background is hidden to
-            // let it show through — making the wash span the full window rather
-            // than just the detail pane.
+            // In the empty/onboarding state the wash spans the whole window. The
+            // sidebar can't show a background placed *behind* the split view
+            // (the column is opaque), so it paints the wash as its own content
+            // background — hiding the list background to reveal it. `seamless`
+            // aligns it to the detail pane's copy so there's no divider seam.
             .scrollContentBackground(showsLandingWash ? .hidden : .automatic)
+            .background {
+                if showsLandingWash { MorphingCategoryBackground(seamless: true) }
+            }
             .navigationTitle("Lab Importer")
             .navigationSplitViewColumnWidth(min: 240, ideal: 280)
             .toolbar {
@@ -130,9 +141,6 @@ struct HomeView: View {
             detailColumn
         }
         .navigationSplitViewStyle(.balanced)
-        // A single wash behind both columns (rather than one per pane) keeps it
-        // seamless across the sidebar/detail divider.
-        .background { if showsLandingWash { MorphingCategoryBackground() } }
     }
 
     /// The full-window colored wash is only shown in the empty "import your first

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -51,55 +51,47 @@ struct HomeView: View {
         // compact widths — while the import overlay, review sheet, report
         // loading and onboarding stay shared across both so behavior is
         // identical no matter how the content is presented.
-        //
-        // The outer GeometryReader publishes the window size and a shared
-        // coordinate space so the empty-state wash (painted as each split-view
-        // column's own background) can align into one seamless full-window field.
-        GeometryReader { proxy in
-            Group {
-                if horizontalSizeClass == .regular {
-                    splitRoot
-                } else {
-                    compactRoot
-                }
+        Group {
+            if horizontalSizeClass == .regular {
+                splitRoot
+            } else {
+                compactRoot
             }
-            .environment(\.appWindowSize, proxy.size)
-            .coordinateSpace(.named(MorphingCategoryBackground.windowSpace))
-            // The processing HUD is presented in its own top-level UIWindow (see
-            // `labImport`), so it floats above the navigation bar and blocks the
-            // toolbar buttons (history/settings/import) while an import is running.
-            .labImport(engine: importEngine)
-            .sheet(isPresented: $showReview) {
-                NavigationStack {
-                    ReviewView(
-                        labValues: labValues,
-                        reportDate: parsedReportDate ?? Date(),
-                        extractedPatientName: parsedPatientName,
-                        extractedAuthorName: parsedAuthorName
-                    )
-                }
-                .interactiveDismissDisabled()
+        }
+        // The processing HUD is presented in its own top-level UIWindow (see
+        // `labImport`), so it floats above the navigation bar and blocks the
+        // toolbar buttons (history/settings/import) while an import is running.
+        .labImport(engine: importEngine)
+        .sheet(isPresented: $showReview) {
+            NavigationStack {
+                ReviewView(
+                    labValues: labValues,
+                    reportDate: parsedReportDate ?? Date(),
+                    extractedPatientName: parsedPatientName,
+                    extractedAuthorName: parsedAuthorName
+                )
             }
-            .task { await loadReports() }
-            .onChange(of: showReview) { _, showing in
-                if !showing { Task { await loadReports() } }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                Task { await loadReports() }
-            }
-            .onAppear {
-                refreshClipboardState()
-                configureImportEngine()
-            }
-            .onOpenURL { url in
-                Task { await importEngine.processFile(at: url) }
-            }
-            .fullScreenCover(isPresented: Binding(
-                get: { !hasSeenWelcome },
-                set: { _ in }
-            )) {
-                WelcomeView { hasSeenWelcome = true }
-            }
+            .interactiveDismissDisabled()
+        }
+        .task { await loadReports() }
+        .onChange(of: showReview) { _, showing in
+            if !showing { Task { await loadReports() } }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            Task { await loadReports() }
+        }
+        .onAppear {
+            refreshClipboardState()
+            configureImportEngine()
+        }
+        .onOpenURL { url in
+            Task { await importEngine.processFile(at: url) }
+        }
+        .fullScreenCover(isPresented: Binding(
+            get: { !hasSeenWelcome },
+            set: { _ in }
+        )) {
+            WelcomeView { hasSeenWelcome = true }
         }
     }
 
@@ -121,15 +113,6 @@ struct HomeView: View {
                         .tag(section)
                 }
             }
-            // In the empty/onboarding state the wash spans the whole window. The
-            // sidebar can't show a background placed *behind* the split view
-            // (the column is opaque), so it paints the wash as its own content
-            // background — hiding the list background to reveal it. `seamless`
-            // aligns it to the detail pane's copy so there's no divider seam.
-            .scrollContentBackground(showsLandingWash ? .hidden : .automatic)
-            .background {
-                if showsLandingWash { MorphingCategoryBackground(seamless: true) }
-            }
             .navigationTitle("Lab Importer")
             .navigationSplitViewColumnWidth(min: 240, ideal: 280)
             .toolbar {
@@ -141,13 +124,6 @@ struct HomeView: View {
             detailColumn
         }
         .navigationSplitViewStyle(.balanced)
-    }
-
-    /// The full-window colored wash is only shown in the empty "import your first
-    /// report" state. Once reports exist, each screen uses its own background
-    /// (e.g. the dashboard's category tint).
-    private var showsLandingWash: Bool {
-        isLoaded && reports.isEmpty
     }
 
     @ViewBuilder

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -101,6 +101,7 @@ struct HomeView: View {
         NavigationStack {
             mainContent(showsLibraryToolbarItems: true)
         }
+        .background { if showsLandingWash { MorphingCategoryBackground() } }
     }
 
     // MARK: - Regular layout (iPad)
@@ -113,6 +114,11 @@ struct HomeView: View {
                         .tag(section)
                 }
             }
+            // In the empty/onboarding state the morphing wash sits behind the
+            // whole split view, so the sidebar's own list background is hidden to
+            // let it show through — making the wash span the full window rather
+            // than just the detail pane.
+            .scrollContentBackground(showsLandingWash ? .hidden : .automatic)
             .navigationTitle("Lab Importer")
             .navigationSplitViewColumnWidth(min: 240, ideal: 280)
             .toolbar {
@@ -124,6 +130,16 @@ struct HomeView: View {
             detailColumn
         }
         .navigationSplitViewStyle(.balanced)
+        // A single wash behind both columns (rather than one per pane) keeps it
+        // seamless across the sidebar/detail divider.
+        .background { if showsLandingWash { MorphingCategoryBackground() } }
+    }
+
+    /// The full-window colored wash is only shown in the empty "import your first
+    /// report" state. Once reports exist, each screen uses its own background
+    /// (e.g. the dashboard's category tint).
+    private var showsLandingWash: Bool {
+        isLoaded && reports.isEmpty
     }
 
     @ViewBuilder

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -24,6 +24,7 @@ struct ImportLandingView: View {
             Spacer()
                 .frame(height: 56)
         }
+        .background { MorphingCategoryBackground() }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -34,12 +35,18 @@ struct ImportLandingView: View {
         VStack(spacing: 20) {
             ZStack {
                 Circle()
-                    .fill(Color.primary.opacity(0.08))
+                    .fill(
+                        LinearGradient(
+                            colors: [LabCategory.bloodGas.color, LabCategory.endocrine.color],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
                     .frame(width: 110, height: 110)
-                    .shadow(color: .black.opacity(0.15), radius: 24, y: 8)
+                    .shadow(color: LabCategory.endocrine.color.opacity(0.35), radius: 24, y: 10)
                 Image(systemName: "waveform.path.ecg.rectangle.fill")
                     .font(.system(size: 52))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(.white)
             }
 
             VStack(spacing: 8) {
@@ -97,7 +104,9 @@ struct ImportLandingView: View {
             .controlSize(.large)
         }
         .padding(24)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28))
+        // Glass (rather than plain material) so the card matches the floating
+        // progress card it morphs into during import — see `LabImportEngine`.
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 28))
         .overlay(
             RoundedRectangle(cornerRadius: 28)
                 .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -24,10 +24,10 @@ struct ImportLandingView: View {
             Spacer()
                 .frame(height: 56)
         }
-        // Painted as this column's own background (which reliably renders, unlike
-        // one placed behind the split view). `seamless` aligns it to the sidebar's
-        // matching wash so the two columns read as one continuous full-window field.
-        .background { MorphingCategoryBackground(seamless: true) }
+        // Painted as this view's own content background — exactly like the
+        // Dashboard's CategoryBackground — so it reliably fills the screen
+        // (iPhone) or the detail pane (iPad).
+        .background { MorphingCategoryBackground() }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -24,6 +24,11 @@ struct ImportLandingView: View {
             Spacer()
                 .frame(height: 56)
         }
+        // Fill the whole pane so the background covers it. A VStack otherwise
+        // hugs its content width (~480pt here), which on iPad left the wash as a
+        // narrow centered strip — the Dashboard avoids this only because its
+        // background sits on a greedy ScrollView.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         // Painted as this view's own content background — exactly like the
         // Dashboard's CategoryBackground — so it reliably fills the screen
         // (iPhone) or the detail pane (iPad).

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -24,8 +24,10 @@ struct ImportLandingView: View {
             Spacer()
                 .frame(height: 56)
         }
-        // The colored wash is hosted behind the whole window in `HomeView` (so it
-        // spans the sidebar too on iPad); this view stays transparent over it.
+        // Painted as this column's own background (which reliably renders, unlike
+        // one placed behind the split view). `seamless` aligns it to the sidebar's
+        // matching wash so the two columns read as one continuous full-window field.
+        .background { MorphingCategoryBackground(seamless: true) }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -24,7 +24,8 @@ struct ImportLandingView: View {
             Spacer()
                 .frame(height: 56)
         }
-        .background { MorphingCategoryBackground() }
+        // The colored wash is hosted behind the whole window in `HomeView` (so it
+        // spans the sidebar too on iPad); this view stays transparent over it.
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/LabImporter/Views/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/MorphingCategoryBackground.swift
@@ -12,15 +12,36 @@ import SwiftUI
 /// low-opacity over `Color(.systemBackground)` — in the same restrained spirit
 /// as `CategoryBackground` on the Dashboard.
 ///
+/// ## Seamless mode
+/// `NavigationSplitView` paints its columns opaquely, so a single background
+/// placed *behind* the split view never shows through the detail column. To span
+/// the whole window (sidebar **and** detail) the wash is instead painted as each
+/// column's own content background. To keep those independent instances looking
+/// like one continuous field — with no seam at the sidebar/detail divider — pass
+/// `seamless: true`: the gradient is then sized to the whole window
+/// (`\.appWindowSize`) and offset by the view's position within a shared
+/// `"appWindow"` coordinate space, so every instance samples the same field.
+///
 /// Respects Reduce Motion: when enabled, it renders a single static frame of the
 /// same gradient (no `TimelineView`), so the look stays consistent while the
 /// animation is dropped.
 struct MorphingCategoryBackground: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.appWindowSize) private var windowSize
 
     /// How wide the wash reads. Onboarding can afford a touch more presence than
     /// the content-dense Dashboard, but it stays subtle by design.
     var intensity: Double = 0.20
+
+    /// When true, align the field to the shared window coordinate space so
+    /// instances in different panes (sidebar / detail) line up seamlessly. When
+    /// false (the default), the gradient simply fills its own bounds — correct
+    /// for a single full-screen host like the Welcome cover.
+    var seamless = false
+
+    /// Name of the coordinate space (declared by `HomeView`) the seamless layout
+    /// measures against.
+    static let windowSpace = "appWindow"
 
     /// A curated, color-wheel-ordered subset of the clinical palette so adjacent
     /// frames blend smoothly (blue → teal → green → orange → pink → purple).
@@ -43,38 +64,44 @@ struct MorphingCategoryBackground: View {
 
     /// Radius of the softening blur. The mesh is drawn larger than the canvas by
     /// a comfortable multiple of this so the blur's faded edges fall outside the
-    /// visible area (see `body`).
+    /// visible area (see `layout`).
     private let blurRadius: CGFloat = 60
 
     var body: some View {
-        // Measure the actual canvas (which, thanks to `ignoresSafeArea` below,
-        // is the full screen / window pane) so we can oversize the gradient
-        // precisely instead of relying on a fixed scale factor.
         GeometryReader { proxy in
-            let size = proxy.size
-            ZStack {
-                Color(.systemBackground)
-                if reduceMotion {
-                    mesh(at: 0)
-                } else {
-                    TimelineView(.animation) { context in
-                        mesh(at: context.date.timeIntervalSinceReferenceDate)
-                    }
-                }
-            }
-            // Draw the gradient larger than the canvas on every side, then clip
-            // back to it. Blurring a gradient fades its edges toward transparent;
-            // pushing those edges well beyond the visible bounds means only the
-            // fully-saturated interior shows, so the wash reaches every edge.
-            .frame(
-                width: size.width + blurRadius * 4,
-                height: size.height + blurRadius * 4
-            )
-            .frame(width: size.width, height: size.height)
-            .clipped()
+            // In seamless mode size the gradient to the whole window and offset
+            // it by this view's origin within the window, so separate instances
+            // (sidebar + detail) sample one shared field. Otherwise just fill the
+            // local bounds.
+            let useWindow = seamless && windowSize != .zero
+            let canvas = useWindow ? windowSize : proxy.size
+            let origin = useWindow ? proxy.frame(in: .named(Self.windowSpace)).origin : .zero
+            layout(canvas: canvas, origin: origin, pane: proxy.size)
         }
         .ignoresSafeArea()
         .allowsHitTesting(false)
+    }
+
+    /// Draws the (oversized, blurred) gradient for a `canvas`-sized field, shifted
+    /// so the window origin lands at `origin` within this pane, then clips to the
+    /// pane. Oversizing by the blur radius keeps the faded blur edges off the
+    /// visible area so the color reaches every edge.
+    private func layout(canvas: CGSize, origin: CGPoint, pane: CGSize) -> some View {
+        let margin = blurRadius * 4
+        return ZStack {
+            Color(.systemBackground)
+            if reduceMotion {
+                mesh(at: 0)
+            } else {
+                TimelineView(.animation) { context in
+                    mesh(at: context.date.timeIntervalSinceReferenceDate)
+                }
+            }
+        }
+        .frame(width: canvas.width + margin, height: canvas.height + margin)
+        .offset(x: -origin.x - margin / 2, y: -origin.y - margin / 2)
+        .frame(width: pane.width, height: pane.height, alignment: .topLeading)
+        .clipped()
     }
 
     private func mesh(at time: TimeInterval) -> some View {
@@ -104,6 +131,22 @@ struct MorphingCategoryBackground: View {
         let upper = (lower + 1) % count
         let fraction = pos - pos.rounded(.down)
         return palette[lower].mix(with: palette[upper], by: fraction)
+    }
+}
+
+// MARK: - Window size environment
+
+/// The size of the app's top-level window, published by `HomeView` so the
+/// seamless background can size itself to the whole window from within an
+/// individual split-view column.
+private struct AppWindowSizeKey: EnvironmentKey {
+    static let defaultValue: CGSize = .zero
+}
+
+extension EnvironmentValues {
+    var appWindowSize: CGSize {
+        get { self[AppWindowSizeKey.self] }
+        set { self[AppWindowSizeKey.self] = newValue }
     }
 }
 

--- a/LabImporter/Views/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/MorphingCategoryBackground.swift
@@ -65,9 +65,17 @@ struct MorphingCategoryBackground: View {
             points: Self.points,
             colors: (0..<9).map { color(forVertex: $0, time: time) }
         )
+        // Greedily fill whatever space we're given so the wash tracks window
+        // resizes (iPad multitasking / Stage Manager) and large canvases.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         // A wide blur melts the nine color zones into one another so the result
         // reads as an organic wash rather than a visible grid.
         .blur(radius: 60)
+        // Blurring a frame-clipped gradient fades its edges toward transparent,
+        // which on a large canvas reads as a dark vignette. Scaling the blurred
+        // result up pushes those faded margins off-screen so the color fills
+        // edge to edge.
+        .scaleEffect(1.4)
     }
 
     /// The color for a given mesh vertex at a moment in time: a continuous

--- a/LabImporter/Views/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/MorphingCategoryBackground.swift
@@ -41,18 +41,37 @@ struct MorphingCategoryBackground: View {
         .init(0, 1), .init(0.5, 1), .init(1, 1)
     ]
 
+    /// Radius of the softening blur. The mesh is drawn larger than the canvas by
+    /// a comfortable multiple of this so the blur's faded edges fall outside the
+    /// visible area (see `body`).
+    private let blurRadius: CGFloat = 60
+
     var body: some View {
-        ZStack {
-            Color(.systemBackground)
-            if reduceMotion {
-                mesh(at: 0)
-                    .opacity(intensity)
-            } else {
-                TimelineView(.animation) { context in
-                    mesh(at: context.date.timeIntervalSinceReferenceDate)
-                        .opacity(intensity)
+        // Measure the actual canvas (which, thanks to `ignoresSafeArea` below,
+        // is the full screen / window pane) so we can oversize the gradient
+        // precisely instead of relying on a fixed scale factor.
+        GeometryReader { proxy in
+            let size = proxy.size
+            ZStack {
+                Color(.systemBackground)
+                if reduceMotion {
+                    mesh(at: 0)
+                } else {
+                    TimelineView(.animation) { context in
+                        mesh(at: context.date.timeIntervalSinceReferenceDate)
+                    }
                 }
             }
+            // Draw the gradient larger than the canvas on every side, then clip
+            // back to it. Blurring a gradient fades its edges toward transparent;
+            // pushing those edges well beyond the visible bounds means only the
+            // fully-saturated interior shows, so the wash reaches every edge.
+            .frame(
+                width: size.width + blurRadius * 4,
+                height: size.height + blurRadius * 4
+            )
+            .frame(width: size.width, height: size.height)
+            .clipped()
         }
         .ignoresSafeArea()
         .allowsHitTesting(false)
@@ -65,17 +84,10 @@ struct MorphingCategoryBackground: View {
             points: Self.points,
             colors: (0..<9).map { color(forVertex: $0, time: time) }
         )
-        // Greedily fill whatever space we're given so the wash tracks window
-        // resizes (iPad multitasking / Stage Manager) and large canvases.
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         // A wide blur melts the nine color zones into one another so the result
         // reads as an organic wash rather than a visible grid.
-        .blur(radius: 60)
-        // Blurring a frame-clipped gradient fades its edges toward transparent,
-        // which on a large canvas reads as a dark vignette. Scaling the blurred
-        // result up pushes those faded margins off-screen so the color fills
-        // edge to edge.
-        .scaleEffect(1.4)
+        .blur(radius: blurRadius)
+        .opacity(intensity)
     }
 
     /// The color for a given mesh vertex at a moment in time: a continuous

--- a/LabImporter/Views/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/MorphingCategoryBackground.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// A slow, gently morphing wash of the app's `LabCategory` palette — the same
+/// clinical colors that later tint the Dashboard's metric cards and charts. Used
+/// behind onboarding (`WelcomeView`) and the empty-state import screen
+/// (`ImportLandingView`) so the very first thing a user sees previews the app's
+/// color system.
+///
+/// The effect is a 3×3 `MeshGradient` with fixed vertices and *animated colors*:
+/// each vertex slowly cross-fades through the palette with a per-vertex phase
+/// offset, producing a calm drift rather than motion. It is deliberately
+/// low-opacity over `Color(.systemBackground)` — in the same restrained spirit
+/// as `CategoryBackground` on the Dashboard.
+///
+/// Respects Reduce Motion: when enabled, it renders a single static frame of the
+/// same gradient (no `TimelineView`), so the look stays consistent while the
+/// animation is dropped.
+struct MorphingCategoryBackground: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// How wide the wash reads. Onboarding can afford a touch more presence than
+    /// the content-dense Dashboard, but it stays subtle by design.
+    var intensity: Double = 0.20
+
+    /// A curated, color-wheel-ordered subset of the clinical palette so adjacent
+    /// frames blend smoothly (blue → teal → green → orange → pink → purple).
+    /// Sourced from `LabCategory.color` to keep a single source of truth.
+    private static let palette: [Color] = [
+        LabCategory.bloodGas.color,     // blue
+        LabCategory.electrolytes.color, // teal
+        LabCategory.hepatic.color,      // green
+        LabCategory.glycemic.color,     // orange
+        LabCategory.hematology.color,   // pink
+        LabCategory.endocrine.color     // purple
+    ]
+
+    /// Static mesh vertices — a regular 3×3 grid. Only the colors animate.
+    private static let points: [SIMD2<Float>] = [
+        .init(0, 0), .init(0.5, 0), .init(1, 0),
+        .init(0, 0.5), .init(0.5, 0.5), .init(1, 0.5),
+        .init(0, 1), .init(0.5, 1), .init(1, 1)
+    ]
+
+    var body: some View {
+        ZStack {
+            Color(.systemBackground)
+            if reduceMotion {
+                mesh(at: 0)
+                    .opacity(intensity)
+            } else {
+                TimelineView(.animation) { context in
+                    mesh(at: context.date.timeIntervalSinceReferenceDate)
+                        .opacity(intensity)
+                }
+            }
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+    }
+
+    private func mesh(at time: TimeInterval) -> some View {
+        MeshGradient(
+            width: 3,
+            height: 3,
+            points: Self.points,
+            colors: (0..<9).map { color(forVertex: $0, time: time) }
+        )
+        // A wide blur melts the nine color zones into one another so the result
+        // reads as an organic wash rather than a visible grid.
+        .blur(radius: 60)
+    }
+
+    /// The color for a given mesh vertex at a moment in time: a continuous
+    /// position walked through `palette`, offset per vertex so the nine corners
+    /// drift out of phase with one another.
+    private func color(forVertex index: Int, time: TimeInterval) -> Color {
+        let palette = Self.palette
+        let count = palette.count
+        // ~90s for a full cycle through the palette — calm, not distracting.
+        let speed = 1.0 / 90.0
+        let phase = time * speed * Double(count) + Double(index) * 0.6
+        let pos = phase.truncatingRemainder(dividingBy: Double(count))
+        let lower = Int(pos.rounded(.down)) % count
+        let upper = (lower + 1) % count
+        let fraction = pos - pos.rounded(.down)
+        return palette[lower].mix(with: palette[upper], by: fraction)
+    }
+}
+
+#Preview {
+    MorphingCategoryBackground()
+}

--- a/LabImporter/Views/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/MorphingCategoryBackground.swift
@@ -6,42 +6,24 @@ import SwiftUI
 /// (`ImportLandingView`) so the very first thing a user sees previews the app's
 /// color system.
 ///
+/// It is painted as a view's own content background (exactly like the Dashboard's
+/// `CategoryBackground`), so it reliably fills its container — the full screen for
+/// the Welcome cover, or the detail pane for the import landing screen.
+///
 /// The effect is a 3×3 `MeshGradient` with fixed vertices and *animated colors*:
 /// each vertex slowly cross-fades through the palette with a per-vertex phase
 /// offset, producing a calm drift rather than motion. It is deliberately
 /// low-opacity over `Color(.systemBackground)` — in the same restrained spirit
-/// as `CategoryBackground` on the Dashboard.
-///
-/// ## Seamless mode
-/// `NavigationSplitView` paints its columns opaquely, so a single background
-/// placed *behind* the split view never shows through the detail column. To span
-/// the whole window (sidebar **and** detail) the wash is instead painted as each
-/// column's own content background. To keep those independent instances looking
-/// like one continuous field — with no seam at the sidebar/detail divider — pass
-/// `seamless: true`: the gradient is then sized to the whole window
-/// (`\.appWindowSize`) and offset by the view's position within a shared
-/// `"appWindow"` coordinate space, so every instance samples the same field.
+/// as `CategoryBackground`.
 ///
 /// Respects Reduce Motion: when enabled, it renders a single static frame of the
 /// same gradient (no `TimelineView`), so the look stays consistent while the
 /// animation is dropped.
 struct MorphingCategoryBackground: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.appWindowSize) private var windowSize
 
-    /// How wide the wash reads. Onboarding can afford a touch more presence than
-    /// the content-dense Dashboard, but it stays subtle by design.
+    /// How wide the wash reads. Kept subtle by design.
     var intensity: Double = 0.20
-
-    /// When true, align the field to the shared window coordinate space so
-    /// instances in different panes (sidebar / detail) line up seamlessly. When
-    /// false (the default), the gradient simply fills its own bounds — correct
-    /// for a single full-screen host like the Welcome cover.
-    var seamless = false
-
-    /// Name of the coordinate space (declared by `HomeView`) the seamless layout
-    /// measures against.
-    static let windowSpace = "appWindow"
 
     /// A curated, color-wheel-ordered subset of the clinical palette so adjacent
     /// frames blend smoothly (blue → teal → green → orange → pink → purple).
@@ -64,44 +46,35 @@ struct MorphingCategoryBackground: View {
 
     /// Radius of the softening blur. The mesh is drawn larger than the canvas by
     /// a comfortable multiple of this so the blur's faded edges fall outside the
-    /// visible area (see `layout`).
+    /// visible area (see `body`).
     private let blurRadius: CGFloat = 60
 
     var body: some View {
         GeometryReader { proxy in
-            // In seamless mode size the gradient to the whole window and offset
-            // it by this view's origin within the window, so separate instances
-            // (sidebar + detail) sample one shared field. Otherwise just fill the
-            // local bounds.
-            let useWindow = seamless && windowSize != .zero
-            let canvas = useWindow ? windowSize : proxy.size
-            let origin = useWindow ? proxy.frame(in: .named(Self.windowSpace)).origin : .zero
-            layout(canvas: canvas, origin: origin, pane: proxy.size)
+            let size = proxy.size
+            ZStack {
+                Color(.systemBackground)
+                if reduceMotion {
+                    mesh(at: 0)
+                } else {
+                    TimelineView(.animation) { context in
+                        mesh(at: context.date.timeIntervalSinceReferenceDate)
+                    }
+                }
+            }
+            // Draw the gradient larger than the canvas on every side, then clip
+            // back to it. Blurring a gradient fades its edges toward transparent;
+            // pushing those edges well beyond the visible bounds means only the
+            // fully-saturated interior shows, so the wash reaches every edge.
+            .frame(
+                width: size.width + blurRadius * 4,
+                height: size.height + blurRadius * 4
+            )
+            .frame(width: size.width, height: size.height)
+            .clipped()
         }
         .ignoresSafeArea()
         .allowsHitTesting(false)
-    }
-
-    /// Draws the (oversized, blurred) gradient for a `canvas`-sized field, shifted
-    /// so the window origin lands at `origin` within this pane, then clips to the
-    /// pane. Oversizing by the blur radius keeps the faded blur edges off the
-    /// visible area so the color reaches every edge.
-    private func layout(canvas: CGSize, origin: CGPoint, pane: CGSize) -> some View {
-        let margin = blurRadius * 4
-        return ZStack {
-            Color(.systemBackground)
-            if reduceMotion {
-                mesh(at: 0)
-            } else {
-                TimelineView(.animation) { context in
-                    mesh(at: context.date.timeIntervalSinceReferenceDate)
-                }
-            }
-        }
-        .frame(width: canvas.width + margin, height: canvas.height + margin)
-        .offset(x: -origin.x - margin / 2, y: -origin.y - margin / 2)
-        .frame(width: pane.width, height: pane.height, alignment: .topLeading)
-        .clipped()
     }
 
     private func mesh(at time: TimeInterval) -> some View {
@@ -131,22 +104,6 @@ struct MorphingCategoryBackground: View {
         let upper = (lower + 1) % count
         let fraction = pos - pos.rounded(.down)
         return palette[lower].mix(with: palette[upper], by: fraction)
-    }
-}
-
-// MARK: - Window size environment
-
-/// The size of the app's top-level window, published by `HomeView` so the
-/// seamless background can size itself to the whole window from within an
-/// individual split-view column.
-private struct AppWindowSizeKey: EnvironmentKey {
-    static let defaultValue: CGSize = .zero
-}
-
-extension EnvironmentValues {
-    var appWindowSize: CGSize {
-        get { self[AppWindowSizeKey.self] }
-        set { self[AppWindowSizeKey.self] = newValue }
     }
 }
 

--- a/LabImporter/Views/WelcomeView.swift
+++ b/LabImporter/Views/WelcomeView.swift
@@ -3,93 +3,156 @@ import SwiftUI
 struct WelcomeView: View {
     let onDismiss: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    private var features: [Feature] {
+        [
+            Feature(
+                icon: "camera.viewfinder",
+                color: LabCategory.bloodGas.color,
+                title: "Import Any Lab Report",
+                description: "Photograph, paste, or scan a report to extract your values."
+            ),
+            Feature(
+                icon: "sparkles",
+                color: LabCategory.endocrine.color,
+                title: "On-Device AI",
+                description: "Apple Intelligence reads your report privately — nothing leaves your device."
+            ),
+            Feature(
+                icon: "heart.text.square.fill",
+                color: LabCategory.cardiac.color,
+                title: "Saved to Apple Health",
+                description: "Reports are stored as clinical CDA records directly in Apple Health."
+            ),
+            Feature(
+                icon: "chart.line.uptrend.xyaxis",
+                color: LabCategory.hepatic.color,
+                title: "Track Your Trends",
+                description: "See how your values change over time with interactive charts."
+            )
+        ]
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-
-            // App icon + title
-            VStack(spacing: 20) {
-                if let icon = UIImage(named: "AppIcon") {
-                    Image(uiImage: icon)
-                        .resizable()
-                        .frame(width: 110, height: 110)
-                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-                        .shadow(color: .black.opacity(0.14), radius: 20, x: 0, y: 8)
-                }
-                VStack(spacing: 4) {
-                    Text("Welcome to")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                    Text(verbatim: "LabImporter")
-                        .font(.largeTitle.bold())
-                }
-            }
-
+            hero
             Spacer()
-
-            // Feature list
-            VStack(alignment: .leading, spacing: 28) {
-                FeatureRow(
-                    icon: "camera.viewfinder",
-                    color: .blue,
-                    title: "Import Any Lab Report",
-                    description: "Photograph, paste, or scan a report to extract your values."
-                )
-                FeatureRow(
-                    icon: "sparkles",
-                    color: .purple,
-                    title: "On-Device AI",
-                    description: "Apple Intelligence reads your report privately — nothing leaves your device."
-                )
-                FeatureRow(
-                    icon: "heart.text.square.fill",
-                    color: .red,
-                    title: "Saved to Apple Health",
-                    description: "Reports are stored as clinical CDA records directly in Apple Health."
-                )
-                FeatureRow(
-                    icon: "chart.line.uptrend.xyaxis",
-                    color: .green,
-                    title: "Track Your Trends",
-                    description: "See how your values change over time with interactive charts."
-                )
-            }
-            .padding(.horizontal, 32)
-
-            Spacer()
-
-            Button("Get Started", action: onDismiss)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .frame(maxWidth: .infinity)
+            featureCard
+                .frame(maxWidth: 480)
                 .padding(.horizontal, 24)
-                .padding(.bottom, 48)
+            Spacer()
+            getStartedButton
         }
+        .background { MorphingCategoryBackground() }
+        .onAppear {
+            guard !reduceMotion else { appeared = true; return }
+            withAnimation(.smooth(duration: 0.7)) { appeared = true }
+        }
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        VStack(spacing: 20) {
+            appIcon
+            VStack(spacing: 4) {
+                Text("Welcome to")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: "LabImporter")
+                    .font(.largeTitle.bold())
+            }
+        }
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 16)
+    }
+
+    @ViewBuilder
+    private var appIcon: some View {
+        if let icon = UIImage(named: "AppIcon") {
+            Image(uiImage: icon)
+                .resizable()
+                .frame(width: 110, height: 110)
+                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(Color.white.opacity(0.25), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.18), radius: 24, x: 0, y: 10)
+        }
+    }
+
+    // MARK: - Feature card
+
+    private var featureCard: some View {
+        VStack(alignment: .leading, spacing: 26) {
+            ForEach(Array(features.enumerated()), id: \.offset) { index, feature in
+                FeatureRow(feature: feature)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 20)
+                    .animation(
+                        reduceMotion ? nil : .smooth(duration: 0.6).delay(0.15 + Double(index) * 0.08),
+                        value: appeared
+                    )
+            }
+        }
+        .padding(24)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 28))
+        .overlay(
+            RoundedRectangle(cornerRadius: 28)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+    }
+
+    // MARK: - Button
+
+    private var getStartedButton: some View {
+        Button("Get Started", action: onDismiss)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 48)
+            .opacity(appeared ? 1 : 0)
     }
 }
 
-// MARK: - Feature row
+// MARK: - Feature model & row
 
-private struct FeatureRow: View {
+private struct Feature {
     let icon: String
     let color: Color
     let title: LocalizedStringKey
     let description: LocalizedStringKey
+}
+
+private struct FeatureRow: View {
+    let feature: Feature
 
     var body: some View {
         HStack(alignment: .center, spacing: 18) {
             ZStack {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(color.opacity(0.13))
+                    .fill(
+                        LinearGradient(
+                            colors: [feature.color, feature.color.opacity(0.7)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
                     .frame(width: 58, height: 58)
-                Image(systemName: icon)
+                    .shadow(color: feature.color.opacity(0.35), radius: 6, x: 0, y: 3)
+                Image(systemName: feature.icon)
                     .font(.title2)
-                    .foregroundStyle(color)
+                    .foregroundStyle(.white)
             }
             VStack(alignment: .leading, spacing: 3) {
-                Text(title)
+                Text(feature.title)
                     .font(.body.bold())
-                Text(description)
+                Text(feature.description)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Brings the two first-launch screens (`WelcomeView`, `ImportLandingView`) in line with the rest of the app's visual language and adds a gentle, on-brand animated backdrop.

## What changed

**New — `MorphingCategoryBackground`**
- A low-opacity `MeshGradient` that slowly cross-fades through the `LabCategory` palette — the same clinical colors used on the Dashboard — so onboarding previews the app's color system.
- Static 3×3 vertices, *animated colors* only (color-wheel ordered: blue → teal → green → orange → pink → purple), ~90s cycle, wide blur for an organic wash. Opacity `0.20`, in the restrained spirit of the Dashboard's `CategoryBackground`.
- **Reduce Motion**: drops `TimelineView` and renders a single static frame.
- Colors sourced from `LabCategory.color` (single source of truth).

**`WelcomeView`**
- Feature icons → gradient medallions (the `ReviewHeaderCard` recipe: two-stop gradient + colored shadow, white glyph), each mapped to a real `LabCategory` color.
- Feature list wrapped in a glass card; app-icon hero gets a hairline stroke + softer shadow.
- Staggered fade-in on appear, gated by Reduce Motion.
- Sits over the morphing background.

**`ImportLandingView`**
- Hero circle → gradient medallion (blood-gas → endocrine).
- Import card promoted from `.ultraThinMaterial` to `.glassEffect(.regular)` so it matches the floating progress card it morphs into during import (`LabImportEngine`).
- Sits over the morphing background.

## Verification
- `swiftlint lint --strict` passes repo-wide.
- Not built/run in Xcode here (needs the iOS 26 SDK + an Apple Intelligence device) — worth an on-device eyeball, especially the mesh opacity in light vs. dark mode. `MeshGradient` and `Color.mix(with:by:)` are both fine on the iOS 26 target.

https://claude.ai/code/session_014QT8u3smipv88NeLuaToLh

---
_Generated by [Claude Code](https://claude.ai/code/session_014QT8u3smipv88NeLuaToLh)_