### PR TITLE
Stop resetting navigation when rotating a large iPhone

### DIFF
--- a/LabImporter/Views/HomeView.swift
+++ b/LabImporter/Views/HomeView.swift
@@ -27,7 +27,19 @@ struct HomeView: View {
     // iPad sidebar state
     @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
     @State private var sidebarSelection: SidebarSection? = .dashboard
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    /// Whether to present the iPad sidebar split view. Keyed off the device
+    /// idiom rather than `horizontalSizeClass` on purpose: a large iPhone flips
+    /// between compact (portrait) and regular (landscape) on every rotation, and
+    /// driving the root layout off that swaps the whole navigation container —
+    /// tearing down any pushed screen and dumping the user back on the
+    /// dashboard. The idiom is stable across rotation, so the iPhone keeps its
+    /// `NavigationStack` (and its navigation state) and only the iPad gets the
+    /// sidebar. `NavigationSplitView` still collapses itself when an iPad is
+    /// horizontally compact (Slide Over), so no behavior is lost there.
+    private var usesSidebarLayout: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
 
     /// Sections shown in the iPad sidebar. On compact widths (iPhone) these are
     /// reached through the dashboard's own toolbar instead, so the sidebar is
@@ -54,13 +66,14 @@ struct HomeView: View {
     }
 
     var body: some View {
-        // The layout adapts to width — a sidebar split view on regular-width
-        // devices (iPad, large iPhones in landscape) and the original stack on
-        // compact widths — while the import overlay, review sheet, report
-        // loading and onboarding stay shared across both so behavior is
-        // identical no matter how the content is presented.
+        // The layout adapts to the device — a sidebar split view on iPad and the
+        // original stack on iPhone — while the import overlay, review sheet,
+        // report loading and onboarding stay shared across both so behavior is
+        // identical no matter how the content is presented. See
+        // `usesSidebarLayout` for why this is keyed off the idiom, not the size
+        // class, so rotating an iPhone doesn't reset navigation.
         Group {
-            if horizontalSizeClass == .regular {
+            if usesSidebarLayout {
                 splitRoot
             } else {
                 compactRoot


### PR DESCRIPTION
## Problem

Rotating a large iPhone (Plus/Max) always kicked the user back to the dashboard/overview, dropping any screen they had navigated into.

`HomeView` chose its root container from `horizontalSizeClass`:

```swift
if horizontalSizeClass == .regular { splitRoot } else { compactRoot }
```

On large iPhones the size class is `.compact` in portrait and `.regular` in landscape, so every rotation swapped `compactRoot` (`NavigationStack`) for `splitRoot` (`NavigationSplitView`) and back. Navigation inside the stack is plain `NavigationLink` pushes (Dashboard → Reports → Report Detail, plus the Trends/Settings sheets), so tearing down and rebuilding the root destroyed all of that state — landing back on the overview. iPads were never affected since they stay `.regular` in both orientations.

## Fix

Key the layout off the **device idiom** instead of the size class — the idiom never changes on rotation:

```swift
private var usesSidebarLayout: Bool {
    UIDevice.current.userInterfaceIdiom == .pad
}
```

- iPhone always keeps its `NavigationStack` (and its pushed screens) across rotation.
- iPad always gets the sidebar. `NavigationSplitView` still collapses itself when an iPad is horizontally compact (Slide Over), so nothing is lost there.

**Tradeoff:** large iPhones in landscape no longer show the sidebar split view — they keep the normal iPhone stack in both orientations. That intentional design was the direct cause of the reset, so dropping it for big iPhones is what eliminates the bug.

## Testing

- `swiftlint lint --strict` passes.
- No iOS build/run available in this environment — worth confirming on a physical large iPhone that rotating while viewing a report detail now stays put.

https://claude.ai/code/session_01HKQVWFzhNPxFiA1j5i9bCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKQVWFzhNPxFiA1j5i9bCA)_