### PR TITLE
Fix live clipboard detection and immediate report refresh after edit/delete

### DIFF
--- a/LabImporter/Services/HealthKitService.swift
+++ b/LabImporter/Services/HealthKitService.swift
@@ -56,6 +56,7 @@ actor HealthKitService {
         try await store.requestAuthorization(toShare: [documentType], read: [documentType])
         let sample = try HKCDADocumentSample(data: data, start: date, end: date, metadata: nil)
         try await store.save(sample)
+        await Self.notifyReportsChanged()
     }
 
     // MARK: - Read
@@ -179,8 +180,24 @@ actor HealthKitService {
 
         if let sample {
             try await store.delete(sample)
+            await Self.notifyReportsChanged()
         }
     }
+
+    /// Broadcasts that the CDA store was mutated so any view showing reports can
+    /// reload from Health — the single source of truth — without waiting to
+    /// become active again. Posted on the main actor so SwiftUI observers receive
+    /// it on the expected thread.
+    private static func notifyReportsChanged() async {
+        await MainActor.run {
+            NotificationCenter.default.post(name: .labReportsDidChange, object: nil)
+        }
+    }
+}
+
+extension Notification.Name {
+    /// Posted after a lab report is saved, replaced, or deleted in Apple Health.
+    static let labReportsDidChange = Notification.Name("dev.idoodler.labimporter.labReportsDidChange")
 }
 
 // MARK: - CDA XML Parser

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -111,6 +111,13 @@ struct HomeView: View {
             // text field in this app, or via Split View / Slide Over).
             refreshClipboardState()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .labReportsDidChange)) { _ in
+            // A report was saved, edited, or deleted — possibly from the pushed
+            // Reports list, which has its own state. Reload so the Dashboard and
+            // Trends reflect the change immediately instead of staying stale until
+            // the app next becomes active.
+            Task { await loadReportsIfAuthorized() }
+        }
         .onAppear {
             refreshClipboardState()
             configureImportEngine()

--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -99,7 +99,17 @@ struct HomeView: View {
             if !showing { Task { await loadReportsIfAuthorized() } }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            // Re-reading the pasteboard here is essential: copying happens in
+            // *another* app, so the only signal we get is becoming active again.
+            // Without this the Paste button stays stuck in whatever state it had
+            // at launch until the app is fully relaunched.
+            refreshClipboardState()
             Task { await loadReportsIfAuthorized() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIPasteboard.changedNotification)) { _ in
+            // Live updates while we're already foregrounded (e.g. copying from a
+            // text field in this app, or via Split View / Slide Over).
+            refreshClipboardState()
         }
         .onAppear {
             refreshClipboardState()


### PR DESCRIPTION
## Summary

Two responsiveness fixes so the UI reflects state changes immediately instead of only after a relaunch / re-activation.

### 1. Paste-from-Clipboard button updates live
The button's enabled state (`clipboardHasContent`) was only computed in `.onAppear`. The `didBecomeActive` handler reloaded reports but never re-checked the clipboard, so copying something in another app and returning left the button stuck disabled until a full relaunch.

- Refresh clipboard state on `didBecomeActiveNotification` (the only signal we get when content is copied in another app).
- Also observe `UIPasteboard.changedNotification` for live updates while foregrounded (copying within the app, Split View / Slide Over).

### 2. Reports refresh immediately after edit or delete
Report data lived in two independent places: `HomeView`'s state (driving the Dashboard/Trends) and `HistoryView`'s own copy. Editing or deleting a report in the Reports list mutated Apple Health but never told `HomeView`, so the Dashboard stayed stale until the app next became active.

- Broadcast a new `.labReportsDidChange` notification from `HealthKitService` whenever the CDA store is mutated (save, replace, delete), posted on the main actor.
- `HomeView` reloads on it, so the Dashboard and Trends reflect changes right away regardless of navigation structure.

## Testing
- `swiftlint lint --strict` — 0 violations.
- No automated tests exist in the project; behavior should be verified in Xcode on a supported device per `CLAUDE.md`.

https://claude.ai/code/session_01URJPeJXW8proarRf9oGMVr

---
_Generated by [Claude Code](https://claude.ai/code/session_01URJPeJXW8proarRf9oGMVr)_