### PR TITLE
Complete localization coverage for all supported languages

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1633,7 +1633,80 @@
       }
     },
     "An iPhone with A17 Pro or an iPad/Mac with Apple silicon (M1 or later) is required." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein iPhone mit A17 Pro oder ein iPad/Mac mit Apple Silicon (M1 oder neuer) ist erforderlich."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere un iPhone con A17 Pro o un iPad/Mac con chip Apple (M1 o posterior)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un iPhone équipé d’une puce A17 Pro ou un iPad/Mac doté d’une puce Apple (M1 ou ultérieure) est requis."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È necessario un iPhone con A17 Pro o un iPad/Mac con chip Apple (M1 o successivo)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A17 Proを搭載したiPhone、またはAppleシリコン（M1以降）を搭載したiPad/Macが必要です。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Een iPhone met A17 Pro of een iPad/Mac met Apple silicon (M1 of nieuwer) is vereist."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wymagany jest iPhone z chipem A17 Pro lub iPad/Mac z układem Apple silicon (M1 lub nowszym)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "É necessário um iPhone com A17 Pro ou um iPad/Mac com chip Apple (M1 ou posterior)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Требуется iPhone с чипом A17 Pro или iPad/Mac с чипом Apple (M1 или новее)."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A17 Pro çipli bir iPhone ya da Apple silikon (M1 veya üzeri) çipli bir iPad/Mac gerekir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потрібен iPhone з чипом A17 Pro або iPad/Mac з чипом Apple (M1 чи новішим)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要配备 A17 Pro 的 iPhone，或配备 Apple 芯片（M1 或更新机型）的 iPad/Mac。"
+          }
+        }
+      }
     },
     "An iPhone with an A17 Pro or M-series chip is required." : {
       "extractionState" : "stale",
@@ -1794,6 +1867,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ein anderer Wert verwendet denselben LOINC-Code – behalte nur einen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otro valor usa el mismo código LOINC — conserva solo uno"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une autre valeur utilise le même code LOINC — n’en gardez qu’une"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un altro valore usa lo stesso codice LOINC — tienine solo uno"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "別の値が同じLOINCコードを使用しています。1つだけ残してください"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Een andere waarde gebruikt dezelfde LOINC-code — houd er maar één"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inna wartość używa tego samego kodu LOINC — zachowaj tylko jedną"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outro valor usa o mesmo código LOINC — mantenha apenas um"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другое значение использует тот же код LOINC — оставьте только одно"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Başka bir değer aynı LOINC kodunu kullanıyor — yalnızca birini tutun"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Інше значення використовує той самий код LOINC — залиште лише одне"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "另一个数值使用了相同的 LOINC 代码，请只保留一个"
           }
         }
       }
@@ -5384,6 +5523,72 @@
             "state" : "translated",
             "value" : "Duplikat"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doublon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dubbel"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplikat"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дубликат"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yinelenen"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дублікат"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重复"
+          }
         }
       }
     },
@@ -7138,7 +7343,80 @@
       }
     },
     "Import Report" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bericht importieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar informe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer le rapport"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa referto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レポートを読み込む"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapport importeren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importuj raport"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar laudo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импортировать отчёт"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raporu içe aktar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Імпортувати звіт"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入报告"
+          }
+        }
+      }
     },
     "IMPORT REPORT" : {
       "localizations" : {
@@ -8588,7 +8866,80 @@
       }
     },
     "Latest OS" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neuestes Betriebssystem"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema operativo más reciente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernier système d’exploitation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema operativo più recente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新のOS"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nieuwste besturingssysteem"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Najnowszy system"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema operacional mais recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новейшая ОС"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En Son İşletim Sistemi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найновіша ОС"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新系统"
+          }
+        }
+      }
     },
     "Layout Only" : {
       "localizations" : {
@@ -9351,7 +9702,80 @@
       }
     },
     "Make sure your device is running iOS or iPadOS 26 or later." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stell sicher, dass auf deinem Gerät iOS oder iPadOS 26 oder neuer läuft."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asegúrate de que tu dispositivo tenga iOS o iPadOS 26 o posterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assurez-vous que votre appareil utilise iOS ou iPadOS 26 ou une version ultérieure."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assicurati che il tuo dispositivo abbia iOS o iPadOS 26 o successivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバイスがiOSまたはiPadOS 26以降で動作していることを確認してください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zorg ervoor dat je apparaat iOS of iPadOS 26 of nieuwer gebruikt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upewnij się, że na urządzeniu działa iOS lub iPadOS 26 albo nowszy."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifique se o seu dispositivo está com o iOS ou iPadOS 26 ou posterior."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убедитесь, что на устройстве установлена iOS или iPadOS 26 либо новее."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cihazınızın iOS ya da iPadOS 26 veya üstünü çalıştırdığından emin olun."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переконайтеся, що на пристрої встановлено iOS або iPadOS 26 чи новішу версію."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请确保你的设备运行 iOS 或 iPadOS 26 或更新版本。"
+          }
+        }
+      }
     },
     "Make sure your device is running the latest version of iOS." : {
       "extractionState" : "stale",
@@ -9811,7 +10235,80 @@
       }
     },
     "More" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Więcej"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ещё"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daha Fazla"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Більше"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
+          }
+        }
+      }
     },
     "Name" : {
       "localizations" : {
@@ -13931,6 +14428,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einige Tests kommen mehrfach vor. Behalte vor dem Speichern pro Test nur einen Wert."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algunas pruebas aparecen más de una vez. Conserva un solo valor por prueba antes de guardar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certains tests apparaissent plusieurs fois. Ne gardez qu’une valeur par test avant d’enregistrer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alcuni test compaiono più di una volta. Tieni un solo valore per test prima di salvare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部の検査が複数回表示されています。保存する前に、検査ごとに値を1つだけ残してください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sommige tests komen meer dan eens voor. Houd vóór het opslaan één waarde per test over."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niektóre badania pojawiają się więcej niż raz. Przed zapisaniem zachowaj jedną wartość na badanie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alguns exames aparecem mais de uma vez. Mantenha um valor por exame antes de salvar."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Некоторые анализы встречаются несколько раз. Перед сохранением оставьте по одному значению на анализ."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazı testler birden fazla kez görünüyor. Kaydetmeden önce her test için tek bir değer bırakın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деякі аналізи трапляються кілька разів. Перед збереженням залиште по одному значенню для кожного аналізу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分检验项目出现了多次。保存前请为每个项目仅保留一个数值。"
           }
         }
       }


### PR DESCRIPTION
## Summary

Audited `Localizable.xcstrings` for translation completeness across all 12 shipped target languages (de, es, fr, it, ja, nl, pl, pt-BR, ru, tr, uk, zh-Hans). Found and filled **8 user-facing strings** with incomplete coverage.

### Had no translations at all (5)
- `"An iPhone with A17 Pro or an iPad/Mac with Apple silicon (M1 or later) is required."` — `UnsupportedDeviceView`
- `"Make sure your device is running iOS or iPadOS 26 or later."` — `UnsupportedDeviceView`
- `"Latest OS"` — requirement-card title
- `"Import Report"` — the `+` button accessibility label in `HomeView`
- `"More"` — trends overflow menu label

### Translated into German only (3)
- `"Duplicate"` — duplicate badge in `LabValueRowView`
- `"Another value uses the same LOINC code — keep only one"` — row help text
- `"Some tests appear more than once. Keep one value per test before saving."` — review header

## Approach
- Added translations for all 12 target languages, reusing existing catalog terminology for consistency (e.g. the already-translated `IMPORT REPORT` strings, `Apple Intelligence Device`, the `An iPhone with an A17 Pro…` sibling).
- None of these strings reference the Health app, so the "Apple Health" localized-naming rules did not apply.

## Intentionally left alone
- `"%lld"` (auto-extracted from `Text("\(count)")` — a bare number) and `""` (empty-string artifact) need no translation.
- `Text(verbatim:)` strings (the `LabImporter` brand name, LOINC codes/version) are deliberately non-localized.

## Verification
- Re-audit confirms **0 real strings remain untranslated** in any language.
- JSON validates and `swiftlint lint --strict` passes.

https://claude.ai/code/session_01XvzwgcEbUet8koPbwgiBag

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvzwgcEbUet8koPbwgiBag)_