### PR TITLE
Hide review action bar while keyboard is visible

### DIFF
--- a/LabImporter/Views/ReviewHeaderCard.swift
+++ b/LabImporter/Views/ReviewHeaderCard.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Wraps `UIActivityViewController` so the review screen can share an exported
 /// CDA file via the standard share sheet.
@@ -77,6 +78,42 @@ struct ReviewActionBar: View {
                 }
                 .ignoresSafeArea(edges: .bottom)
         }
+    }
+}
+
+/// Removes the view from the layout while the software keyboard is on screen.
+///
+/// The review screen pins `ReviewActionBar` to the bottom via `safeAreaInset`, so
+/// SwiftUI lifts it to sit just above the keyboard when a field is focused — the
+/// exact spot the keyboard's own "Done" accessory toolbar docks to, leaving the two
+/// overlapping. Dropping the action bar during editing hands that strip to the
+/// keyboard toolbar; it animates back in when editing ends. We watch the keyboard
+/// notifications (rather than a `FocusState`) so this also covers the per-row value
+/// fields, whose focus is private to `LabValueRowView`. The `onReceive` lives on an
+/// always-present container so the hide notification still arrives once the content
+/// has been removed.
+private struct HideWhileKeyboardVisible: ViewModifier {
+    @State private var keyboardVisible = false
+
+    func body(content: Content) -> some View {
+        Group {
+            if !keyboardVisible {
+                content.transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            withAnimation(.easeInOut(duration: 0.25)) { keyboardVisible = true }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            withAnimation(.easeInOut(duration: 0.25)) { keyboardVisible = false }
+        }
+    }
+}
+
+extension View {
+    /// Hides the view while the software keyboard is visible — see `HideWhileKeyboardVisible`.
+    func hiddenWhileKeyboardVisible() -> some View {
+        modifier(HideWhileKeyboardVisible())
     }
 }
 

--- a/LabImporter/Views/ReviewView.swift
+++ b/LabImporter/Views/ReviewView.swift
@@ -129,7 +129,7 @@ struct ReviewView: View {
             Text("Any entered values will not be saved.")
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            bottomButtons
+            bottomButtons.hiddenWhileKeyboardVisible()
         }
         .labImport(engine: importEngine)
         .task { await loadHKCharacteristics() }


### PR DESCRIPTION
## Problem

On the Lab Report review screen, the floating action bar (**Save to Health Records** / **Share CDA File**) is pinned to the bottom via `.safeAreaInset(edge: .bottom)`. When a field is focused, SwiftUI lifts that inset to sit just above the keyboard — the exact spot the keyboard's own "Done" accessory toolbar docks to. The two land in the same place and overlap.

This is visible when editing the patient name, the lab/doctor name, or a lab value.

## Fix

Added a small reusable view modifier, `hiddenWhileKeyboardVisible()`, and applied it to the action bar:

```swift
.safeAreaInset(edge: .bottom, spacing: 0) {
    bottomButtons.hiddenWhileKeyboardVisible()
}
```

While the keyboard is up, the action bar drops out of the layout (animated), handing that bottom strip to the keyboard's Done toolbar — no more overlap. It slides back in when editing ends.

### Notes on the approach

- **Watches the keyboard notifications, not a `FocusState`.** The patient/lab-name fields share `anyFieldFocused`, but each value row's number field has its *own* private focus state inside `LabValueRowView`, which the parent can't observe. Listening for `keyboardWillShow/Hide` covers all editable cases (name, lab/doctor, value) uniformly.
- The `onReceive` lives on an always-present container so the hide notification still arrives after the content has been removed.
- Placed the modifier in `ReviewHeaderCard.swift` (the existing home of the shared review components like `ReviewActionBar`) rather than `ReviewView.swift`, which was already exactly at the 500-line SwiftLint limit. Applying it inline keeps `ReviewView` at 500.

## Testing

- `swiftlint lint --strict` passes with 0 violations.
- ⚠️ Not compile-verified — building needs Xcode 26 / iOS 26 on macOS. Worth a quick build-and-run on a device to confirm the animation feels right.

https://claude.ai/code/session_011356vptETdfnhk1r3Jc5uY