### PR TITLE
Flag duplicate LOINC codes for review instead of collapsing them

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,6 +1,36 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Another value uses the same LOINC code — keep only one" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein anderer Wert verwendet denselben LOINC-Code – behalte nur einen"
+          }
+        }
+      }
+    },
+    "Duplicate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplikat"
+          }
+        }
+      }
+    },
+    "Some tests appear more than once. Keep one value per test before saving." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Tests kommen mehrfach vor. Behalte vor dem Speichern pro Test nur einen Wert."
+          }
+        }
+      }
+    },
     "The on-device AI couldn't recognize the language of this report. This can happen with very short reports, or ones made up mostly of codes and numbers. Try importing or scanning the full report so there's more text to read, then try again." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/LabImporter/Models/LabValue.swift
+++ b/LabImporter/Models/LabValue.swift
@@ -62,4 +62,46 @@ struct LabValue: Identifiable, Equatable, @unchecked Sendable {
             && unit == other.unit
             && isSelected == other.isSelected
     }
+
+    /// Dedup ranking: a value that will actually be saved (selected *and*
+    /// carrying a numeric result) outranks one that won't, so when two rows
+    /// share a LOINC the one holding real, exportable data survives. Ties keep
+    /// the earlier row (see `deduplicatedByLoinc`).
+    fileprivate var dedupRank: Int {
+        if isSelected && numericValue != nil { return 2 }
+        if numericValue != nil { return 1 }
+        return 0
+    }
+}
+
+extension Array where Element == LabValue {
+    /// Collapses entries that share the same LOINC code so a report never holds
+    /// more than one value per LOINC — the app's canonical identity for a test.
+    ///
+    /// Only entries carrying a *valid* LOINC mapping are deduplicated; rows whose
+    /// code is an unmapped mnemonic, `"MANUAL"`, or empty are genuinely distinct
+    /// until the user maps them, so they pass through untouched (collapsing them
+    /// would merge unrelated tests). Codes are compared by their resolved LOINC
+    /// (`LabMapping.loincCode`) so equivalent spellings count as one. Within a
+    /// collapsed group the most useful row wins (selected + numeric beats the
+    /// rest, see `dedupRank`), and each kept row stays in its first-seen slot.
+    func deduplicatedByLoinc() -> [LabValue] {
+        var slotForLoinc: [String: Int] = [:]
+        var result: [LabValue] = []
+        for value in self {
+            guard let loinc = LabMapping.loincCode(for: value.code)?.loinc else {
+                result.append(value)
+                continue
+            }
+            if let slot = slotForLoinc[loinc] {
+                if value.dedupRank > result[slot].dedupRank {
+                    result[slot] = value
+                }
+            } else {
+                slotForLoinc[loinc] = result.count
+                result.append(value)
+            }
+        }
+        return result
+    }
 }

--- a/LabImporter/Models/LabValue.swift
+++ b/LabImporter/Models/LabValue.swift
@@ -63,6 +63,16 @@ struct LabValue: Identifiable, Equatable, @unchecked Sendable {
             && isSelected == other.isSelected
     }
 
+    /// Whether this row would collide with another exportable row on the same
+    /// LOINC, given the report's set of duplicated codes (`duplicateLoincCodes`).
+    /// Only selected, numeric, LOINC-mapped rows can collide, so the rest never
+    /// flag as duplicates. Drives the "Duplicate" badge in `LabValueRowView`.
+    func isDuplicate(in duplicateLoincCodes: Set<String>) -> Bool {
+        guard isSelected, numericValue != nil,
+              let loinc = LabMapping.loincCode(for: code)?.loinc else { return false }
+        return duplicateLoincCodes.contains(loinc)
+    }
+
     /// Dedup ranking: a value that will actually be saved (selected *and*
     /// carrying a numeric result) outranks one that won't, so when two rows
     /// share a LOINC the one holding real, exportable data survives. Ties keep
@@ -75,8 +85,30 @@ struct LabValue: Identifiable, Equatable, @unchecked Sendable {
 }
 
 extension Array where Element == LabValue {
+    /// The LOINC codes carried by more than one *exportable* entry — i.e. rows
+    /// that are selected and hold a numeric result, the exact set that would be
+    /// written to the CDA. Two such rows sharing a LOINC (the app's canonical
+    /// identity for a test) is a duplicate the user must resolve before saving;
+    /// the review screen surfaces them visually instead of silently merging.
+    ///
+    /// Only entries carrying a *valid* LOINC mapping are considered; rows whose
+    /// code is an unmapped mnemonic, `"MANUAL"`, or empty are genuinely distinct
+    /// until the user maps them, so they never count as duplicates. Deselected
+    /// or non-numeric rows won't be saved, so they don't create a conflict.
+    func duplicateLoincCodes() -> Set<String> {
+        var counts: [String: Int] = [:]
+        for value in self where value.isSelected && value.numericValue != nil {
+            guard let loinc = LabMapping.loincCode(for: value.code)?.loinc else { continue }
+            counts[loinc, default: 0] += 1
+        }
+        return Set(counts.filter { $0.value > 1 }.keys)
+    }
+
     /// Collapses entries that share the same LOINC code so a report never holds
     /// more than one value per LOINC — the app's canonical identity for a test.
+    /// This is the **last-resort guarantee** at the CDA save/share boundary: the
+    /// review UI surfaces duplicates (see `duplicateLoincCodes`) and blocks saving
+    /// until the user resolves them, so in normal use this never has to collapse.
     ///
     /// Only entries carrying a *valid* LOINC mapping are deduplicated; rows whose
     /// code is an unmapped mnemonic, `"MANUAL"`, or empty are genuinely distinct

--- a/LabImporter/Services/CDAExportService.swift
+++ b/LabImporter/Services/CDAExportService.swift
@@ -29,7 +29,10 @@ struct CDAExportService {
         // swiftlint:disable:next line_length
         let authorOrgXML = authorTrimmed.isEmpty ? "" : "\n      <representedOrganization>\n        <name>\(esc(authorTrimmed))</name>\n      </representedOrganization>"
 
-        let exportable = labValues.filter {
+        // Final guarantee that a saved/shared report carries one entry per LOINC,
+        // even if review-time edits (a re-mapped code, a manual add) collided two
+        // rows onto the same code after import-time dedup.
+        let exportable = labValues.deduplicatedByLoinc().filter {
             $0.isSelected && $0.numericValue != nil && LabMapping.loincCode(for: $0.code) != nil
         }
 

--- a/LabImporter/Services/CDAExportService.swift
+++ b/LabImporter/Services/CDAExportService.swift
@@ -29,9 +29,10 @@ struct CDAExportService {
         // swiftlint:disable:next line_length
         let authorOrgXML = authorTrimmed.isEmpty ? "" : "\n      <representedOrganization>\n        <name>\(esc(authorTrimmed))</name>\n      </representedOrganization>"
 
-        // Final guarantee that a saved/shared report carries one entry per LOINC,
-        // even if review-time edits (a re-mapped code, a manual add) collided two
-        // rows onto the same code after import-time dedup.
+        // Last-resort guarantee that a saved/shared report carries one entry per
+        // LOINC. The review screen surfaces duplicates and blocks saving until the
+        // user resolves them, so this guard normally has nothing to collapse — it
+        // just keeps the persisted CDA well-formed for any non-review export path.
         let exportable = labValues.deduplicatedByLoinc().filter {
             $0.isSelected && $0.numericValue != nil && LabMapping.loincCode(for: $0.code) != nil
         }

--- a/LabImporter/Services/LabParserService.swift
+++ b/LabImporter/Services/LabParserService.swift
@@ -134,7 +134,10 @@ actor LabParserService {
             )
         }
 
-        return ParseResult(values: values, reportDate: reportDate, patientName: patientName, authorName: authorName)
+        // A printed report can list the same test twice (e.g. a value and its
+        // recalculation), and two terse names can resolve to the same LOINC —
+        // keep a single entry per LOINC, the app's canonical identity.
+        return ParseResult(values: values.deduplicatedByLoinc(), reportDate: reportDate, patientName: patientName, authorName: authorName)
     }
 
     // Resolves a parsed entry to a LOINC code entirely from the bundled catalog.

--- a/LabImporter/Views/LabValueRowView.swift
+++ b/LabImporter/Views/LabValueRowView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct LabValueRowView: View {
     @Binding var value: LabValue
+    /// True when another exportable row carries the same LOINC code; surfaces a
+    /// "Duplicate" badge so the user can resolve the collision before saving.
+    var isDuplicate: Bool = false
 
     @State private var showCodePicker = false
     @FocusState private var isFocused: Bool
@@ -38,6 +41,17 @@ struct LabValueRowView: View {
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                             .help("No LOINC code — excluded from CDA export")
+                    }
+
+                    if isDuplicate {
+                        Label("Duplicate", systemImage: "exclamationmark.triangle.fill")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2.weight(.medium))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.orange.opacity(0.15), in: Capsule())
+                            .foregroundStyle(.orange)
+                            .help("Another value uses the same LOINC code — keep only one")
                     }
                 }
 

--- a/LabImporter/Views/ReviewHeaderCard.swift
+++ b/LabImporter/Views/ReviewHeaderCard.swift
@@ -29,23 +29,39 @@ struct CDAShareSheet: UIViewControllerRepresentable {
 /// above. Dimmed and non-interactive until at least one value is exportable.
 struct ReviewActionBar: View {
     let isEnabled: Bool
+    /// When true, the report still has two or more values sharing a LOINC code.
+    /// We show a warning and keep save/share dimmed until the user resolves them,
+    /// so the disabled state isn't a mystery.
+    var hasDuplicates: Bool = false
     let onSave: () -> Void
     let onShare: () -> Void
 
     var body: some View {
         VStack(spacing: 10) {
-            Button("Save to Health Records", action: onSave)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .frame(maxWidth: .infinity)
+            if hasDuplicates {
+                Label(
+                    "Some tests appear more than once. Keep one value per test before saving.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.footnote)
+                .foregroundStyle(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
 
-            Button("Share CDA File", action: onShare)
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-                .frame(maxWidth: .infinity)
+            VStack(spacing: 10) {
+                Button("Save to Health Records", action: onSave)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
+
+                Button("Share CDA File", action: onShare)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
+            }
+            .opacity(isEnabled ? 1 : 0.4)
+            .allowsHitTesting(isEnabled)
         }
-        .opacity(isEnabled ? 1 : 0.4)
-        .allowsHitTesting(isEnabled)
         .padding(.horizontal)
         .padding(.bottom)
         .padding(.top, 16)
@@ -101,6 +117,7 @@ struct CategoryCount: Identifiable {
 struct ReviewHeaderCard: View {
     let supportedCount: Int
     let exportableCount: Int
+    var duplicateCount: Int = 0
     let groups: [CategoryCount]
     let dominantColor: Color
 
@@ -146,6 +163,16 @@ struct ReviewHeaderCard: View {
                         }
                     }
                 }
+            }
+
+            if duplicateCount > 0 {
+                Label(
+                    "Some tests appear more than once. Keep one value per test before saving.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(18)

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -38,9 +38,7 @@ struct ReviewView: View {
     private let cdaService = CDAExportService()
 
     private var exportableCount: Int {
-        labValues.filter {
-            $0.isSelected && $0.numericValue != nil && LabMapping.loincCode(for: $0.code) != nil
-        }.count
+        labValues.filter { $0.isSelected && $0.numericValue != nil && LabMapping.loincCode(for: $0.code) != nil }.count
     }
 
     private var unsupportedValues: [LabValue] {
@@ -51,6 +49,9 @@ struct ReviewView: View {
     private var supportedCount: Int {
         labValues.filter { LabMapping.loincCode(for: $0.code) != nil }.count
     }
+
+    // LOINC codes claimed by 2+ exportable rows — duplicates the user must resolve.
+    private var duplicateLoincCodes: Set<String> { labValues.duplicateLoincCodes() }
 
     private struct ValueGroup {
         let category: LabCategory
@@ -70,10 +71,8 @@ struct ReviewView: View {
 
     // Up to three category colors for the soft background wash.
     private var backgroundColors: [Color] {
-        valueGroups
-            .sorted { $0.indices.count > $1.indices.count }
-            .prefix(3)
-            .map { $0.category.color }
+        valueGroups.sorted { $0.indices.count > $1.indices.count }
+            .prefix(3).map { $0.category.color }
     }
 
     private var dominantColor: Color {
@@ -88,12 +87,12 @@ struct ReviewView: View {
         replacingReport: LabReport? = nil,
         onSaved: (() -> Void)? = nil
     ) {
-        _labValues = State(initialValue: labValues.deduplicatedByLoinc())
+        _labValues = State(initialValue: labValues)
         _reportDate = State(initialValue: reportDate)
         _extractedPatientName = State(initialValue: extractedPatientName)
         _extractedAuthorName = State(initialValue: extractedAuthorName)
         _replacingReport = State(initialValue: replacingReport)
-        _initialLabValues = State(initialValue: labValues.deduplicatedByLoinc())
+        _initialLabValues = State(initialValue: labValues)
         _initialReportDate = State(initialValue: reportDate)
         self.onSaved = onSaved
     }
@@ -169,6 +168,7 @@ struct ReviewView: View {
             ReviewHeaderCard(
                 supportedCount: supportedCount,
                 exportableCount: exportableCount,
+                duplicateCount: duplicateLoincCodes.count,
                 groups: categoryCounts,
                 dominantColor: dominantColor
             )
@@ -266,7 +266,7 @@ struct ReviewView: View {
         ForEach(valueGroups, id: \.category) { group in
             Section {
                 ForEach(group.indices, id: \.self) { idx in
-                    LabValueRowView(value: $labValues[idx])
+                    LabValueRowView(value: $labValues[idx], isDuplicate: labValues[idx].isDuplicate(in: duplicateLoincCodes))
                         .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                         .swipeActions(edge: .trailing) {
                             Button(role: .destructive) {
@@ -359,7 +359,8 @@ private extension ReviewView {
 
     var bottomButtons: some View {
         ReviewActionBar(
-            isEnabled: exportableCount > 0,
+            isEnabled: exportableCount > 0 && duplicateLoincCodes.isEmpty,
+            hasDuplicates: !duplicateLoincCodes.isEmpty,
             onSave: { Task { await performCDAImport() } },
             onShare: { shareCDA() }
         )
@@ -399,11 +400,10 @@ private extension ReviewView {
         return zip(labValues, initialLabValues).contains { !$0.matchesSavedData(of: $1) }
     }
 
-    /// Merges freshly parsed values into the open report (scan/file/paste add to
-    /// what's being reviewed), keeping one entry per LOINC so a re-scan can't duplicate.
+    /// Appends parsed values (scan/file/paste); re-imported tests surface as flagged duplicates.
     func configureImportEngine() {
         importEngine.onParsed = { result in
-            labValues = (labValues + result.values).deduplicatedByLoinc()
+            labValues.append(contentsOf: result.values)
         }
     }
 

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -88,12 +88,12 @@ struct ReviewView: View {
         replacingReport: LabReport? = nil,
         onSaved: (() -> Void)? = nil
     ) {
-        _labValues = State(initialValue: labValues)
+        _labValues = State(initialValue: labValues.deduplicatedByLoinc())
         _reportDate = State(initialValue: reportDate)
         _extractedPatientName = State(initialValue: extractedPatientName)
         _extractedAuthorName = State(initialValue: extractedAuthorName)
         _replacingReport = State(initialValue: replacingReport)
-        _initialLabValues = State(initialValue: labValues)
+        _initialLabValues = State(initialValue: labValues.deduplicatedByLoinc())
         _initialReportDate = State(initialValue: reportDate)
         self.onSaved = onSaved
     }
@@ -399,11 +399,11 @@ private extension ReviewView {
         return zip(labValues, initialLabValues).contains { !$0.matchesSavedData(of: $1) }
     }
 
-    /// Appends freshly parsed values to the open report rather than replacing it,
-    /// so scan/file/paste add to what the user is already reviewing or editing.
+    /// Merges freshly parsed values into the open report (scan/file/paste add to
+    /// what's being reviewed), keeping one entry per LOINC so a re-scan can't duplicate.
     func configureImportEngine() {
         importEngine.onParsed = { result in
-            labValues.append(contentsOf: result.values)
+            labValues = (labValues + result.values).deduplicatedByLoinc()
         }
     }
 


### PR DESCRIPTION
## Summary

A report can list the same test twice, two terse names can resolve to the same LOINC, and a re-scan or manual edit can collide rows onto an existing code. The previous behaviour on this branch **silently collapsed** these duplicates on import/edit, hiding the conflict from the user. This PR replaces that with **visual feedback** so the user can see the duplication and decide which value to keep.

## Changes

**Detection** (`Models/LabValue.swift`)
- Add `Array<LabValue>.duplicateLoincCodes()` — the LOINC codes carried by two or more *exportable* rows (selected + numeric + mapped). Unmapped/manual/deselected rows can't collide on export, so they never count.
- Add `LabValue.isDuplicate(in:)` for per-row checks.
- `deduplicatedByLoinc()` stays only as the last-resort guard at the CDA export boundary (keeps any non-review export path well-formed).

**Stop silent collapsing**
- `LabParserService.parseLabValues` — keep both rows instead of deduping.
- `ReviewView` init + import-merge — no longer dedup on open or re-scan, so duplicates stay visible.

**Visual feedback**
- `LabValueRowView` — orange **"Duplicate"** badge on each colliding row.
- `ReviewHeaderCard` — duplicate warning line in the summary card.
- `ReviewActionBar` — warning line above the buttons; **Save/Share disabled until the user resolves the duplicates** (delete, deselect, or re-map a row).

**Localization**
- Add German strings for the new copy to `Localizable.xcstrings`.

## Verification
- `swiftlint lint --strict` → 0 violations across 33 files.
- `Localizable.xcstrings` validated as well-formed JSON.
- ⚠️ Not built/run on device — the app requires Xcode 26 + an Apple Intelligence device, which isn't available in this environment. UI behaviour should be confirmed in Xcode on a supported device.

https://claude.ai/code/session_014KHhhB3CuVpeDyQPVjN1gV

---
_Generated by [Claude Code](https://claude.ai/code/session_014KHhhB3CuVpeDyQPVjN1gV)_