### PR TITLE
Separate pinned metrics into their own dashboard section

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -10331,6 +10331,82 @@
         }
       }
     },
+    "Pinned" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angeheftet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fijados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épinglés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fissati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピン留め"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vastgezet"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przypięte"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fixados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закреплённые"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sabitlenenler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закріплені"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已置顶"
+          }
+        }
+      }
+    },
     "Project" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/LabImporter/Views/DashboardView.swift
+++ b/LabImporter/Views/DashboardView.swift
@@ -31,7 +31,7 @@ struct DashboardView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                metricsGrid
+                metricSections
                 footer
             }
             .padding(.horizontal, 16)
@@ -100,12 +100,39 @@ struct DashboardView: View {
 
     // MARK: - Metrics grid
 
-    private var metricsGrid: some View {
+    /// Pinned metrics get their own labeled section on top; the rest flow
+    /// underneath with no header. When nothing is pinned this collapses to a
+    /// single unlabeled grid — identical to the pre-sectioning layout.
+    @ViewBuilder
+    private var metricSections: some View {
+        let pinned = pinnedMetrics
+        if !pinned.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                pinnedHeader
+                grid(pinned)
+            }
+        }
+        grid(unpinnedMetrics)
+    }
+
+    private func grid(_ items: [MetricData]) -> some View {
         LazyVGrid(columns: gridColumns, spacing: 14) {
-            ForEach(sortedMetrics) { metric in
+            ForEach(items) { metric in
                 metricCard(for: metric)
             }
         }
+    }
+
+    private var pinnedHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "pin.fill")
+                .font(.caption)
+            Text("Pinned")
+                .font(.subheadline.weight(.semibold))
+            Spacer()
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 2)
     }
 
     /// Two fixed columns on compact widths (iPhone); on regular widths (iPad) the
@@ -189,6 +216,16 @@ struct DashboardView: View {
                 if aOrd != bOrd { return aOrd < bOrd }
                 return lhs.entry.resolvedName < rhs.entry.resolvedName
             }
+    }
+
+    private var pinnedMetrics: [MetricData] {
+        let pinned = prefs.pinnedSet
+        return sortedMetrics.filter { pinned.contains($0.entry.code) }
+    }
+
+    private var unpinnedMetrics: [MetricData] {
+        let pinned = prefs.pinnedSet
+        return sortedMetrics.filter { !pinned.contains($0.entry.code) }
     }
 
     // Up to three distinct category colors from the visible metrics, used for

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -277,6 +277,7 @@ struct LabSortEditor: View {
 
     var body: some View {
         List {
+            pinnedSection
             visibleSection
             hiddenSection
         }
@@ -288,30 +289,56 @@ struct LabSortEditor: View {
         .onChange(of: pinnedSet) { save() }
     }
 
+    /// Visible codes split by pin state. Both partitions preserve their relative
+    /// order within `visibleOrdered`, which is normalized pinned-first so the
+    /// editor order matches how the dashboard groups the cards.
+    private var pinnedItems: [CodeName] { visibleOrdered.filter { pinnedSet.contains($0.code) } }
+    private var unpinnedItems: [CodeName] { visibleOrdered.filter { !pinnedSet.contains($0.code) } }
+
+    @ViewBuilder
+    private var pinnedSection: some View {
+        if !pinnedItems.isEmpty {
+            Section("Pinned") {
+                ForEach(pinnedItems) { item in row(for: item) }
+                    .onMove { from, dest in
+                        var pinned = pinnedItems
+                        pinned.move(fromOffsets: from, toOffset: dest)
+                        visibleOrdered = pinned + unpinnedItems
+                    }
+            }
+        }
+    }
+
     @ViewBuilder
     private var visibleSection: some View {
         Section("Visible") {
-            ForEach(visibleOrdered) { item in
-                HStack(spacing: 12) {
-                    Button { togglePin(item.code) } label: {
-                        Image(systemName: pinnedSet.contains(item.code) ? "pin.fill" : "pin")
-                            .foregroundStyle(pinnedSet.contains(item.code) ? Color.yellow : Color.secondary)
-                            .frame(width: 20)
-                    }
-                    .buttonStyle(.plain)
-                    Circle()
-                        .fill(LabCategory.forCode(item.code).color.gradient)
-                        .frame(width: 9, height: 9)
-                    Text(item.name)
-                    Spacer()
-                    Button { hideCode(item.code) } label: {
-                        Image(systemName: "eye.slash")
-                            .foregroundStyle(Color.secondary)
-                    }
-                    .buttonStyle(.plain)
+            ForEach(unpinnedItems) { item in row(for: item) }
+                .onMove { from, dest in
+                    var unpinned = unpinnedItems
+                    unpinned.move(fromOffsets: from, toOffset: dest)
+                    visibleOrdered = pinnedItems + unpinned
                 }
+        }
+    }
+
+    private func row(for item: CodeName) -> some View {
+        HStack(spacing: 12) {
+            Button { togglePin(item.code) } label: {
+                Image(systemName: pinnedSet.contains(item.code) ? "pin.fill" : "pin")
+                    .foregroundStyle(pinnedSet.contains(item.code) ? Color.yellow : Color.secondary)
+                    .frame(width: 20)
             }
-            .onMove { from, dest in visibleOrdered.move(fromOffsets: from, toOffset: dest) }
+            .buttonStyle(.plain)
+            Circle()
+                .fill(LabCategory.forCode(item.code).color.gradient)
+                .frame(width: 9, height: 9)
+            Text(item.name)
+            Spacer()
+            Button { hideCode(item.code) } label: {
+                Image(systemName: "eye.slash")
+                    .foregroundStyle(Color.secondary)
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -345,6 +372,9 @@ struct LabSortEditor: View {
         } else {
             pinnedSet.insert(code)
         }
+        // Keep the backing order pinned-first so a toggled row moves between the
+        // two sections in place, matching the dashboard's grouping.
+        visibleOrdered = pinnedItems + unpinnedItems
     }
 
     private func hideCode(_ code: String) {


### PR DESCRIPTION
## What & why

Pinned metrics previously just floated to the top of one continuous grid with a small pin glyph as the only cue — and the Sort & Visibility editor didn't reflect that grouping (a pinned row could sit mid-list in the editor while jumping to the top of the dashboard). This gives pinned items a clear home and makes the editor WYSIWYG.

## Changes

**Dashboard (`DashboardView`)**
- Pinned cards now group under a labeled **"Pinned"** header at the top; the rest flow below with no header.
- When nothing is pinned, the layout collapses to the previous single unlabeled grid — no extra chrome on the empty/first-launch state.

**Sort & Visibility editor (`LabSortEditor`)**
- Split into matching **"Pinned"** and **"Visible"** sections.
- Drag reorders *within* each section; the pin button moves a row *across* the boundary (cleaner than cross-section drag in SwiftUI).
- `visibleOrdered` is normalized pinned-first so the editor order mirrors the dashboard grouping — the order *among* pinned cards is now editable too.

## Notes

- **No model/CDA impact.** Pure UI — `LabDisplayPreferences` and its JSON payload are untouched, so no schema bump and nothing touches the Health/CDA round-trip.
- Added a localized `"Pinned"` string across all shipped languages.
- `swiftlint lint --strict` passes clean.
- Not verified on-device (no tests in the project; the app requires Apple Intelligence hardware).

https://claude.ai/code/session_01Kccrwg98gL3jGw3BhmqsBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kccrwg98gL3jGw3BhmqsBf)_