### PR TITLE
Make onboarding screens responsive and structurally consistent

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "if": "Bash(git push *)",
-            "command": "if ! command -v swiftlint >/dev/null 2>&1; then echo 'swiftlint not installed locally; skipping pre-push lint (CI will still run it)' >&2; exit 0; fi; swiftlint lint --strict --quiet >&2 || { echo 'SwiftLint failed — fix violations before pushing' >&2; exit 2; }",
+            "command": "if ! command -v swiftlint >/dev/null 2>&1; then echo 'swiftlint not installed locally; skipping pre-push lint (CI will still run it)' >&2; exit 0; fi; cd \"$CLAUDE_PROJECT_DIR\" && swiftlint lint --strict --quiet --config \"$CLAUDE_PROJECT_DIR/.swiftlint.yml\" >&2 || { echo 'SwiftLint failed — fix violations before pushing' >&2; exit 2; }",
             "timeout": 90,
             "statusMessage": "Running SwiftLint before push…"
           }

--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		636BA85E2FCC52EE006E8E71 /* HealthPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636BA85D2FCC52EE006E8E71 /* HealthPermissionView.swift */; };
 		AABB0000000000000000D3AA /* CloudSyncOptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000D2AA /* CloudSyncOptInView.swift */; };
+		AABB0000000000000000F5AA /* OnboardingScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000F6AA /* OnboardingScaffold.swift */; };
 		AABB000000000000000040AA /* LabImporterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000020AA /* LabImporterApp.swift */; };
 		AABB000000000000000041AA /* LabValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000021AA /* LabValue.swift */; };
 		AABB000000000000000042AA /* LabMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000022AA /* LabMapping.swift */; };
@@ -56,6 +57,7 @@
 /* Begin PBXFileReference section */
 		636BA85D2FCC52EE006E8E71 /* HealthPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPermissionView.swift; sourceTree = "<group>"; };
 		AABB0000000000000000D2AA /* CloudSyncOptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncOptInView.swift; sourceTree = "<group>"; };
+		AABB0000000000000000F6AA /* OnboardingScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingScaffold.swift; sourceTree = "<group>"; };
 		AABB000000000000000019AA /* LabImporter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LabImporter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABB000000000000000020AA /* LabImporterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabImporterApp.swift; sourceTree = "<group>"; };
 		AABB000000000000000021AA /* LabValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabValue.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 				AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */,
 				636BA85D2FCC52EE006E8E71 /* HealthPermissionView.swift */,
 				AABB0000000000000000D2AA /* CloudSyncOptInView.swift */,
+				AABB0000000000000000F6AA /* OnboardingScaffold.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				AABB0000000000000000F1AA /* LabImportEngine.swift in Sources */,
 				636BA85E2FCC52EE006E8E71 /* HealthPermissionView.swift in Sources */,
 				AABB0000000000000000D3AA /* CloudSyncOptInView.swift in Sources */,
+				AABB0000000000000000F5AA /* OnboardingScaffold.swift in Sources */,
 				AABB0000000000000000F3AA /* AddValueSheet.swift in Sources */,
 				AABB000000000000000060AA /* LabReport.swift in Sources */,
 				AABB000000000000000064AA /* HistoryView.swift in Sources */,

--- a/LabImporter/Views/CloudSyncOptInView.swift
+++ b/LabImporter/Views/CloudSyncOptInView.swift
@@ -36,19 +36,15 @@ struct CloudSyncOptInView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        OnboardingScaffold {
             hero
-            Spacer()
+        } card: {
             benefitCard
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-            Spacer()
-            privacyNote
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 32)
-                .padding(.bottom, 16)
-            buttons
+        } footer: {
+            VStack(spacing: 16) {
+                privacyNote
+                buttons
+            }
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -157,8 +153,6 @@ struct CloudSyncOptInView: View {
             .buttonStyle(.bordered)
             .controlSize(.large)
         }
-        .padding(.horizontal, 24)
-        .padding(.bottom, 48)
         .opacity(appeared ? 1 : 0)
     }
 }

--- a/LabImporter/Views/CloudSyncOptInView.swift
+++ b/LabImporter/Views/CloudSyncOptInView.swift
@@ -41,10 +41,7 @@ struct CloudSyncOptInView: View {
         } card: {
             benefitCard
         } footer: {
-            VStack(spacing: 16) {
-                privacyNote
-                buttons
-            }
+            footer
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -131,7 +128,14 @@ struct CloudSyncOptInView: View {
         .opacity(appeared ? 1 : 0)
     }
 
-    // MARK: - Buttons
+    // MARK: - Footer
+
+    private var footer: some View {
+        VStack(spacing: 16) {
+            privacyNote
+            buttons
+        }
+    }
 
     private var buttons: some View {
         VStack(spacing: 12) {

--- a/LabImporter/Views/DisclaimerView.swift
+++ b/LabImporter/Views/DisclaimerView.swift
@@ -39,7 +39,7 @@ struct DisclaimerView: View {
         } card: {
             pointCard
         } footer: {
-            continueButton
+            footer
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -110,9 +110,9 @@ struct DisclaimerView: View {
         )
     }
 
-    // MARK: - Button
+    // MARK: - Footer
 
-    private var continueButton: some View {
+    private var footer: some View {
         Button("I Understand", action: onAcknowledge)
             .buttonStyle(.borderedProminent)
             .controlSize(.large)

--- a/LabImporter/Views/DisclaimerView.swift
+++ b/LabImporter/Views/DisclaimerView.swift
@@ -34,14 +34,11 @@ struct DisclaimerView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        OnboardingScaffold {
             hero
-            Spacer()
+        } card: {
             pointCard
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-            Spacer()
+        } footer: {
             continueButton
         }
         .background { MorphingCategoryBackground() }
@@ -120,8 +117,6 @@ struct DisclaimerView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .frame(maxWidth: .infinity)
-            .padding(.horizontal, 24)
-            .padding(.bottom, 48)
             .opacity(appeared ? 1 : 0)
     }
 }

--- a/LabImporter/Views/HealthPermissionView.swift
+++ b/LabImporter/Views/HealthPermissionView.swift
@@ -34,19 +34,15 @@ struct HealthPermissionView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        OnboardingScaffold {
             hero
-            Spacer()
+        } card: {
             benefitCard
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-            Spacer()
-            privacyNote
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 32)
-                .padding(.bottom, 16)
-            continueButton
+        } footer: {
+            VStack(spacing: 16) {
+                privacyNote
+                continueButton
+            }
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -158,8 +154,7 @@ struct HealthPermissionView: View {
         .buttonStyle(.borderedProminent)
         .controlSize(.large)
         .disabled(isRequesting)
-        .padding(.horizontal, 24)
-        .padding(.bottom, 48)
+        .frame(maxWidth: .infinity)
         .opacity(appeared ? 1 : 0)
     }
 

--- a/LabImporter/Views/HealthPermissionView.swift
+++ b/LabImporter/Views/HealthPermissionView.swift
@@ -39,10 +39,7 @@ struct HealthPermissionView: View {
         } card: {
             benefitCard
         } footer: {
-            VStack(spacing: 16) {
-                privacyNote
-                continueButton
-            }
+            footer
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -135,7 +132,14 @@ struct HealthPermissionView: View {
         .opacity(appeared ? 1 : 0)
     }
 
-    // MARK: - Button
+    // MARK: - Footer
+
+    private var footer: some View {
+        VStack(spacing: 16) {
+            privacyNote
+            continueButton
+        }
+    }
 
     private var continueButton: some View {
         Button {
@@ -154,7 +158,6 @@ struct HealthPermissionView: View {
         .buttonStyle(.borderedProminent)
         .controlSize(.large)
         .disabled(isRequesting)
-        .frame(maxWidth: .infinity)
         .opacity(appeared ? 1 : 0)
     }
 

--- a/LabImporter/Views/OnboardingScaffold.swift
+++ b/LabImporter/Views/OnboardingScaffold.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// Shared adaptive layout for the full-screen onboarding steps (Welcome,
+/// Disclaimer, Health permission, iCloud sync, Unsupported device).
+///
+/// All of those screens are built from the same three pieces — a `hero`
+/// (large icon + title + subtitle), a `card` of feature/benefit rows, and a
+/// `footer` (optional note + action buttons). This container arranges them so
+/// they never clip:
+///
+/// - **Regular height** (portrait, and iPad in any orientation): the original
+///   single centred column — hero on top, card in the middle, footer pinned to
+///   the bottom.
+/// - **Compact height** (`verticalSizeClass == .compact`, i.e. iPhone
+///   landscape): a two-column split — the hero on the left, the card + footer
+///   on the right — so the short landscape height no longer squeezes the
+///   bottom button off-screen.
+///
+/// Both layouts fall back to scrolling when the content still doesn't fit, so
+/// even the smallest devices keep every control reachable. Entrance animations
+/// live in the slot views, so they keep working regardless of which layout is
+/// active.
+struct OnboardingScaffold<Hero: View, Card: View, Footer: View>: View {
+    private let hero: Hero
+    private let card: Card
+    private let footer: Footer
+
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+
+    init(
+        @ViewBuilder hero: () -> Hero,
+        @ViewBuilder card: () -> Card,
+        @ViewBuilder footer: () -> Footer = { EmptyView() }
+    ) {
+        self.hero = hero()
+        self.card = card()
+        self.footer = footer()
+    }
+
+    private var isCompactHeight: Bool { verticalSizeClass == .compact }
+
+    var body: some View {
+        if isCompactHeight {
+            landscapeLayout
+        } else {
+            portraitLayout
+        }
+    }
+
+    // MARK: - Portrait (regular height)
+
+    private var portraitLayout: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 16)
+            hero
+            Spacer(minLength: 16)
+            card
+                .frame(maxWidth: 480)
+                .padding(.horizontal, 24)
+            Spacer(minLength: 16)
+            footer
+                .frame(maxWidth: 480)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 48)
+        }
+    }
+
+    // MARK: - Landscape (compact height)
+
+    private var landscapeLayout: some View {
+        GeometryReader { proxy in
+            HStack(spacing: 0) {
+                column(centredIn: proxy.size.height) {
+                    hero
+                        .padding(.horizontal, 16)
+                }
+                column(centredIn: proxy.size.height) {
+                    VStack(spacing: 20) {
+                        card
+                        footer
+                    }
+                    .frame(maxWidth: 480)
+                    .padding(.horizontal, 24)
+                }
+            }
+        }
+    }
+
+    /// A scrolling half-width column whose content is vertically centred while
+    /// it fits, and scrolls once it doesn't.
+    private func column<Content: View>(
+        centredIn height: CGFloat,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            content()
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, minHeight: height)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/LabImporter/Views/OnboardingScaffold.swift
+++ b/LabImporter/Views/OnboardingScaffold.swift
@@ -50,18 +50,23 @@ struct OnboardingScaffold<Hero: View, Card: View, Footer: View>: View {
     // MARK: - Portrait (regular height)
 
     private var portraitLayout: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 16)
-            hero
-            Spacer(minLength: 16)
-            card
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-            Spacer(minLength: 16)
-            footer
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-                .padding(.bottom, 48)
+        GeometryReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 16)
+                    hero
+                    Spacer(minLength: 16)
+                    card
+                        .frame(maxWidth: 480)
+                        .padding(.horizontal, 24)
+                    Spacer(minLength: 16)
+                    footer
+                        .frame(maxWidth: 480)
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 48)
+                }
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
+            }
         }
     }
 

--- a/LabImporter/Views/UnsupportedDeviceView.swift
+++ b/LabImporter/Views/UnsupportedDeviceView.swift
@@ -22,9 +22,7 @@ enum DeviceSupport {
 
 struct UnsupportedDeviceView: View {
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-
+        OnboardingScaffold {
             VStack(spacing: 20) {
                 ZStack {
                     Circle()
@@ -47,9 +45,7 @@ struct UnsupportedDeviceView: View {
                 }
                 .padding(.horizontal, 32)
             }
-
-            Spacer()
-
+        } card: {
             VStack(alignment: .leading, spacing: 24) {
                 RequirementRow(
                     icon: "cpu",
@@ -64,11 +60,7 @@ struct UnsupportedDeviceView: View {
                     description: "Make sure your device is running iOS or iPadOS 26 or later."
                 )
             }
-            .padding(.horizontal, 32)
-
-            Spacer()
         }
-        .padding(.bottom, 48)
     }
 }
 

--- a/LabImporter/Views/UnsupportedDeviceView.swift
+++ b/LabImporter/Views/UnsupportedDeviceView.swift
@@ -21,71 +21,135 @@ enum DeviceSupport {
 }
 
 struct UnsupportedDeviceView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
+
+    private var requirements: [Requirement] {
+        [
+            Requirement(
+                icon: "cpu",
+                color: LabCategory.bloodGas.color,
+                title: "Apple Intelligence Device",
+                description: "An iPhone with A17 Pro or an iPad/Mac with Apple silicon (M1 or later) is required."
+            ),
+            Requirement(
+                icon: "arrow.up.circle",
+                color: LabCategory.hepatic.color,
+                title: "Latest OS",
+                description: "Make sure your device is running iOS or iPadOS 26 or later."
+            )
+        ]
+    }
+
     var body: some View {
         OnboardingScaffold {
-            VStack(spacing: 20) {
-                ZStack {
-                    Circle()
-                        .fill(Color.orange.opacity(0.13))
-                        .frame(width: 110, height: 110)
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 48))
-                        .foregroundStyle(.orange)
-                }
-
-                VStack(spacing: 8) {
-                    Text("Device Not Supported")
-                        .font(.largeTitle.bold())
-                        .multilineTextAlignment(.center)
-                    Text("LabImporter needs Apple Intelligence to read your lab reports privately on-device.")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .padding(.horizontal, 32)
-            }
+            hero
         } card: {
-            VStack(alignment: .leading, spacing: 24) {
-                RequirementRow(
-                    icon: "cpu",
-                    color: .blue,
-                    title: "Apple Intelligence Device",
-                    description: "An iPhone with A17 Pro or an iPad/Mac with Apple silicon (M1 or later) is required."
-                )
-                RequirementRow(
-                    icon: "arrow.up.circle",
-                    color: .green,
-                    title: "Latest OS",
-                    description: "Make sure your device is running iOS or iPadOS 26 or later."
-                )
+            requirementCard
+        }
+        .background { MorphingCategoryBackground() }
+        .onAppear {
+            guard !reduceMotion else { appeared = true; return }
+            withAnimation(.smooth(duration: 0.7)) { appeared = true }
+        }
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        VStack(spacing: 20) {
+            ZStack {
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [Color.orange.opacity(0.45), Color.orange.opacity(0)],
+                            center: .center,
+                            startRadius: 4,
+                            endRadius: 90
+                        )
+                    )
+                    .frame(width: 180, height: 180)
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 88, weight: .semibold))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, Color.orange.gradient)
+                    .shadow(color: .orange.opacity(0.35), radius: 18, x: 0, y: 8)
+            }
+            VStack(spacing: 6) {
+                Text("Device Not Supported")
+                    .font(.largeTitle.bold())
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .minimumScaleFactor(0.8)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("LabImporter needs Apple Intelligence to read your lab reports privately on-device.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 24)
+        }
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 16)
+    }
+
+    // MARK: - Requirement card
+
+    private var requirementCard: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            ForEach(Array(requirements.enumerated()), id: \.offset) { index, requirement in
+                RequirementRow(requirement: requirement)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 20)
+                    .animation(
+                        reduceMotion ? nil : .smooth(duration: 0.6).delay(0.15 + Double(index) * 0.08),
+                        value: appeared
+                    )
             }
         }
+        .padding(24)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 28))
+        .overlay(
+            RoundedRectangle(cornerRadius: 28)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
     }
 }
 
-// MARK: - Requirement row
+// MARK: - Requirement model & row
 
-private struct RequirementRow: View {
+private struct Requirement {
     let icon: String
     let color: Color
     let title: LocalizedStringKey
     let description: LocalizedStringKey
+}
+
+private struct RequirementRow: View {
+    let requirement: Requirement
 
     var body: some View {
         HStack(alignment: .center, spacing: 18) {
             ZStack {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(color.opacity(0.13))
+                    .fill(
+                        LinearGradient(
+                            colors: [requirement.color, requirement.color.opacity(0.7)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
                     .frame(width: 58, height: 58)
-                Image(systemName: icon)
+                    .shadow(color: requirement.color.opacity(0.35), radius: 6, x: 0, y: 3)
+                Image(systemName: requirement.icon)
                     .font(.title2)
-                    .foregroundStyle(color)
+                    .foregroundStyle(.white)
             }
             VStack(alignment: .leading, spacing: 3) {
-                Text(title)
+                Text(requirement.title)
                     .font(.body.bold())
-                Text(description)
+                Text(requirement.description)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/LabImporter/Views/WelcomeView.swift
+++ b/LabImporter/Views/WelcomeView.swift
@@ -36,14 +36,11 @@ struct WelcomeView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        OnboardingScaffold {
             hero
-            Spacer()
+        } card: {
             featureCard
-                .frame(maxWidth: 480)
-                .padding(.horizontal, 24)
-            Spacer()
+        } footer: {
             getStartedButton
         }
         .background { MorphingCategoryBackground() }
@@ -114,8 +111,6 @@ struct WelcomeView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
             .frame(maxWidth: .infinity)
-            .padding(.horizontal, 24)
-            .padding(.bottom, 48)
             .opacity(appeared ? 1 : 0)
     }
 }

--- a/LabImporter/Views/WelcomeView.swift
+++ b/LabImporter/Views/WelcomeView.swift
@@ -41,7 +41,7 @@ struct WelcomeView: View {
         } card: {
             featureCard
         } footer: {
-            getStartedButton
+            footer
         }
         .background { MorphingCategoryBackground() }
         .onAppear {
@@ -85,7 +85,7 @@ struct WelcomeView: View {
     // MARK: - Feature card
 
     private var featureCard: some View {
-        VStack(alignment: .leading, spacing: 26) {
+        VStack(alignment: .leading, spacing: 22) {
             ForEach(Array(features.enumerated()), id: \.offset) { index, feature in
                 FeatureRow(feature: feature)
                     .opacity(appeared ? 1 : 0)
@@ -104,9 +104,9 @@ struct WelcomeView: View {
         )
     }
 
-    // MARK: - Button
+    // MARK: - Footer
 
-    private var getStartedButton: some View {
+    private var footer: some View {
         Button("Get Started", action: onDismiss)
             .buttonStyle(.borderedProminent)
             .controlSize(.large)


### PR DESCRIPTION
## Summary

The onboarding screens (Welcome, Disclaimer, Device-not-supported, Health permission, iCloud sync) didn't lay out well on iPhone — content clipped in landscape, and the densest screen (iCloud) could overflow even in portrait on smaller viewports / larger Dynamic Type. This PR makes all of them adaptive and brings them onto one shared, consistent structure.

## What changed

**New `OnboardingScaffold`** — a shared adaptive container that every onboarding screen routes through:
- **Regular height** (portrait, iPad): the original centred single column — hero on top, card in the middle, footer pinned to the bottom.
- **Compact height** (iPhone landscape): a two-column split — hero on the left, card + footer on the right — so the short landscape height no longer pushes the action buttons off-screen.
- Both layouts fall back to scrolling (`GeometryReader` + min-height-equals-viewport) so nothing can clip on small devices or at large text sizes.

**Design-system alignment for `UnsupportedDeviceView`** — it was the one screen still on the old flat styling. It now matches its siblings: `MorphingCategoryBackground`, a radial-glow palette hero, a glass card with gradient icon tiles, and the same staggered entrance animation.

**Structural unification** — all five screens now share one skeleton: a `hero`, a `card`, and a single `footer` computed property fed to the scaffold, so every body reads `hero / card / footer` identically. Welcome's card row spacing was normalised (26 → 22) to match the others, and a redundant `maxWidth` frame on the Health button was removed.

**Pre-push hook fix** — the `.claude/settings.json` SwiftLint hook ran without `--config`, so it relied on the shell's working directory to discover `.swiftlint.yml`; from a subdirectory it fell back to SwiftLint's defaults and flagged many pre-existing files. It's now anchored to `$CLAUDE_PROJECT_DIR` with an explicit `--config`, so the local hook lints the same way CI does regardless of cwd.

## Commits
- Make onboarding screens adaptive in iPhone landscape
- Align UnsupportedDeviceView with onboarding design system
- Make onboarding portrait layout scroll when content overflows
- Unify structure across onboarding screens
- Fix pre-push SwiftLint hook to use project config

## Testing
- `swiftlint lint --strict` passes under the project config.
- ⚠️ Not built/run on device — this was developed in a Linux container with no Xcode/iOS SDK. Please verify the five screens in the Xcode previews in **portrait + landscape** and at a couple of **Dynamic Type** steps before merging. All `#Preview`s are intact.

https://claude.ai/code/session_01ScpJnix5JKNLFGwjPSRcUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScpJnix5JKNLFGwjPSRcUQ)_