### PR TITLE
Complete "Open With" file import from other apps

### DIFF
--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -66,7 +66,7 @@
 		</dict>
 	</array>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<false/>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -14,6 +14,9 @@ struct HomeView: View {
     @State private var parsedAuthorName: String?
     @State private var showReview = false
     @State private var clipboardHasContent = false
+    /// An "Open With" file that arrived before onboarding was dismissed; held
+    /// back so its review sheet isn't presented underneath the welcome cover.
+    @State private var pendingImportURL: URL?
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
 
     // iPad sidebar state
@@ -85,13 +88,16 @@ struct HomeView: View {
             configureImportEngine()
         }
         .onOpenURL { url in
-            Task { await importEngine.processFile(at: url) }
+            handleIncomingFile(url)
         }
         .fullScreenCover(isPresented: Binding(
             get: { !hasSeenWelcome },
             set: { _ in }
         )) {
-            WelcomeView { hasSeenWelcome = true }
+            WelcomeView {
+                hasSeenWelcome = true
+                flushPendingImport()
+            }
         }
     }
 
@@ -211,6 +217,26 @@ struct HomeView: View {
             }
         }
         return result
+    }
+
+    // MARK: - Incoming files ("Open With")
+
+    /// Routes a file opened from another app (share sheet / Files) into the
+    /// import pipeline. If onboarding hasn't been completed yet the URL is
+    /// stashed and replayed once `WelcomeView` is dismissed — otherwise the
+    /// review sheet would present beneath the welcome cover and stay hidden.
+    private func handleIncomingFile(_ url: URL) {
+        guard hasSeenWelcome else {
+            pendingImportURL = url
+            return
+        }
+        Task { await importEngine.processFile(at: url) }
+    }
+
+    private func flushPendingImport() {
+        guard let url = pendingImportURL else { return }
+        pendingImportURL = nil
+        Task { await importEngine.processFile(at: url) }
     }
 
     // MARK: - Import engine

--- a/LabImporter/Views/LabImportEngine.swift
+++ b/LabImporter/Views/LabImportEngine.swift
@@ -65,6 +65,11 @@ final class LabImportEngine {
         let accessing = url.startAccessingSecurityScopedResource()
         defer {
             if accessing { url.stopAccessingSecurityScopedResource() }
+            // Files handed over via "Copy to App" (share sheet) are duplicated
+            // into our Documents/Inbox; once parsed they're dead weight, so we
+            // remove them. Files opened in place (the user's own document in
+            // Files) live outside our container and are left untouched.
+            removeInboxCopy(at: url)
         }
 
         let isPDF = url.pathExtension.lowercased() == "pdf"
@@ -77,6 +82,18 @@ final class LabImportEngine {
         } else {
             errorMessage = String(localized: "Could not load the selected file.")
         }
+    }
+
+    /// Deletes `url` only if it sits inside this app's `Documents/Inbox`, the
+    /// drop box iOS uses when another app copies a document to us. In-place URLs
+    /// (security-scoped references to the user's own files) are never deleted.
+    private func removeInboxCopy(at url: URL) {
+        guard url.isFileURL,
+              let inbox = try? FileManager.default.url(
+                for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false
+              ).appendingPathComponent("Inbox") else { return }
+        guard url.standardizedFileURL.path.hasPrefix(inbox.standardizedFileURL.path) else { return }
+        try? FileManager.default.removeItem(at: url)
     }
 
     func processImages(_ images: [UIImage]) async {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Scan, import, or paste your lab report — the app uses Vision OCR and the on-de
 
 ## Features
 
-- **Import** by scanning multi-page documents with the camera, picking PDFs or images from Files, or pasting from the clipboard
+- **Import** by scanning multi-page documents with the camera, picking PDFs or images from Files, pasting from the clipboard, or sending a PDF/image to LabImporter from any app via the share sheet ("Open With")
 - **On-device AI parsing** — Foundation Models + Vision OCR extract lab values without sending any data to a server
 - **Review & correct** — edit values, change codes, add or remove entries before saving
 - **Dashboard** — metric cards with current value, sparkline, and a trend-direction indicator (rising / falling / steady)
@@ -112,7 +112,7 @@ After the first manual run succeeds, builds are triggered automatically on the *
 
 | Step | Technology |
 |---|---|
-| Document input | `VisionKit` document scanner (multi-page), `UIDocumentPicker` for PDFs / images, or Clipboard |
+| Document input | `VisionKit` document scanner (multi-page), `UIDocumentPicker` for PDFs / images, Clipboard, or files opened from other apps (`CFBundleDocumentTypes` + `onOpenURL`) |
 | PDF rendering | `PDFKit` — extracts embedded text or renders pages for OCR |
 | Text extraction | `Vision` — `VNRecognizeTextRequest` (German + English) |
 | Lab value parsing | `FoundationModels` — `@Generable` structured output via `LanguageModelSession` |


### PR DESCRIPTION
## Summary

Lets users send a lab PDF or image to LabImporter from any app's share sheet ("Open With"), or open one in place from the Files app, dropping straight into the existing import flow.

The document types (`CFBundleDocumentTypes`) and the `onOpenURL` handler were already declared — this rounds out the three gaps that kept the path from being complete:

- **Enable in-place opening** (`LSSupportsOpeningDocumentsInPlace` → `true`) so files opened from the Files app are read in place instead of duplicated into the app container.
- **Clean up `Documents/Inbox` copies** that "Copy to App" leaves behind once parsing finishes — with a guard so in-place user files are never deleted.
- **Defer an incoming file until onboarding is dismissed**, so its review sheet isn't presented underneath the `WelcomeView` cover on first run.

Also updated the README to list the new entry point.

## Notes
- **No Share Extension** by design: the on-device Foundation Models parse + HealthKit auth + review UI would be fragile inside a memory-constrained extension. Launching the full app via "Open With" is the right architecture here.
- Verified with `swiftlint lint --strict` (0 violations). Not built on-device — no macOS/Xcode in the environment — so the share-sheet flow is worth exercising on a real device before release.

https://claude.ai/code/session_01A8KR4rCXq5UPE4aUkVr6zW

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8KR4rCXq5UPE4aUkVr6zW)_