### PR TITLE
Confirm before deleting reports via swipe in HistoryView

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -13073,6 +13073,82 @@
         }
       }
     },
+    "%lld reports will be permanently removed from Apple Health." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Berichte werden dauerhaft aus der Gesundheits-App entfernt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se eliminarán permanentemente %lld informes de Salud."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld rapports seront définitivement supprimés de Santé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld referti verranno rimossi definitivamente da Salute."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld件のレポートがヘルスケアから完全に削除されます。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld rapporten worden permanent verwijderd uit Gezondheid."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld raportów zostanie trwale usuniętych ze Zdrowia."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld laudos serão removidos permanentemente do Saúde."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld отчётов будет навсегда удалено из Здоровья."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld rapor Sağlık'tan kalıcı olarak kaldırılacak."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld звітів буде назавжди видалено зі Здоров'я."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 份报告将从健康中永久删除。"
+          }
+        }
+      }
+    },
     "This report will be permanently removed from Apple Health." : {
       "localizations" : {
         "de" : {

--- a/LabImporter/Views/HistoryView.swift
+++ b/LabImporter/Views/HistoryView.swift
@@ -5,6 +5,9 @@ struct HistoryView: View {
     @State private var loadError: String?
     @State private var deleteError: String?
     @State private var reportToEdit: LabReport?
+    // Reports the user swiped to delete, awaiting confirmation. Deletion from
+    // Apple Health is irreversible, so we verify intent before removing them.
+    @State private var pendingDeleteIDs: [UUID] = []
 
     var body: some View {
         Group {
@@ -42,6 +45,19 @@ struct HistoryView: View {
         } message: {
             Text(deleteError ?? "")
         }
+        .alert("Delete Report?", isPresented: .constant(!pendingDeleteIDs.isEmpty)) {
+            Button("Delete", role: .destructive) {
+                deleteReports(ids: pendingDeleteIDs)
+                pendingDeleteIDs = []
+            }
+            Button("Cancel", role: .cancel) { pendingDeleteIDs = [] }
+        } message: {
+            if pendingDeleteIDs.count == 1 {
+                Text("This report will be permanently removed from Apple Health.")
+            } else {
+                Text("\(pendingDeleteIDs.count) reports will be permanently removed from Apple Health.")
+            }
+        }
     }
 
     // MARK: - List
@@ -69,7 +85,7 @@ struct HistoryView: View {
                             .tint(.blue)
                         }
                     }
-                    .onDelete { offsets in deleteReports(in: group.reports, at: offsets) }
+                    .onDelete { offsets in pendingDeleteIDs = offsets.map { group.reports[$0].id } }
                 }
             }
         }
@@ -190,8 +206,7 @@ struct HistoryView: View {
         }
     }
 
-    private func deleteReports(in groupReports: [LabReport], at offsets: IndexSet) {
-        let ids = offsets.map { groupReports[$0].id }
+    private func deleteReports(ids: [UUID]) {
         reports.removeAll { ids.contains($0.id) }
         Task {
             var failed = false


### PR DESCRIPTION
## Summary

Swipe-to-delete in the report list (`HistoryView`) removed reports from Apple Health **immediately**, with no confirmation — even though deletion is irreversible. Meanwhile the detail view (`ReportDetailView`) already asked first. This PR closes that gap so the user always verifies before a report is deleted from Apple Health.

## Changes

- **`Views/HistoryView.swift`**
  - Added `pendingDeleteIDs` state to hold the reports a swipe targets, awaiting confirmation.
  - The `.onDelete` swipe now records the targeted IDs instead of deleting right away.
  - Added a `"Delete Report?"` `.alert` (matching the existing pattern in `ReportDetailView`) with a destructive **Delete** and a **Cancel** button. The Health deletion only runs on confirmation; Cancel clears the pending set.
  - The message adapts to singular vs. multi-report deletion (full-swipe / multi-select can target more than one).
- **`Localizable.xcstrings`**
  - Added the new plural string `"%lld reports will be permanently removed from Apple Health."`, translated across all 12 shipped languages. The singular case reuses the existing string.

## Verification

- `swiftlint lint --strict` on the changed file: **0 violations**.
- Localization JSON validated as well-formed.
- No test suite exists and the app requires an Apple Intelligence device + Xcode 26 to run, so the UI wasn't exercised here — but the alert wiring mirrors the already-working confirmation in `ReportDetailView`.

https://claude.ai/code/session_015P6zkGVJVov13Nmg11EtQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_015P6zkGVJVov13Nmg11EtQ9)_