### PR TITLE
Localize the Apple Health app name per device language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,18 @@ Config.xcconfig  # BUNDLE_IDENTIFIER = dev.idoodler.$(DEVELOPMENT_TEAM).labimpor
 ### UI patterns
 - All user-facing text uses `String(localized:)` / SwiftUI auto-localization and
   lives in `Localizable.xcstrings`. Add new strings there; the app ships German + English.
+- **Naming the Health app:** never leave "Apple Health" untranslated. Every
+  reference to the Health app must use the **on-device localized app name** for
+  that language, keeping the **`Apple` brand prefix**. Canonical forms:
+  `de Apple Health` · `fr Apple Santé` · `es Apple Salud` · `it Apple Salute` ·
+  `pt-BR Apple Saúde` · `nl Apple Gezondheid` · `pl Apple Zdrowie` ·
+  `ja Appleヘルスケア` · `zh-Hans Apple 健康` · `ru Apple Здоровье` ·
+  `tr Apple Sağlık` · `uk Apple Здоров'я`. Inflect the localized noun for the
+  surrounding grammar (pl/ru/uk case declensions, fr `d'Apple` elision, uk в/у
+  euphony) — the `Apple` prefix stays invariant. Where the **English source**
+  itself uses a bare "Health" (e.g. the `Save Reports to Health` toggle), mirror
+  that and use the bare localized name without the prefix. `Health Records`
+  (`Gesundheitsakte`, …) is a *different* Apple feature — leave it alone.
 - OCR recognizes German + English (`["de-DE", "en-US"]`); narrative CDA labels are German.
 - Preferences (`labDisplayPrefs`, `patientName`, `hasSeenWelcome`, etc.) are read
   via `@AppStorage`. `LabDisplayPreferences` is `RawRepresentable` over JSON — note

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -910,13 +910,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Health-toegang toestaan"
+            "value" : "Apple Gezondheid-toegang toestaan"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zezwól na dostęp do Apple Health"
+            "value" : "Zezwól na dostęp do Apple Zdrowia"
           }
         },
         "pt-BR" : {
@@ -1295,13 +1295,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Health-toegang vereist"
+            "value" : "Apple Gezondheid-toegang vereist"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wymagany dostęp do Apple Health"
+            "value" : "Wymagany dostęp do Apple Zdrowia"
           }
         },
         "pt-BR" : {
@@ -2894,13 +2894,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbinden met Apple Health"
+            "value" : "Verbinden met Apple Gezondheid"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Połącz z Apple Health"
+            "value" : "Połącz z Apple Zdrowiem"
           }
         },
         "pt-BR" : {
@@ -5833,73 +5833,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importiere einen Laborbericht und speichere ihn in der Gesundheits-App, um ihn hier zu sehen."
+            "value" : "Importiere einen Laborbericht und speichere ihn in Apple Health, um ihn hier zu sehen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importa un informe de laboratorio y guárdalo en Salud para verlo aquí."
+            "value" : "Importa un informe de laboratorio y guárdalo en Apple Salud para verlo aquí."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importez un rapport de laboratoire et enregistrez-le dans Santé pour le voir ici."
+            "value" : "Importez un rapport de laboratoire et enregistrez-le dans Apple Santé pour le voir ici."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importa un referto e salvalo in Salute per vederlo qui."
+            "value" : "Importa un referto e salvalo in Apple Salute per vederlo qui."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "検査レポートをインポートしてヘルスケアに保存すると、ここに表示されます。"
+            "value" : "検査レポートをインポートしてAppleヘルスケアに保存すると、ここに表示されます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importeer een labrapport en sla het op in Gezondheid om het hier te zien."
+            "value" : "Importeer een labrapport en sla het op in Apple Gezondheid om het hier te zien."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaimportuj raport z badań i zapisz go w Zdrowiu, aby zobaczyć go tutaj."
+            "value" : "Zaimportuj raport z badań i zapisz go w Apple Zdrowiu, aby zobaczyć go tutaj."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Importe um laudo e salve-o no Saúde para vê-lo aqui."
+            "value" : "Importe um laudo e salve-o no Apple Saúde para vê-lo aqui."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Импортируйте лабораторный отчёт и сохраните его в Здоровье, чтобы он появился здесь."
+            "value" : "Импортируйте лабораторный отчёт и сохраните его в Apple Здоровье, чтобы он появился здесь."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bir laboratuvar raporu içe aktarın ve burada görmek için Sağlık'a kaydedin."
+            "value" : "Bir laboratuvar raporu içe aktarın ve burada görmek için Apple Sağlık'a kaydedin."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Імпортуйте лабораторний звіт і збережіть його у Здоров'ї, щоб побачити тут."
+            "value" : "Імпортуйте лабораторний звіт і збережіть його в Apple Здоров'ї, щоб побачити тут."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "导入检验报告并保存到健康，即可在此查看。"
+            "value" : "导入检验报告并保存到 Apple 健康，即可在此查看。"
           }
         }
       }
@@ -6246,13 +6246,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geïmporteerde labwaarden worden als klinische CDA-records in Apple Health opgeslagen."
+            "value" : "Geïmporteerde labwaarden worden als klinische CDA-records in Apple Gezondheid opgeslagen."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaimportowane wyniki są zapisywane jako kliniczne dokumenty CDA w Apple Health."
+            "value" : "Zaimportowane wyniki są zapisywane jako kliniczne dokumenty CDA w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
@@ -7237,13 +7237,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LabImporter heeft volledige Apple Health-toegang nodig. Open Instellingen, tik op Apple Health en zet elke categorie voor LabImporter aan."
+            "value" : "LabImporter heeft volledige Apple Gezondheid-toegang nodig. Open Instellingen, tik op Apple Gezondheid en zet elke categorie voor LabImporter aan."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LabImporter potrzebuje pełnego dostępu do Apple Health. Otwórz Ustawienia, wybierz Apple Health i włącz każdą kategorię dla LabImporter."
+            "value" : "LabImporter potrzebuje pełnego dostępu do Apple Zdrowia. Otwórz Ustawienia, wybierz Apple Zdrowie i włącz każdą kategorię dla LabImporter."
           }
         },
         "pt-BR" : {
@@ -7313,13 +7313,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LabImporter bewaart alles in Apple Health — daarvoor heeft het eerst je toestemming nodig."
+            "value" : "LabImporter bewaart alles in Apple Gezondheid — daarvoor heeft het eerst je toestemming nodig."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LabImporter zapisuje wszystko w Apple Health — dlatego najpierw potrzebuje Twojej zgody."
+            "value" : "LabImporter zapisuje wszystko w Apple Zdrowiu — dlatego najpierw potrzebuje Twojej zgody."
           }
         },
         "pt-BR" : {
@@ -9833,13 +9833,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eerdere rapporten worden uit Apple Health geladen zodat je ze kunt bekijken en delen."
+            "value" : "Eerdere rapporten worden uit Apple Gezondheid geladen zodat je ze kunt bekijken en delen."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wcześniejsze raporty są wczytywane z Apple Health, abyś mógł je przeglądać i udostępniać."
+            "value" : "Wcześniejsze raporty są wczytywane z Apple Zdrowia, abyś mógł je przeglądać i udostępniać."
           }
         },
         "pt-BR" : {
@@ -10108,73 +10108,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fotografiere deinen Laborbericht und\nspeichere ihn direkt in der Gesundheits-App."
+            "value" : "Fotografiere deinen Laborbericht und\nspeichere ihn direkt in Apple Health."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fotografía tu informe de laboratorio y\nguárdalo directamente en Salud."
+            "value" : "Fotografía tu informe de laboratorio y\nguárdalo directamente en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Photographiez votre rapport de labo et\nenregistrez-le directement dans Santé."
+            "value" : "Photographiez votre rapport de labo et\nenregistrez-le directement dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fotografa il tuo referto e\nsalvalo direttamente in Salute."
+            "value" : "Fotografa il tuo referto e\nsalvalo direttamente in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "検査レポートを撮影して\nヘルスケアに直接保存。"
+            "value" : "検査レポートを撮影して\nAppleヘルスケアに直接保存。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fotografeer uw labrapport en\nsla het rechtstreeks op in Gezondheid."
+            "value" : "Fotografeer uw labrapport en\nsla het rechtstreeks op in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sfotografuj raport z badań i\nzapisz go bezpośrednio w Zdrowiu."
+            "value" : "Sfotografuj raport z badań i\nzapisz go bezpośrednio w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fotografe seu laudo e\nsalve-o diretamente no Saúde."
+            "value" : "Fotografe seu laudo e\nsalve-o diretamente no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сфотографируйте лабораторный отчёт и\nсохраните его прямо в Здоровье."
+            "value" : "Сфотографируйте лабораторный отчёт и\nсохраните его прямо в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Laboratuvar raporunuzu fotoğraflayın ve\ndoğrudan Sağlık'a kaydedin."
+            "value" : "Laboratuvar raporunuzu fotoğraflayın ve\ndoğrudan Apple Sağlık'a kaydedin."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сфотографуйте лабораторний звіт і\nзбережіть його прямо у Здоров'ї."
+            "value" : "Сфотографуйте лабораторний звіт і\nзбережіть його прямо в Apple Здоров'ї."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "拍摄检验报告，\n直接保存到健康。"
+            "value" : "拍摄检验报告，\n直接保存到 Apple 健康。"
           }
         }
       }
@@ -11022,73 +11022,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Berichte werden als klinische CDA-Datensätze direkt in der Gesundheits-App gespeichert."
+            "value" : "Berichte werden als klinische CDA-Datensätze direkt in Apple Health gespeichert."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los informes se almacenan como registros CDA clínicos directamente en Salud."
+            "value" : "Los informes se almacenan como registros CDA clínicos directamente en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les rapports sont stockés en tant qu'enregistrements CDA cliniques directement dans Santé."
+            "value" : "Les rapports sont stockés en tant qu'enregistrements CDA cliniques directement dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "I referti sono archiviati come record CDA clinici direttamente in Salute."
+            "value" : "I referti sono archiviati come record CDA clinici direttamente in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レポートは臨床CDA記録としてヘルスケアに直接保存されます。"
+            "value" : "レポートは臨床CDA記録としてAppleヘルスケアに直接保存されます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rapporten worden opgeslagen als klinische CDA-records rechtstreeks in Gezondheid."
+            "value" : "Rapporten worden opgeslagen als klinische CDA-records rechtstreeks in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Raporty są przechowywane jako kliniczne dokumenty CDA bezpośrednio w Zdrowiu."
+            "value" : "Raporty są przechowywane jako kliniczne dokumenty CDA bezpośrednio w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Os laudos são armazenados como registros CDA clínicos diretamente no Saúde."
+            "value" : "Os laudos são armazenados como registros CDA clínicos diretamente no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отчёты хранятся как клинические документы CDA непосредственно в Здоровье."
+            "value" : "Отчёты хранятся как клинические документы CDA непосредственно в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Raporlar, klinik CDA kayıtları olarak doğrudan Sağlık'ta depolanır."
+            "value" : "Raporlar, klinik CDA kayıtları olarak doğrudan Apple Sağlık'ta depolanır."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Звіти зберігаються як клінічні документи CDA безпосередньо у Здоров'ї."
+            "value" : "Звіти зберігаються як клінічні документи CDA безпосередньо в Apple Здоров'ї."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "报告作为临床 CDA 记录直接存储在健康中。"
+            "value" : "报告作为临床 CDA 记录直接存储在 Apple 健康中。"
           }
         }
       }
@@ -11357,13 +11357,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rapporten in Health opslaan"
+            "value" : "Rapporten in Gezondheid opslaan"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapisuj raporty w Health"
+            "value" : "Zapisuj raporty w Zdrowiu"
           }
         },
         "pt-BR" : {
@@ -11485,67 +11485,67 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Guardado en Salud"
+            "value" : "Guardado en Apple Salud"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enregistré dans Santé"
+            "value" : "Enregistré dans Apple Santé"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvato in Salute"
+            "value" : "Salvato in Apple Salute"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ヘルスケアに保存済み"
+            "value" : "Appleヘルスケアに保存済み"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opgeslagen in Gezondheid"
+            "value" : "Opgeslagen in Apple Gezondheid"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zapisano w Zdrowiu"
+            "value" : "Zapisano w Apple Zdrowiu"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvo no Saúde"
+            "value" : "Salvo no Apple Saúde"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сохранено в Здоровье"
+            "value" : "Сохранено в Apple Здоровье"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sağlık'a Kaydedildi"
+            "value" : "Apple Sağlık'a Kaydedildi"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Збережено у Здоров'ї"
+            "value" : "Збережено в Apple Здоров'ї"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已保存到健康"
+            "value" : "已保存到 Apple 健康"
           }
         }
       }
@@ -11808,7 +11808,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "検査レポートをスキャンまたは取り込んで\nそのままApple Healthに保存。"
+            "value" : "検査レポートをスキャンまたは取り込んで\nそのままAppleヘルスケアに保存。"
           }
         },
         "nl" : {
@@ -11820,7 +11820,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeskanuj lub zaimportuj raport laboratoryjny i\nzapisz go bezpośrednio w Apple Health."
+            "value" : "Zeskanuj lub zaimportuj raport laboratoryjny i\nzapisz go bezpośrednio w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
@@ -11832,7 +11832,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сканируйте или импортируйте лабораторный отчёт и\nсохраните его прямо в Apple Health."
+            "value" : "Сканируйте или импортируйте лабораторный отчёт и\nсохраните его прямо в Apple Здоровье."
           }
         },
         "tr" : {
@@ -11844,7 +11844,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Скануйте або імпортуйте лабораторний звіт і\nзбережіть його одразу в Apple Health."
+            "value" : "Скануйте або імпортуйте лабораторний звіт і\nзбережіть його одразу в Apple Здоров’ї."
           }
         },
         "zh-Hans" : {
@@ -12240,73 +12240,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Einige Berichte konnten nicht aus der Gesundheits-App entfernt werden."
+            "value" : "Einige Berichte konnten nicht aus Apple Health entfernt werden."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudieron eliminar algunos informes de Salud."
+            "value" : "No se pudieron eliminar algunos informes de Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Certains rapports n'ont pas pu être supprimés de Santé."
+            "value" : "Certains rapports n'ont pas pu être supprimés d’Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Non è stato possibile rimuovere alcuni referti da Salute."
+            "value" : "Non è stato possibile rimuovere alcuni referti da Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一部のレポートをヘルスケアから削除できませんでした。"
+            "value" : "一部のレポートをAppleヘルスケアから削除できませんでした。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sommige rapporten konden niet uit Gezondheid worden verwijderd."
+            "value" : "Sommige rapporten konden niet uit Apple Gezondheid worden verwijderd."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nie udało się usunąć niektórych raportów ze Zdrowia."
+            "value" : "Nie udało się usunąć niektórych raportów z Apple Zdrowia."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Não foi possível remover alguns laudos do Saúde."
+            "value" : "Não foi possível remover alguns laudos do Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Некоторые отчёты не удалось удалить из Здоровья."
+            "value" : "Некоторые отчёты не удалось удалить из Apple Здоровья."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bazı raporlar Sağlık'tan kaldırılamadı."
+            "value" : "Bazı raporlar Apple Sağlık'tan kaldırılamadı."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Деякі звіти не вдалося видалити зі Здоров'я."
+            "value" : "Деякі звіти не вдалося видалити з Apple Здоров'я."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "部分报告无法从健康中删除。"
+            "value" : "部分报告无法从 Apple 健康中删除。"
           }
         }
       }
@@ -12698,73 +12698,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der Laborbericht wurde als CDA-Dokument in der Gesundheits-App gespeichert."
+            "value" : "Der Laborbericht wurde als CDA-Dokument in Apple Health gespeichert."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El informe de laboratorio se ha guardado como documento CDA en Salud."
+            "value" : "El informe de laboratorio se ha guardado como documento CDA en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le rapport de laboratoire a été enregistré en tant que document CDA dans Santé."
+            "value" : "Le rapport de laboratoire a été enregistré en tant que document CDA dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il referto è stato salvato come documento CDA in Salute."
+            "value" : "Il referto è stato salvato come documento CDA in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "検査レポートがCDAドキュメントとしてヘルスケアに保存されました。"
+            "value" : "検査レポートがCDAドキュメントとしてAppleヘルスケアに保存されました。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Het labrapport is opgeslagen als CDA-document in Gezondheid."
+            "value" : "Het labrapport is opgeslagen als CDA-document in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Raport z badań został zapisany jako dokument CDA w Zdrowiu."
+            "value" : "Raport z badań został zapisany jako dokument CDA w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "O laudo foi salvo como documento CDA no Saúde."
+            "value" : "O laudo foi salvo como documento CDA no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Лабораторный отчёт сохранён как документ CDA в Здоровье."
+            "value" : "Лабораторный отчёт сохранён как документ CDA в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Laboratuvar raporu Sağlık'ta CDA belgesi olarak kaydedildi."
+            "value" : "Laboratuvar raporu Apple Sağlık'ta CDA belgesi olarak kaydedildi."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Лабораторний звіт збережено як документ CDA у Здоров'ї."
+            "value" : "Лабораторний звіт збережено як документ CDA в Apple Здоров'ї."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检验报告已作为 CDA 文档保存到健康。"
+            "value" : "检验报告已作为 CDA 文档保存到 Apple 健康。"
           }
         }
       }
@@ -12850,73 +12850,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der aktualisierte Bericht wurde gespeichert, aber die vorherige Version konnte nicht aus der Gesundheits-App entfernt werden. Du kannst sie in der Berichtsliste löschen."
+            "value" : "Der aktualisierte Bericht wurde gespeichert, aber die vorherige Version konnte nicht aus Apple Health entfernt werden. Du kannst sie in der Berichtsliste löschen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El informe actualizado se guardó, pero no se pudo eliminar la versión anterior de Salud. Puedes eliminarla desde la lista de informes."
+            "value" : "El informe actualizado se guardó, pero no se pudo eliminar la versión anterior de Apple Salud. Puedes eliminarla desde la lista de informes."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le rapport mis à jour a été enregistré, mais la version précédente n'a pas pu être supprimée de Santé. Vous pouvez la supprimer depuis la liste des rapports."
+            "value" : "Le rapport mis à jour a été enregistré, mais la version précédente n'a pas pu être supprimée d’Apple Santé. Vous pouvez la supprimer depuis la liste des rapports."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il referto aggiornato è stato salvato, ma non è stato possibile rimuovere la versione precedente da Salute. Puoi eliminarla dall'elenco dei referti."
+            "value" : "Il referto aggiornato è stato salvato, ma non è stato possibile rimuovere la versione precedente da Apple Salute. Puoi eliminarla dall'elenco dei referti."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更新したレポートは保存されましたが、以前のバージョンをヘルスケアから削除できませんでした。レポート一覧から削除できます。"
+            "value" : "更新したレポートは保存されましたが、以前のバージョンをAppleヘルスケアから削除できませんでした。レポート一覧から削除できます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Het bijgewerkte rapport is bewaard, maar de vorige versie kon niet uit Gezondheid worden verwijderd. Je kunt deze verwijderen via de rapportenlijst."
+            "value" : "Het bijgewerkte rapport is bewaard, maar de vorige versie kon niet uit Apple Gezondheid worden verwijderd. Je kunt deze verwijderen via de rapportenlijst."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaktualizowany raport został zapisany, ale nie udało się usunąć poprzedniej wersji ze Zdrowia. Możesz ją usunąć z listy raportów."
+            "value" : "Zaktualizowany raport został zapisany, ale nie udało się usunąć poprzedniej wersji z Apple Zdrowia. Możesz ją usunąć z listy raportów."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "O laudo atualizado foi salvo, mas não foi possível remover a versão anterior do Saúde. Você pode excluí-la na lista de laudos."
+            "value" : "O laudo atualizado foi salvo, mas não foi possível remover a versão anterior do Apple Saúde. Você pode excluí-la na lista de laudos."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Обновлённый отчёт сохранён, но предыдущую версию не удалось удалить из Здоровья. Вы можете удалить её из списка отчётов."
+            "value" : "Обновлённый отчёт сохранён, но предыдущую версию не удалось удалить из Apple Здоровья. Вы можете удалить её из списка отчётов."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Güncellenen rapor kaydedildi, ancak önceki sürüm Sağlık'tan kaldırılamadı. Bunu Raporlar listesinden silebilirsiniz."
+            "value" : "Güncellenen rapor kaydedildi, ancak önceki sürüm Apple Sağlık'tan kaldırılamadı. Bunu Raporlar listesinden silebilirsiniz."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Оновлений звіт збережено, але попередню версію не вдалося видалити зі Здоров'я. Ви можете видалити її зі списку звітів."
+            "value" : "Оновлений звіт збережено, але попередню версію не вдалося видалити з Apple Здоров'я. Ви можете видалити її зі списку звітів."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已保存更新后的报告，但无法从健康中删除旧版本。你可以在报告列表中删除它。"
+            "value" : "已保存更新后的报告，但无法从 Apple 健康中删除旧版本。你可以在报告列表中删除它。"
           }
         }
       }
@@ -12926,73 +12926,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Werte haben keinen LOINC-Code und werden nicht in der Gesundheits-App gespeichert."
+            "value" : "Diese Werte haben keinen LOINC-Code und werden nicht in Apple Health gespeichert."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estos valores no tienen código LOINC y no se guardarán en Salud."
+            "value" : "Estos valores no tienen código LOINC y no se guardarán en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ces valeurs n'ont pas de code LOINC et ne seront pas enregistrées dans Santé."
+            "value" : "Ces valeurs n'ont pas de code LOINC et ne seront pas enregistrées dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Questi valori non hanno un codice LOINC e non verranno salvati in Salute."
+            "value" : "Questi valori non hanno un codice LOINC e non verranno salvati in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "これらの値にはLOINCコードがないため、ヘルスケアには保存されません。"
+            "value" : "これらの値にはLOINCコードがないため、Appleヘルスケアには保存されません。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deze waarden hebben geen LOINC-code en worden niet opgeslagen in Gezondheid."
+            "value" : "Deze waarden hebben geen LOINC-code en worden niet opgeslagen in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Te wartości nie mają kodu LOINC i nie zostaną zapisane w Zdrowiu."
+            "value" : "Te wartości nie mają kodu LOINC i nie zostaną zapisane w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Esses valores não têm código LOINC e não serão salvos no Saúde."
+            "value" : "Esses valores não têm código LOINC e não serão salvos no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Эти значения не имеют кода LOINC и не будут сохранены в Здоровье."
+            "value" : "Эти значения не имеют кода LOINC и не будут сохранены в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu değerlerin LOINC kodu yok ve Sağlık'a kaydedilmeyecek."
+            "value" : "Bu değerlerin LOINC kodu yok ve Apple Sağlık'a kaydedilmeyecek."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ці значення не мають коду LOINC і не будуть збережені у Здоров'ї."
+            "value" : "Ці значення не мають коду LOINC і не будуть збережені в Apple Здоров'ї."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这些数值没有 LOINC 代码，不会保存到健康。"
+            "value" : "这些数值没有 LOINC 代码，不会保存到 Apple 健康。"
           }
         }
       }
@@ -13078,73 +13078,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld Berichte werden dauerhaft aus der Gesundheits-App entfernt."
+            "value" : "%lld Berichte werden dauerhaft aus Apple Health entfernt."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se eliminarán permanentemente %lld informes de Salud."
+            "value" : "Se eliminarán permanentemente %lld informes de Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld rapports seront définitivement supprimés de Santé."
+            "value" : "%lld rapports seront définitivement supprimés d’Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld referti verranno rimossi definitivamente da Salute."
+            "value" : "%lld referti verranno rimossi definitivamente da Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld件のレポートがヘルスケアから完全に削除されます。"
+            "value" : "%lld件のレポートがAppleヘルスケアから完全に削除されます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld rapporten worden permanent verwijderd uit Gezondheid."
+            "value" : "%lld rapporten worden permanent verwijderd uit Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld raportów zostanie trwale usuniętych ze Zdrowia."
+            "value" : "%lld raportów zostanie trwale usuniętych z Apple Zdrowia."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld laudos serão removidos permanentemente do Saúde."
+            "value" : "%lld laudos serão removidos permanentemente do Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld отчётов будет навсегда удалено из Здоровья."
+            "value" : "%lld отчётов будет навсегда удалено из Apple Здоровья."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld rapor Sağlık'tan kalıcı olarak kaldırılacak."
+            "value" : "%lld rapor Apple Sağlık'tan kalıcı olarak kaldırılacak."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld звітів буде назавжди видалено зі Здоров'я."
+            "value" : "%lld звітів буде назавжди видалено з Apple Здоров'я."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 份报告将从健康中永久删除。"
+            "value" : "%lld 份报告将从 Apple 健康中永久删除。"
           }
         }
       }
@@ -13154,73 +13154,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieser Bericht wird dauerhaft aus der Gesundheits-App entfernt."
+            "value" : "Dieser Bericht wird dauerhaft aus Apple Health entfernt."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este informe se eliminará permanentemente de Salud."
+            "value" : "Este informe se eliminará permanentemente de Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce rapport sera définitivement supprimé de Santé."
+            "value" : "Ce rapport sera définitivement supprimé d’Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Questo referto verrà rimosso definitivamente da Salute."
+            "value" : "Questo referto verrà rimosso definitivamente da Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このレポートはヘルスケアから完全に削除されます。"
+            "value" : "このレポートはAppleヘルスケアから完全に削除されます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dit rapport wordt permanent verwijderd uit Gezondheid."
+            "value" : "Dit rapport wordt permanent verwijderd uit Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ten raport zostanie trwale usunięty ze Zdrowia."
+            "value" : "Ten raport zostanie trwale usunięty z Apple Zdrowia."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este laudo será removido permanentemente do Saúde."
+            "value" : "Este laudo será removido permanentemente do Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Этот отчёт будет навсегда удалён из Здоровья."
+            "value" : "Этот отчёт будет навсегда удалён из Apple Здоровья."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu rapor Sağlık'tan kalıcı olarak kaldırılacak."
+            "value" : "Bu rapor Apple Sağlık'tan kalıcı olarak kaldırılacak."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Цей звіт буде назавжди видалено зі Здоров'я."
+            "value" : "Цей звіт буде назавжди видалено з Apple Здоров'я."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此报告将从健康中永久删除。"
+            "value" : "此报告将从 Apple 健康中永久删除。"
           }
         }
       }
@@ -15238,13 +15238,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen je kaartindeling wordt gesynchroniseerd. Je labwaarden blijven in Apple Health en verlaten het nooit."
+            "value" : "Alleen je kaartindeling wordt gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizowany jest tylko układ kart. Twoje wyniki badań pozostają w Apple Health i nigdy go nie opuszczają."
+            "value" : "Synchronizowany jest tylko układ kart. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
           }
         },
         "pt-BR" : {
@@ -15390,13 +15390,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde plus wat je vastzet en verbergt — op al je apparaten. Je labwaarden blijven in Apple Health."
+            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde plus wat je vastzet en verbergt — op al je apparaten. Je labwaarden blijven in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizuj układ pulpitu — kolejność kart oraz to, co przypinasz i ukrywasz — między urządzeniami. Twoje wyniki badań pozostają w Apple Health."
+            "value" : "Synchronizuj układ pulpitu — kolejność kart oraz to, co przypinasz i ukrywasz — między urządzeniami. Twoje wyniki badań pozostają w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
@@ -15466,13 +15466,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gesynchroniseerd via je privé-iCloud-account. Je labgegevens verlaten Apple Health nooit."
+            "value" : "Gesynchroniseerd via je privé-iCloud-account. Je labgegevens verlaten Apple Gezondheid nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizacja odbywa się przez Twoje prywatne konto iCloud. Twoje dane laboratoryjne nigdy nie opuszczają Apple Health."
+            "value" : "Synchronizacja odbywa się przez Twoje prywatne konto iCloud. Twoje dane laboratoryjne nigdy nie opuszczają Apple Zdrowia."
           }
         },
         "pt-BR" : {


### PR DESCRIPTION
## Summary

Every reference to Apple's Health app in `Localizable.xcstrings` now uses the **on-device localized app name with the `Apple` brand prefix**, matching how the app is actually named on the Home Screen / in Settings for each language:

| | | | |
|---|---|---|---|
| de `Apple Health` | fr `Apple Santé` | es `Apple Salud` | it `Apple Salute` |
| pt-BR `Apple Saúde` | nl `Apple Gezondheid` | pl `Apple Zdrowie` | ja `Appleヘルスケア` |
| zh-Hans `Apple 健康` | ru `Apple Здоровье` | tr `Apple Sağlık` | uk `Apple Здоров'я` |

Each name was confirmed against Apple's localized App Store / support pages first. Notably, on a German device the app label is **"Health"**, so German stays `Apple Health`.

## What changed (145 value edits)

- Standardized German (`Gesundheits-App` / bare `Health` → `Apple Health`).
- Translated the leftover English "Apple Health" in Dutch, Polish, Japanese, Russian, Ukrainian.
- Added the brand prefix where translations had dropped it (`Santé` → `Apple Santé`, etc.).
- Preserved grammar: Polish/Russian/Ukrainian case declensions (`do Apple Zdrowia`, `z Apple Zdrowiem`, `из Apple Здоровья`), French elision (`d'Apple Santé`), and Ukrainian в/у euphony (`в Apple Здоров'ї`).

## Deliberately left alone

- **English source strings** — already use `Apple Health`, so no Swift changes were needed.
- **Bare "Health" labels** where the English source itself is bare (e.g. `Save Reports to Health`, `Detected in Health`) — these mirror the source with the bare localized name; only nl/pl were fixed there (they had leaked the English word "Health").
- **`Health Records`** (`Gesundheitsakte`, …) — a distinct Apple feature, not the app name.

## Documentation

Added the rule to `CLAUDE.md` (UI patterns) so future work follows it: localized app name + `Apple` prefix, the canonical per-language table, grammar inflection of the localized noun, and the bare-source / `Health Records` exceptions.

## Verification

- JSON re-parses; diff is exactly 145 clean one-line value replacements (no formatting drift).
- No `Apple Apple` doubling; no English "Apple Health" left in non-English/non-German.
- `swiftlint lint --strict` passes (exit 0) — no Swift was touched.

https://claude.ai/code/session_01VLTXRxPyDDitFSzVkVXadx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLTXRxPyDDitFSzVkVXadx)_