### PR TITLE
Fix "unsupported language or locale" error on terse, code-only reports

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,79 +1,79 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "On-device AI isn't available for your device's current language or region. Open Settings → Apple Intelligence & Siri and set your iPhone language to one Apple Intelligence supports (for example English or German), then try again." : {
+    "The on-device AI couldn't recognize the language of this report. This can happen with very short reports, or ones made up mostly of codes and numbers. Try importing or scanning the full report so there's more text to read, then try again." : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die geräteinterne KI ist für die aktuelle Sprache oder Region deines Geräts nicht verfügbar. Öffne „Einstellungen“ → „Apple Intelligence & Siri“ und stelle die Sprache deines iPhones auf eine von Apple Intelligence unterstützte Sprache ein (zum Beispiel Englisch oder Deutsch), und versuche es dann erneut."
+            "value" : "Die geräteinterne KI konnte die Sprache dieses Befunds nicht erkennen. Das kann bei sehr kurzen Befunden vorkommen oder bei solchen, die überwiegend aus Codes und Zahlen bestehen. Importiere oder scanne den vollständigen Befund, damit mehr Text vorhanden ist, und versuche es dann erneut."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La IA en el dispositivo no está disponible para el idioma o la región actuales de tu dispositivo. Abre Ajustes → Apple Intelligence y Siri y configura el idioma de tu iPhone en uno compatible con Apple Intelligence (por ejemplo, inglés o alemán); luego, inténtalo de nuevo."
+            "value" : "La IA en el dispositivo no pudo reconocer el idioma de este informe. Esto puede ocurrir con informes muy cortos o compuestos principalmente por códigos y números. Importa o escanea el informe completo para que haya más texto y vuelve a intentarlo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’IA sur l’appareil n’est pas disponible pour la langue ou la région actuelles de votre appareil. Ouvrez Réglages → Apple Intelligence et Siri, puis réglez la langue de votre iPhone sur une langue prise en charge par Apple Intelligence (par exemple l’anglais ou l’allemand) avant de réessayer."
+            "value" : "L’IA sur l’appareil n’a pas pu reconnaître la langue de ce compte rendu. Cela peut arriver avec des comptes rendus très courts ou composés principalement de codes et de chiffres. Importez ou numérisez le compte rendu complet afin d’avoir plus de texte, puis réessayez."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’IA sul dispositivo non è disponibile per la lingua o la regione attuali del dispositivo. Apri Impostazioni → Apple Intelligence e Siri e imposta la lingua dell’iPhone su una supportata da Apple Intelligence (ad esempio inglese o tedesco), quindi riprova."
+            "value" : "L’IA sul dispositivo non è riuscita a riconoscere la lingua di questo referto. Può accadere con referti molto brevi o composti principalmente da codici e numeri. Importa o scansiona il referto completo in modo da avere più testo, quindi riprova."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デバイス上のAIは、お使いのデバイスの現在の言語または地域では利用できません。「設定」→「Apple Intelligenceとシリ」を開き、iPhoneの言語をApple Intelligenceが対応している言語（例：英語またはドイツ語）に設定してから、もう一度お試しください。"
+            "value" : "デバイス上のAIはこのレポートの言語を認識できませんでした。これは、非常に短いレポートや、ほとんどがコードと数字で構成されているレポートで起こることがあります。テキストが増えるようレポート全体を読み込むかスキャンしてから、もう一度お試しください。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De AI op het apparaat is niet beschikbaar voor de huidige taal of regio van je apparaat. Open Instellingen → Apple Intelligence en Siri en stel de taal van je iPhone in op een taal die door Apple Intelligence wordt ondersteund (bijvoorbeeld Engels of Duits) en probeer het opnieuw."
+            "value" : "De AI op het apparaat kon de taal van dit rapport niet herkennen. Dit kan gebeuren bij zeer korte rapporten of rapporten die vooral uit codes en cijfers bestaan. Importeer of scan het volledige rapport zodat er meer tekst is en probeer het opnieuw."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sztuczna inteligencja na urządzeniu nie jest dostępna dla bieżącego języka lub regionu Twojego urządzenia. Otwórz Ustawienia → Apple Intelligence i Siri i ustaw język iPhone’a na obsługiwany przez Apple Intelligence (na przykład angielski lub niemiecki), a następnie spróbuj ponownie."
+            "value" : "Sztuczna inteligencja na urządzeniu nie rozpoznała języka tego raportu. Może się to zdarzyć w przypadku bardzo krótkich raportów lub takich, które składają się głównie z kodów i liczb. Zaimportuj lub zeskanuj cały raport, aby było więcej tekstu, a następnie spróbuj ponownie."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A IA no dispositivo não está disponível para o idioma ou a região atuais do seu dispositivo. Abra Ajustes → Apple Intelligence e Siri e defina o idioma do seu iPhone como um compatível com a Apple Intelligence (por exemplo, inglês ou alemão); em seguida, tente novamente."
+            "value" : "A IA no dispositivo não conseguiu reconhecer o idioma deste relatório. Isso pode acontecer com relatórios muito curtos ou compostos principalmente por códigos e números. Importe ou digitalize o relatório completo para que haja mais texto e tente novamente."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ИИ на устройстве недоступен для текущего языка или региона вашего устройства. Откройте «Настройки» → «Apple Intelligence и Siri» и установите для iPhone язык, поддерживаемый Apple Intelligence (например, английский или немецкий), затем повторите попытку."
+            "value" : "ИИ на устройстве не смог распознать язык этого отчета. Это может произойти с очень короткими отчетами или с теми, что состоят в основном из кодов и цифр. Импортируйте или отсканируйте отчет целиком, чтобы было больше текста, и повторите попытку."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cihaz üzerindeki yapay zeka, cihazınızın geçerli dili veya bölgesi için kullanılamıyor. Ayarlar → Apple Intelligence ve Siri’yi açın ve iPhone’unuzun dilini Apple Intelligence’ın desteklediği bir dile (örneğin İngilizce veya Almanca) ayarlayın, ardından tekrar deneyin."
+            "value" : "Cihaz üzerindeki yapay zeka bu raporun dilini tanıyamadı. Bu durum çok kısa raporlarda veya çoğunlukla kod ve sayılardan oluşan raporlarda görülebilir. Daha fazla metin olması için raporun tamamını içe aktarın veya tarayın, ardından tekrar deneyin."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Штучний інтелект на пристрої недоступний для поточної мови або регіону вашого пристрою. Відкрийте «Параметри» → «Apple Intelligence та Siri» і встановіть для iPhone мову, яку підтримує Apple Intelligence (наприклад, англійську або німецьку), а потім повторіть спробу."
+            "value" : "Штучний інтелект на пристрої не зміг розпізнати мову цього звіту. Це може статися з дуже короткими звітами або тими, що складаються переважно з кодів і цифр. Імпортуйте або відскануйте повний звіт, щоб було більше тексту, а потім повторіть спробу."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设备端 AI 不支持您设备当前的语言或地区。请打开“设置”→“Apple Intelligence 与 Siri”，将 iPhone 的语言设置为 Apple Intelligence 支持的语言（例如英语或德语），然后重试。"
+            "value" : "设备端 AI 无法识别此报告的语言。这可能发生在非常简短的报告，或主要由代码和数字组成的报告中。请导入或扫描完整的报告以提供更多文本，然后重试。"
           }
         }
       }

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,6 +1,237 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "On-device AI isn't available for your device's current language or region. Open Settings → Apple Intelligence & Siri and set your iPhone language to one Apple Intelligence supports (for example English or German), then try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die geräteinterne KI ist für die aktuelle Sprache oder Region deines Geräts nicht verfügbar. Öffne „Einstellungen“ → „Apple Intelligence & Siri“ und stelle die Sprache deines iPhones auf eine von Apple Intelligence unterstützte Sprache ein (zum Beispiel Englisch oder Deutsch), und versuche es dann erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La IA en el dispositivo no está disponible para el idioma o la región actuales de tu dispositivo. Abre Ajustes → Apple Intelligence y Siri y configura el idioma de tu iPhone en uno compatible con Apple Intelligence (por ejemplo, inglés o alemán); luego, inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’IA sur l’appareil n’est pas disponible pour la langue ou la région actuelles de votre appareil. Ouvrez Réglages → Apple Intelligence et Siri, puis réglez la langue de votre iPhone sur une langue prise en charge par Apple Intelligence (par exemple l’anglais ou l’allemand) avant de réessayer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’IA sul dispositivo non è disponibile per la lingua o la regione attuali del dispositivo. Apri Impostazioni → Apple Intelligence e Siri e imposta la lingua dell’iPhone su una supportata da Apple Intelligence (ad esempio inglese o tedesco), quindi riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス上のAIは、お使いのデバイスの現在の言語または地域では利用できません。「設定」→「Apple Intelligenceとシリ」を開き、iPhoneの言語をApple Intelligenceが対応している言語（例：英語またはドイツ語）に設定してから、もう一度お試しください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De AI op het apparaat is niet beschikbaar voor de huidige taal of regio van je apparaat. Open Instellingen → Apple Intelligence en Siri en stel de taal van je iPhone in op een taal die door Apple Intelligence wordt ondersteund (bijvoorbeeld Engels of Duits) en probeer het opnieuw."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sztuczna inteligencja na urządzeniu nie jest dostępna dla bieżącego języka lub regionu Twojego urządzenia. Otwórz Ustawienia → Apple Intelligence i Siri i ustaw język iPhone’a na obsługiwany przez Apple Intelligence (na przykład angielski lub niemiecki), a następnie spróbuj ponownie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A IA no dispositivo não está disponível para o idioma ou a região atuais do seu dispositivo. Abra Ajustes → Apple Intelligence e Siri e defina o idioma do seu iPhone como um compatível com a Apple Intelligence (por exemplo, inglês ou alemão); em seguida, tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ИИ на устройстве недоступен для текущего языка или региона вашего устройства. Откройте «Настройки» → «Apple Intelligence и Siri» и установите для iPhone язык, поддерживаемый Apple Intelligence (например, английский или немецкий), затем повторите попытку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cihaz üzerindeki yapay zeka, cihazınızın geçerli dili veya bölgesi için kullanılamıyor. Ayarlar → Apple Intelligence ve Siri’yi açın ve iPhone’unuzun dilini Apple Intelligence’ın desteklediği bir dile (örneğin İngilizce veya Almanca) ayarlayın, ardından tekrar deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Штучний інтелект на пристрої недоступний для поточної мови або регіону вашого пристрою. Відкрийте «Параметри» → «Apple Intelligence та Siri» і встановіть для iPhone мову, яку підтримує Apple Intelligence (наприклад, англійську або німецьку), а потім повторіть спробу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端 AI 不支持您设备当前的语言或地区。请打开“设置”→“Apple Intelligence 与 Siri”，将 iPhone 的语言设置为 Apple Intelligence 支持的语言（例如英语或德语），然后重试。"
+          }
+        }
+      }
+    },
+    "The on-device AI couldn't process this document. Make sure it's a lab report and try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die geräteinterne KI konnte dieses Dokument nicht verarbeiten. Stelle sicher, dass es sich um einen Laborbefund handelt, und versuche es erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La IA en el dispositivo no pudo procesar este documento. Asegúrate de que sea un informe de laboratorio e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’IA sur l’appareil n’a pas pu traiter ce document. Assurez-vous qu’il s’agit d’un compte rendu de laboratoire, puis réessayez."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’IA sul dispositivo non è riuscita a elaborare questo documento. Assicurati che sia un referto di laboratorio e riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイス上のAIはこの書類を処理できませんでした。検査報告書であることを確認して、もう一度お試しください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De AI op het apparaat kon dit document niet verwerken. Controleer of het een laboratoriumrapport is en probeer het opnieuw."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sztuczna inteligencja na urządzeniu nie mogła przetworzyć tego dokumentu. Upewnij się, że to wynik badań laboratoryjnych, i spróbuj ponownie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A IA no dispositivo não conseguiu processar este documento. Verifique se é um laudo laboratorial e tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ИИ на устройстве не смог обработать этот документ. Убедитесь, что это лабораторный отчет, и повторите попытку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cihaz üzerindeki yapay zeka bu belgeyi işleyemedi. Bunun bir laboratuvar raporu olduğundan emin olun ve tekrar deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Штучний інтелект на пристрої не зміг обробити цей документ. Переконайтеся, що це лабораторний звіт, і повторіть спробу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端 AI 无法处理此文档。请确认这是一份化验报告，然后重试。"
+          }
+        }
+      }
+    },
+    "This report is too long for the on-device AI to read at once. Try importing fewer pages, or one report at a time." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Befund ist zu lang, als dass ihn die geräteinterne KI auf einmal lesen könnte. Versuche, weniger Seiten oder jeweils einen Befund zu importieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este informe es demasiado largo para que la IA en el dispositivo lo lea de una vez. Intenta importar menos páginas o un informe a la vez."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce rapport est trop long pour que l’IA sur l’appareil puisse le lire en une seule fois. Essayez d’importer moins de pages, ou un rapport à la fois."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo referto è troppo lungo perché l’IA sul dispositivo possa leggerlo in una volta sola. Prova a importare meno pagine o un referto alla volta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このレポートは長すぎるため、デバイス上のAIで一度に読み取ることができません。ページ数を減らすか、レポートを1件ずつ読み込んでみてください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit rapport is te lang om in één keer door de AI op het apparaat te laten lezen. Probeer minder pagina’s of één rapport tegelijk te importeren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten raport jest zbyt długi, aby sztuczna inteligencja na urządzeniu mogła go odczytać za jednym razem. Spróbuj zaimportować mniej stron lub po jednym raporcie naraz."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este relatório é longo demais para a IA no dispositivo ler de uma vez. Tente importar menos páginas ou um relatório por vez."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот отчет слишком длинный, чтобы ИИ на устройстве мог прочитать его за один раз. Попробуйте импортировать меньше страниц или по одному отчету за раз."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu rapor, cihaz üzerindeki yapay zekanın bir kerede okuyamayacağı kadar uzun. Daha az sayfa veya her seferinde bir rapor içe aktarmayı deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цей звіт надто довгий, щоб штучний інтелект на пристрої міг прочитати його за один раз. Спробуйте імпортувати менше сторінок або по одному звіту за раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此报告太长，设备端 AI 无法一次性读取。请尝试导入较少的页面，或一次导入一份报告。"
+          }
+        }
+      }
+    },
     "" : {
 
     },

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -56,7 +56,7 @@ struct ParseResult {
 /// UI is confusing — especially in a non-English app — so we translate the
 /// cases we care about into clear, localized, actionable messages.
 enum LabParserError: LocalizedError {
-    /// Apple Intelligence won't run for the device's current language/region.
+    /// The on-device model couldn't classify the report's language as supported.
     case unsupportedLanguageOrLocale
     /// The document was too large for the model's context window.
     case documentTooLong
@@ -69,9 +69,9 @@ enum LabParserError: LocalizedError {
         switch self {
         case .unsupportedLanguageOrLocale:
             return String(localized: """
-            On-device AI isn't available for your device's current language or region. \
-            Open Settings → Apple Intelligence & Siri and set your iPhone language to one \
-            Apple Intelligence supports (for example English or German), then try again.
+            The on-device AI couldn't recognize the language of this report. This can happen \
+            with very short reports, or ones made up mostly of codes and numbers. Try importing \
+            or scanning the full report so there's more text to read, then try again.
             """)
         case .documentTooLong:
             return String(localized: """
@@ -182,9 +182,25 @@ actor LabParserService {
             """
         )
 
+        // Foundation Models detects the language of the *prompt* and refuses
+        // (`unsupportedLanguageOrLocale`) if it can't classify it as a supported
+        // language. A terse report — mostly codes, numbers and units, e.g.
+        // "KREA: 0.80 mg/dl; GPT: 59 U/l; HB-A1C: 6.5 %" — carries almost no
+        // natural-language signal, so detection can fail even on a device whose
+        // language is fully supported. Wrapping the report in a few sentences of
+        // plain English gives the detector a reliable anchor without changing
+        // what we ask it to extract (names stay in the report's own language).
+        let prompt = """
+        You are reading a laboratory test report. The report text below may be very short \
+        and consist mostly of abbreviated test codes, numbers and units. Read it carefully \
+        and extract every laboratory test value it contains. Here is the report text:
+
+        \(text)
+        """
+
         do {
             let response = try await session.respond(
-                to: "Extract all lab values from this text:\n\n\(text)",
+                to: prompt,
                 generating: AILabReport.self
             )
             return response.content

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -46,6 +46,63 @@ struct ParseResult {
     let authorName: String?
 }
 
+// MARK: - Errors
+
+/// Errors surfaced to the user when the on-device model can't parse a report.
+///
+/// Foundation Models throws `LanguageModelSession.GenerationError`, whose
+/// `localizedDescription` is a terse, English-only system string (e.g. "An
+/// unsupported language or locale was used"). Leaking that verbatim into the
+/// UI is confusing — especially in a non-English app — so we translate the
+/// cases we care about into clear, localized, actionable messages.
+enum LabParserError: LocalizedError {
+    /// Apple Intelligence won't run for the device's current language/region.
+    case unsupportedLanguageOrLocale
+    /// The document was too large for the model's context window.
+    case documentTooLong
+    /// The model's safety guardrails blocked the request.
+    case contentBlocked
+    /// Any other generation failure — carries the system description as-is.
+    case generationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedLanguageOrLocale:
+            return String(localized: """
+            On-device AI isn't available for your device's current language or region. \
+            Open Settings → Apple Intelligence & Siri and set your iPhone language to one \
+            Apple Intelligence supports (for example English or German), then try again.
+            """)
+        case .documentTooLong:
+            return String(localized: """
+            This report is too long for the on-device AI to read at once. \
+            Try importing fewer pages, or one report at a time.
+            """)
+        case .contentBlocked:
+            return String(localized: """
+            The on-device AI couldn't process this document. \
+            Make sure it's a lab report and try again.
+            """)
+        case .generationFailed(let detail):
+            return detail
+        }
+    }
+
+    /// Maps a Foundation Models generation error to a user-facing `LabParserError`.
+    init(_ generationError: LanguageModelSession.GenerationError) {
+        switch generationError {
+        case .unsupportedLanguageOrLocale:
+            self = .unsupportedLanguageOrLocale
+        case .exceededContextWindowSize:
+            self = .documentTooLong
+        case .guardrailViolation:
+            self = .contentBlocked
+        default:
+            self = .generationFailed(generationError.localizedDescription)
+        }
+    }
+}
+
 // MARK: - Parser
 
 actor LabParserService {
@@ -125,12 +182,17 @@ actor LabParserService {
             """
         )
 
-        let response = try await session.respond(
-            to: "Extract all lab values from this text:\n\n\(text)",
-            generating: AILabReport.self
-        )
-
-        return response.content
+        do {
+            let response = try await session.respond(
+                to: "Extract all lab values from this text:\n\n\(text)",
+                generating: AILabReport.self
+            )
+            return response.content
+        } catch let error as LanguageModelSession.GenerationError {
+            // Translate the model's terse, English-only system error into a
+            // clear, localized message before it reaches the UI alert.
+            throw LabParserError(error)
+        }
     }
 
     // MARK: - Date helpers


### PR DESCRIPTION
## Problem

Importing a short, code-heavy screenshot (e.g. `KREA: 0.80 mg/dl; MDRD: 122 ml/min/1,73m2KOF; GPT: 59 U/l; G-GT: 26 U/l; HB-A1C: 6.5 %; HB-A1: 48 mmol/mol`) failed with a raw, English-only system alert — **"Fehler — An unsupported language or locale was used"** — even inside the German UI.

That string is the `localizedDescription` of `LanguageModelSession.GenerationError.unsupportedLanguageOrLocale` from Foundation Models, leaked verbatim into the import error alert.

## Root cause

Per Apple's docs, `unsupportedLanguageOrLocale` is thrown primarily from the **detected language of the prompt**, not just the device locale. A report that's almost entirely abbreviations, numbers and units carries too little natural-language signal, so the on-device language detector can't classify it as a supported language and refuses *before* generating. This is why the **same device** parsed normal (prose-heavy) reports fine but failed on this terse screenshot.

## Fix

1. **Anchor the parse prompt** (`LabParserService`) — the report text is now wrapped in a few sentences of plain English so the language detector has a reliable supported-language anchor even when the report is just codes and numbers. Extraction semantics are unchanged: test names still stay in the report's own language.
2. **Graceful, accurate error handling** — map `LanguageModelSession.GenerationError` to a typed `LabParserError: LocalizedError` (mirroring the existing `OCRError` pattern) instead of leaking the raw system string:
   - `unsupportedLanguageOrLocale` → message describing the real cause (unrecognized report language on very short / code-only reports; suggests importing or scanning the fuller report)
   - `exceededContextWindowSize` → "report too long"
   - `guardrailViolation` → "couldn't process this document"
   - everything else → falls back to the system description
3. **Localization** — new strings added to `Localizable.xcstrings` for all 13 shipped languages.

## Notes / caveat

This couldn't be verified on a physical Apple Intelligence device from the build environment. The English-anchored prompt is the principled fix given how Foundation Models' prompt-language detection works, and it's low-risk. If the exact screenshot still trips detection on device, the follow-up would be to pre-detect with `NLLanguageRecognizer` and handle undetermined input explicitly.

`swiftlint lint --strict` passes.

https://claude.ai/code/session_01DPWcijHGmijTkWZCXqXSKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPWcijHGmijTkWZCXqXSKA)_