### PR TITLE
Enforce one entry per LOINC on import and edit

### DIFF
--- a/LabImporter/Models/LabValue.swift
+++ b/LabImporter/Models/LabValue.swift
@@ -62,4 +62,46 @@ struct LabValue: Identifiable, Equatable, @unchecked Sendable {
             && unit == other.unit
             && isSelected == other.isSelected
     }
+
+    /// Dedup ranking: a value that will actually be saved (selected *and*
+    /// carrying a numeric result) outranks one that won't, so when two rows
+    /// share a LOINC the one holding real, exportable data survives. Ties keep
+    /// the earlier row (see `deduplicatedByLoinc`).
+    fileprivate var dedupRank: Int {
+        if isSelected && numericValue != nil { return 2 }
+        if numericValue != nil { return 1 }
+        return 0
+    }
+}
+
+extension Array where Element == LabValue {
+    /// Collapses entries that share the same LOINC code so a report never holds
+    /// more than one value per LOINC — the app's canonical identity for a test.
+    ///
+    /// Only entries carrying a *valid* LOINC mapping are deduplicated; rows whose
+    /// code is an unmapped mnemonic, `"MANUAL"`, or empty are genuinely distinct
+    /// until the user maps them, so they pass through untouched (collapsing them
+    /// would merge unrelated tests). Codes are compared by their resolved LOINC
+    /// (`LabMapping.loincCode`) so equivalent spellings count as one. Within a
+    /// collapsed group the most useful row wins (selected + numeric beats the
+    /// rest, see `dedupRank`), and each kept row stays in its first-seen slot.
+    func deduplicatedByLoinc() -> [LabValue] {
+        var slotForLoinc: [String: Int] = [:]
+        var result: [LabValue] = []
+        for value in self {
+            guard let loinc = LabMapping.loincCode(for: value.code)?.loinc else {
+                result.append(value)
+                continue
+            }
+            if let slot = slotForLoinc[loinc] {
+                if value.dedupRank > result[slot].dedupRank {
+                    result[slot] = value
+                }
+            } else {
+                slotForLoinc[loinc] = result.count
+                result.append(value)
+            }
+        }
+        return result
+    }
 }

--- a/LabImporter/Services/CDAExportService.swift
+++ b/LabImporter/Services/CDAExportService.swift
@@ -29,7 +29,10 @@ struct CDAExportService {
         // swiftlint:disable:next line_length
         let authorOrgXML = authorTrimmed.isEmpty ? "" : "\n      <representedOrganization>\n        <name>\(esc(authorTrimmed))</name>\n      </representedOrganization>"
 
-        let exportable = labValues.filter {
+        // Final guarantee that a saved/shared report carries one entry per LOINC,
+        // even if review-time edits (a re-mapped code, a manual add) collided two
+        // rows onto the same code after import-time dedup.
+        let exportable = labValues.deduplicatedByLoinc().filter {
             $0.isSelected && $0.numericValue != nil && LabMapping.loincCode(for: $0.code) != nil
         }
 

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -134,7 +134,10 @@ actor LabParserService {
             )
         }
 
-        return ParseResult(values: values, reportDate: reportDate, patientName: patientName, authorName: authorName)
+        // A printed report can list the same test twice (e.g. a value and its
+        // recalculation), and two terse names can resolve to the same LOINC —
+        // keep a single entry per LOINC, the app's canonical identity.
+        return ParseResult(values: values.deduplicatedByLoinc(), reportDate: reportDate, patientName: patientName, authorName: authorName)
     }
 
     // Resolves a parsed entry to a LOINC code entirely from the bundled catalog.

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -88,12 +88,12 @@ struct ReviewView: View {
         replacingReport: LabReport? = nil,
         onSaved: (() -> Void)? = nil
     ) {
-        _labValues = State(initialValue: labValues)
+        _labValues = State(initialValue: labValues.deduplicatedByLoinc())
         _reportDate = State(initialValue: reportDate)
         _extractedPatientName = State(initialValue: extractedPatientName)
         _extractedAuthorName = State(initialValue: extractedAuthorName)
         _replacingReport = State(initialValue: replacingReport)
-        _initialLabValues = State(initialValue: labValues)
+        _initialLabValues = State(initialValue: labValues.deduplicatedByLoinc())
         _initialReportDate = State(initialValue: reportDate)
         self.onSaved = onSaved
     }
@@ -399,11 +399,11 @@ private extension ReviewView {
         return zip(labValues, initialLabValues).contains { !$0.matchesSavedData(of: $1) }
     }
 
-    /// Appends freshly parsed values to the open report rather than replacing it,
-    /// so scan/file/paste add to what the user is already reviewing or editing.
+    /// Merges freshly parsed values into the open report (scan/file/paste add to
+    /// what's being reviewed), keeping one entry per LOINC so a re-scan can't duplicate.
     func configureImportEngine() {
         importEngine.onParsed = { result in
-            labValues.append(contentsOf: result.values)
+            labValues = (labValues + result.values).deduplicatedByLoinc()
         }
     }
 


### PR DESCRIPTION
A printed report can list the same test twice, two terse names can resolve to the same LOINC, and a re-scan or manual edit can collide rows onto a code that already exists. Add `Array<LabValue>.deduplicatedByLoinc()` and apply it at every point a report is formed:

- LabParserService.parseLabValues — the parsed import list.
- ReviewView merge + init — values shown for review/edit (incl. legacy reports loaded via asLabValues, so duplicates collapse on open, not just on save).
- CDAExportService.generateCDA — the hard guarantee at the save/share boundary, so no persisted CDA can carry duplicate LOINCs.

Only entries with a valid LOINC mapping are collapsed; unmapped/manual rows stay distinct. Within a group the selected, numeric value wins and order is preserved.