### PR TITLE
Add mock data to SwiftUI previews and fill in missing ones

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		AABB0000000000000000F1AA /* LabImportEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000F2AA /* LabImportEngine.swift */; };
 		AABB0000000000000000F3AA /* AddValueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000F4AA /* AddValueSheet.swift */; };
 		AACC000000000000000001AA /* ReviewView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACC000000000000000002AA /* ReviewView+Preview.swift */; };
+		AACC000000000000000003AA /* PreviewSampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACC000000000000000004AA /* PreviewSampleData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +99,7 @@
 		AABB0000000000000000F2AA /* LabImportEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabImportEngine.swift; sourceTree = "<group>"; };
 		AABB0000000000000000F4AA /* AddValueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddValueSheet.swift; sourceTree = "<group>"; };
 		AACC000000000000000002AA /* ReviewView+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReviewView+Preview.swift"; sourceTree = "<group>"; };
+		AACC000000000000000004AA /* PreviewSampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSampleData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +184,7 @@
 				AABB000000000000000026AA /* HomeView.swift */,
 				AABB000000000000000027AA /* ReviewView.swift */,
 				AACC000000000000000002AA /* ReviewView+Preview.swift */,
+				AACC000000000000000004AA /* PreviewSampleData.swift */,
 				AABB0000000000000000B0AA /* ReviewHeaderCard.swift */,
 				AABB000000000000000028AA /* LabValueRowView.swift */,
 				AABB0000000000000000C1DE /* CodePickerSheet.swift */,
@@ -336,6 +339,7 @@
 				AABB000000000000000046AA /* HomeView.swift in Sources */,
 				AABB000000000000000047AA /* ReviewView.swift in Sources */,
 				AACC000000000000000001AA /* ReviewView+Preview.swift in Sources */,
+				AACC000000000000000003AA /* PreviewSampleData.swift in Sources */,
 				AABB0000000000000000B1AA /* ReviewHeaderCard.swift in Sources */,
 				AABB000000000000000048AA /* LabValueRowView.swift in Sources */,
 				AABB0000000000000000C0DE /* CodePickerSheet.swift in Sources */,

--- a/LabImporter/Views/AddValueSheet.swift
+++ b/LabImporter/Views/AddValueSheet.swift
@@ -81,3 +81,9 @@ struct AddValueSheet: View {
         dismiss()
     }
 }
+
+// MARK: - Preview
+
+#Preview {
+    AddValueSheet { _ in }
+}

--- a/LabImporter/Views/CodePickerSheet.swift
+++ b/LabImporter/Views/CodePickerSheet.swift
@@ -113,3 +113,11 @@ struct CodePickerSheet: View {
         }
     }
 }
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var code = "2160-0"
+    @Previewable @State var name = "Creatinine"
+    CodePickerSheet(code: $code, name: $name)
+}

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -423,3 +423,29 @@ struct CategoryBackground: View {
         colors.isEmpty ? [Color.accentColor.opacity(0.6)] : colors
     }
 }
+
+// MARK: - Preview
+
+#Preview("Dashboard") {
+    NavigationStack {
+        DashboardView(
+            reports: LabReport.sampleHistory,
+            onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
+            scannerAvailable: true,
+            clipboardAvailable: true,
+            isProcessing: false
+        )
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        DashboardView(
+            reports: [],
+            onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
+            scannerAvailable: true,
+            clipboardAvailable: false,
+            isProcessing: false
+        )
+    }
+}

--- a/LabImporter/Views/HistoryView.swift
+++ b/LabImporter/Views/HistoryView.swift
@@ -298,3 +298,17 @@ private struct CategoryDots: View {
         }
     }
 }
+
+// MARK: - Preview
+
+#Preview("History") {
+    NavigationStack {
+        HistoryView()
+    }
+}
+
+#Preview("Report Row") {
+    List {
+        ReportRow(report: .sample)
+    }
+}

--- a/LabImporter/Views/ImportLandingView.swift
+++ b/LabImporter/Views/ImportLandingView.swift
@@ -144,3 +144,16 @@ struct ImportLandingView: View {
         )
     }
 }
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        ImportLandingView(
+            onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
+            scannerAvailable: true,
+            clipboardAvailable: true,
+            isProcessing: false
+        )
+    }
+}

--- a/LabImporter/Views/LoincBrowserView.swift
+++ b/LabImporter/Views/LoincBrowserView.swift
@@ -164,3 +164,23 @@ struct LoincTermDetailView: View {
         }
     }
 }
+
+// MARK: - Previews
+
+#Preview("Term Detail") {
+    NavigationStack {
+        LoincTermDetailView(term: .sample)
+    }
+}
+
+#Preview("Catalog") {
+    NavigationStack {
+        LoincCatalogView()
+    }
+}
+
+#Preview("License") {
+    NavigationStack {
+        LoincLicenseView()
+    }
+}

--- a/LabImporter/Views/PreviewSampleData.swift
+++ b/LabImporter/Views/PreviewSampleData.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// Shared sample data for SwiftUI previews. The codes are real LOINC numbers so
+// the previews read realistically, but the names and units are supplied inline:
+// the bundled `loinc.db` is a build product that isn't present in the preview
+// canvas, so `LabMapping`/`LabCategory` fall back to these values (and a neutral
+// category color). Keeping the fixtures in one place lets every preview tell the
+// same coherent story — one patient, one lab, values that drift over time.
+
+extension LabReport {
+    /// The most recent multi-panel report — used by `ReportDetailView` and as a
+    /// row in `HistoryView`.
+    static var sample: LabReport { sampleHistory[0] }
+
+    /// Four reports spread across roughly a year (newest first) so trend charts
+    /// and dashboard sparklines have a real series to draw.
+    static var sampleHistory: [LabReport] {
+        let day: TimeInterval = 86_400
+        // A fixed anchor (~2026-05) keeps previews deterministic across runs.
+        let anchor = Date(timeIntervalSince1970: 1_780_000_000)
+        return [0, 92, 184, 276].enumerated().map { index, daysAgo in
+            LabReport(
+                id: UUID(),
+                date: anchor.addingTimeInterval(-Double(daysAgo) * day),
+                patientName: "Max Mustermann",
+                authorName: "Laborzentrum München",
+                entries: sampleEntries(step: Double(index))
+            )
+        }
+    }
+
+    /// One panel of entries; `step` nudges a few values so successive reports
+    /// differ and the charts show movement rather than flat lines.
+    private static func sampleEntries(step: Double) -> [Entry] {
+        func entry(_ code: String, _ name: String, _ value: Double, _ unit: String) -> Entry {
+            let shown = value.truncatingRemainder(dividingBy: 1) == 0
+                ? String(format: "%.0f", value)
+                : String(format: "%.2f", value)
+            return Entry(id: UUID(), code: code, name: name,
+                         displayValue: shown, numericValue: value, unit: unit)
+        }
+        let drift = 1 + step * 0.04
+        return [
+            entry("2345-7", "Glucose", 92 * drift, "mg/dL"),
+            entry("4548-4", "HbA1c", 5.4 + step * 0.1, "%"),
+            entry("2093-3", "Cholesterol", 188 * drift, "mg/dL"),
+            entry("2085-9", "HDL Cholesterol", 58, "mg/dL"),
+            entry("13457-7", "LDL Cholesterol", 110 * drift, "mg/dL"),
+            entry("2571-8", "Triglycerides", 130 * drift, "mg/dL"),
+            entry("2160-0", "Creatinine", 0.91, "mg/dL"),
+            entry("2951-2", "Sodium", 140, "mmol/L"),
+            entry("2823-3", "Potassium", 4.3, "mmol/L"),
+            entry("718-7", "Hemoglobin", 14.6, "g/dL"),
+            entry("3016-3", "TSH", 1.8 + step * 0.05, "mIU/L"),
+            entry("1742-6", "ALT", 24, "U/L"),
+            entry("1989-3", "Vitamin D", 32 + step, "ng/mL"),
+        ]
+    }
+}
+
+extension LabValue {
+    /// A short, mixed set for review/edit previews: a few ordinary values, one
+    /// fuzzily-resolved suggestion to confirm, and one value with no LOINC code
+    /// (so the "not supported for export" UI appears).
+    static var sampleValues: [LabValue] {
+        [
+            LabValue(code: "2345-7", name: "Glucose", displayValue: "92",
+                     numericValue: 92, unit: "mg/dL"),
+            LabValue(code: "4548-4", name: "HbA1c", displayValue: "5.4",
+                     numericValue: 5.4, unit: "%"),
+            LabValue(code: "2093-3", name: "Cholesterol", displayValue: "188",
+                     numericValue: 188, unit: "mg/dL"),
+            LabValue(code: "2160-0", name: "Creatinine", displayValue: "0.91",
+                     numericValue: 0.91, unit: "mg/dL", isSuggestedCode: true),
+            LabValue(code: "CRP-X", name: "C-Reactive Protein", displayValue: "3.1",
+                     numericValue: 3.1, unit: "mg/L"),
+        ]
+    }
+}
+
+extension LoincTerm {
+    /// A representative term for `LoincTermDetailView` / description-card previews.
+    static var sample: LoincTerm {
+        LoincTerm(
+            code: "4548-4",
+            name: "Hemoglobin A1c",
+            englishName: "Hemoglobin A1c/Hemoglobin.total in Blood",
+            description: "Glycated hemoglobin — reflects average blood glucose over the past ~3 months.",
+            ucum: "%",
+            rank: 12
+        )
+    }
+}
+
+extension CodeName {
+    /// Code/name pairs drawn from the sample report, for the sort/visibility and
+    /// settings previews.
+    static var sampleCodes: [CodeName] {
+        LabReport.sample.entries.map { CodeName(code: $0.code, name: $0.name) }
+    }
+}
+
+extension CategoryCount {
+    /// A spread of clinical categories for the review header card preview.
+    static var sampleGroups: [CategoryCount] {
+        [
+            CategoryCount(category: .glycemic, count: 2),
+            CategoryCount(category: .lipids, count: 4),
+            CategoryCount(category: .renal, count: 1),
+            CategoryCount(category: .electrolytes, count: 2),
+            CategoryCount(category: .hematology, count: 1),
+        ]
+    }
+}

--- a/LabImporter/Views/ReportDetailView.swift
+++ b/LabImporter/Views/ReportDetailView.swift
@@ -320,3 +320,11 @@ private struct ShareSheet: UIViewControllerRepresentable {
         }
     }
 }
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        ReportDetailView(report: .sample, onDeleted: { _ in })
+    }
+}

--- a/LabImporter/Views/ReviewHeaderCard.swift
+++ b/LabImporter/Views/ReviewHeaderCard.swift
@@ -282,3 +282,50 @@ struct CategorySectionHeader: View {
         .textCase(nil)
     }
 }
+
+// MARK: - Previews
+
+#Preview("Header Card") {
+    ReviewHeaderCard(
+        supportedCount: 10,
+        exportableCount: 8,
+        groups: CategoryCount.sampleGroups,
+        dominantColor: LabCategory.lipids.color
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}
+
+#Preview("Action Bar") {
+    VStack {
+        Spacer()
+        ReviewActionBar(isEnabled: true, onSave: {}, onShare: {})
+    }
+}
+
+#Preview("Unsupported Values") {
+    List {
+        UnsupportedValuesSection(
+            values: [
+                LabValue(code: "CRP-X", name: "C-Reactive Protein",
+                         displayValue: "3.1", numericValue: 3.1, unit: "mg/L"),
+                LabValue(code: "FOO", name: "Unknown Marker",
+                         displayValue: "1.2", numericValue: 1.2, unit: ""),
+            ],
+            onDelete: { _ in }
+        )
+    }
+}
+
+#Preview("Category Chips") {
+    VStack(alignment: .leading, spacing: 12) {
+        CategorySectionHeader(category: .lipids, count: 4)
+        HStack {
+            ForEach(CategoryCount.sampleGroups) { group in
+                CategoryChip(category: group.category, count: group.count)
+            }
+        }
+        SuggestionRow(label: "Detected in report: \"Max Mustermann\"") {}
+    }
+    .padding()
+}

--- a/LabImporter/Views/ReviewView+Preview.swift
+++ b/LabImporter/Views/ReviewView+Preview.swift
@@ -1,15 +1,20 @@
 import SwiftUI
 
-#Preview {
+#Preview("New Report") {
     NavigationStack {
         ReviewView(
-            labValues: [
-                LabValue(code: "2345-7", name: "Blood Glucose", displayValue: "95", numericValue: 95, unit: "mg/dl"),
-                LabValue(code: "2160-0", name: "Creatinine", displayValue: "0.91", numericValue: 0.91, unit: "mg/dl"),
-                LabValue(code: "4548-4", name: "HbA1c (%)", displayValue: "6.5", numericValue: 6.5, unit: "%"),
-                LabValue(code: "2093-3", name: "Total Cholesterol", displayValue: "162", numericValue: 162, unit: "mg/dl"),
-            ],
+            labValues: LabValue.sampleValues,
             extractedPatientName: "Max Mustermann"
+        )
+    }
+}
+
+#Preview("Editing Saved Report") {
+    NavigationStack {
+        ReviewView(
+            labValues: LabReport.sample.asLabValues,
+            reportDate: LabReport.sample.date,
+            replacingReport: .sample
         )
     }
 }

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -407,3 +407,17 @@ struct LicenseView: View {
     SOFTWARE.
     """
 }
+
+// MARK: - Previews
+
+#Preview("Settings") {
+    @Previewable @State var prefs = LabDisplayPreferences()
+    SettingsView(prefs: $prefs, allCodes: CodeName.sampleCodes)
+}
+
+#Preview("Sort & Visibility") {
+    @Previewable @State var prefs = LabDisplayPreferences()
+    NavigationStack {
+        LabSortEditor(prefs: $prefs, allCodes: CodeName.sampleCodes)
+    }
+}

--- a/LabImporter/Views/TrendsView.swift
+++ b/LabImporter/Views/TrendsView.swift
@@ -401,3 +401,17 @@ private struct ValueDescriptionCard: View {
         return term.englishName == term.name ? nil : term.englishName
     }
 }
+
+// MARK: - Preview
+
+#Preview("Trends") {
+    NavigationStack {
+        TrendsView(reports: LabReport.sampleHistory, initialCode: "4548-4")
+    }
+}
+
+#Preview("No Data") {
+    NavigationStack {
+        TrendsView(reports: [])
+    }
+}


### PR DESCRIPTION
## What

Adds mock data to the SwiftUI previews and creates previews for every view that was missing one, so the Xcode preview canvas shows realistic content across the app.

## Shared fixtures — `LabImporter/Views/PreviewSampleData.swift` (new)

A single, discoverable source of deterministic preview data (registered in the Xcode project):

- `LabReport.sampleHistory` — four dated reports (newest first) for one patient/lab, with values that drift over time so trend charts and dashboard sparklines render a real series.
- `LabReport.sample`, `LabValue.sampleValues` (includes a fuzzily-resolved "suggested" code and an unsupported/no-LOINC value so that UI shows), `LoincTerm.sample`, `CodeName.sampleCodes`, `CategoryCount.sampleGroups`.
- Codes are real LOINC numbers so previews read realistically; names/units are supplied inline because `loinc.db` is a build product absent from the preview canvas (so `LabMapping`/`LabCategory` fall back gracefully to a neutral category color).

## Previews added (were missing)

`DashboardView` (+ empty state), `HistoryView` (+ `ReportRow`), `ReportDetailView`, `TrendsView` (+ no-data), `ReviewHeaderCard` and its sibling components (action bar, unsupported-values section, chips/suggestion row), `AddValueSheet`, `CodePickerSheet`, `ImportLandingView`, `SettingsView` (+ `LabSortEditor`), `LoincBrowserView` (term detail / catalog / license).

## Previews enriched

`ReviewView+Preview.swift` now uses the shared fixtures and gains an "editing saved report" variant.

## Left as-is

`HomeView` and the onboarding screens already had previews and own/self-load their data; `DocumentScannerView` is a `UIViewControllerRepresentable` (camera), not previewable.

## Verification

- `swiftlint lint --strict` passes clean (exit 0).
- pbxproj edits mirror the existing preview-file registration pattern, with balanced references.
- Note: this was developed on Linux, so previews are verified for lint/syntax but not compiled against the iOS 26 SDK — worth a quick open in Xcode to confirm they render.

https://claude.ai/code/session_01UhDME6Sz1MxK9wznDhWHYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhDME6Sz1MxK9wznDhWHYh)_