### PR TITLE
Share a common license screen and read app license from LICENSE file

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		AABB0000000000000000D1AA /* CloudSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000D0AA /* CloudSyncService.swift */; };
 		AABB000000000000000093AA /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000092AA /* libsqlite3.tbd */; };
 		AABB000000000000000095AA /* LoincBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000094AA /* LoincBrowserView.swift */; };
+		AABB0000000000000000A2AA /* LicenseDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000A1AA /* LicenseDocumentView.swift */; };
 		AABB000000000000000097AA /* LabCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000096AA /* LabCategory.swift */; };
 		AABB0000000000000000B1AA /* ReviewHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000B0AA /* ReviewHeaderCard.swift */; };
 		AABB0000000000000000C0AA /* MorphingCategoryBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */; };
@@ -99,6 +100,7 @@
 		AABB0000000000000000D0AA /* CloudSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncService.swift; sourceTree = "<group>"; };
 		AABB000000000000000092AA /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		AABB000000000000000094AA /* LoincBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoincBrowserView.swift; sourceTree = "<group>"; };
+		AABB0000000000000000A1AA /* LicenseDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseDocumentView.swift; sourceTree = "<group>"; };
 		AABB000000000000000096AA /* LabCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabCategory.swift; sourceTree = "<group>"; };
 		AABB0000000000000000B0AA /* ReviewHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewHeaderCard.swift; sourceTree = "<group>"; };
 		AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorphingCategoryBackground.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 				AABB000000000000000028AA /* LabValueRowView.swift */,
 				AABB0000000000000000C1DE /* CodePickerSheet.swift */,
 				AABB000000000000000094AA /* LoincBrowserView.swift */,
+				AABB0000000000000000A1AA /* LicenseDocumentView.swift */,
 				AABB000000000000000081AA /* DocumentScannerView.swift */,
 				AABB0000000000000000F2AA /* LabImportEngine.swift */,
 				AABB0000000000000000F4AA /* AddValueSheet.swift */,
@@ -244,6 +247,7 @@
 				AABB000000000000000017AA /* Frameworks */,
 				AABB000000000000000018AA /* Resources */,
 				AABB000000000000000089AA /* Generate LOINC resource */,
+				AABB0000000000000000A3AA /* Copy LICENSE */,
 				AABB000000000000000088AA /* Embed Git Branch */,
 			);
 			buildRules = (
@@ -316,6 +320,21 @@
 			shellPath = /bin/sh;
 			shellScript = "set -u\nINFO_PLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n[ -f \"$INFO_PLIST\" ] || exit 0\nBRANCH=$(cd \"${SRCROOT}\" && git rev-parse --abbrev-ref HEAD 2>/dev/null)\nCOMMIT=$(cd \"${SRCROOT}\" && git rev-parse --short HEAD 2>/dev/null)\n[ -n \"$BRANCH\" ] || BRANCH=unknown\n[ -n \"$COMMIT\" ] || COMMIT=unknown\n/usr/libexec/PlistBuddy -c \"Set :GitBranch $BRANCH\" \"$INFO_PLIST\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Add :GitBranch string $BRANCH\" \"$INFO_PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :GitCommit $COMMIT\" \"$INFO_PLIST\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Add :GitCommit string $COMMIT\" \"$INFO_PLIST\"\n";
 		};
+		AABB0000000000000000A3AA /* Copy LICENSE */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy LICENSE";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nRES_DIR=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\nSRC=\"${SRCROOT}/LICENSE\"\nif [ ! -f \"$SRC\" ]; then echo \"warning: no LICENSE file at $SRC\"; exit 0; fi\nmkdir -p \"$RES_DIR\"\ncp \"$SRC\" \"$RES_DIR/LICENSE\"\n";
+		};
 		AABB000000000000000089AA /* Generate LOINC resource */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -356,6 +375,7 @@
 				AABB000000000000000048AA /* LabValueRowView.swift in Sources */,
 				AABB0000000000000000C0DE /* CodePickerSheet.swift in Sources */,
 				AABB000000000000000095AA /* LoincBrowserView.swift in Sources */,
+				AABB0000000000000000A2AA /* LicenseDocumentView.swift in Sources */,
 				AABB000000000000000080AA /* DocumentScannerView.swift in Sources */,
 				AABB0000000000000000F1AA /* LabImportEngine.swift in Sources */,
 				636BA85E2FCC52EE006E8E71 /* HealthPermissionView.swift in Sources */,

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -15488,6 +15488,82 @@
         }
       }
     },
+    "The license is unavailable in this build." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Lizenztext ist in diesem Build nicht verfügbar."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La licencia no está disponible en esta compilación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La licence n'est pas disponible dans cette version."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La licenza non è disponibile in questa build."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このビルドではライセンスを利用できません。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De licentie is niet beschikbaar in deze build."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Licencja jest niedostępna w tej wersji."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A licença não está disponível nesta versão."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лицензия недоступна в этой сборке."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lisans bu derlemede kullanılamıyor."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ліцензія недоступна в цій збірці."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此版本中无法提供许可。"
+          }
+        }
+      }
+    },
     "The LOINC license is unavailable in this build." : {
       "localizations" : {
         "de" : {

--- a/LabImporter/Views/LicenseDocumentView.swift
+++ b/LabImporter/Views/LicenseDocumentView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+// MARK: - LicenseDocumentView
+
+/// Shared layout for the app's license screens. Renders a license document as a
+/// scrollable footnote with an optional bold header line (used by the LOINC
+/// screen to show the catalog version). Both `LicenseView` and `LoincLicenseView`
+/// build on this so the two screens stay visually identical and the styling
+/// lives in one place.
+struct LicenseDocumentView: View {
+    let title: LocalizedStringKey
+    /// An optional bold line shown above the body (e.g. `LOINC® 2.82`). Hidden
+    /// when `nil` or empty.
+    var header: String?
+    let text: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                if let header, !header.isEmpty {
+                    Text(verbatim: header)
+                        .font(.subheadline.weight(.semibold))
+                }
+                Text(text)
+                    .font(.footnote)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding()
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Document") {
+    NavigationStack {
+        LicenseDocumentView(title: "License", text: "MIT License\n\nCopyright (c) 2026 idoodler")
+    }
+}

--- a/LabImporter/Views/LoincBrowserView.swift
+++ b/LabImporter/Views/LoincBrowserView.swift
@@ -6,20 +6,12 @@ import SwiftUI
 /// requirement that the license travels with the LOINC data.
 struct LoincLicenseView: View {
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
-                if !LoincDirectory.shared.version.isEmpty {
-                    Text(verbatim: "LOINC® \(LoincDirectory.shared.version)")
-                        .font(.subheadline.weight(.semibold))
-                }
-                Text(licenseText)
-                    .font(.footnote)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding()
-        }
-        .navigationTitle("LOINC License")
-        .navigationBarTitleDisplayMode(.inline)
+        LicenseDocumentView(title: "LOINC License", header: header, text: licenseText)
+    }
+
+    private var header: String? {
+        let version = LoincDirectory.shared.version
+        return version.isEmpty ? nil : "LOINC® \(version)"
     }
 
     private var licenseText: String {

--- a/LabImporter/Views/SettingsView.swift
+++ b/LabImporter/Views/SettingsView.swift
@@ -15,6 +15,18 @@ enum AppInfo {
     static var branch: String { string("GitBranch") ?? "unknown" }
     static var commit: String { string("GitCommit") ?? "unknown" }
 
+    /// The app's license text, read from the `LICENSE` file copied into the
+    /// bundle at build time (see the "Copy LICENSE" build phase). This keeps the
+    /// single source of truth in the repo-root `LICENSE` rather than duplicating
+    /// it in source. Returns a short message if the file is missing.
+    static var licenseText: String {
+        guard let url = Bundle.main.url(forResource: "LICENSE", withExtension: nil),
+              let text = try? String(contentsOf: url, encoding: .utf8) else {
+            return String(localized: "The license is unavailable in this build.")
+        }
+        return text
+    }
+
     /// Web URL of the repository this build came from, stamped into `Info.plist`
     /// at build time (`GitRepositoryURL`) so forks open their own repo. Returns
     /// `nil` when the build did not stamp a URL (e.g. local Xcode builds), in
@@ -259,41 +271,11 @@ struct CodeName: Identifiable {
 
 // MARK: - LicenseView
 
+/// The app's MIT license, read from the bundled `LICENSE` file via `AppInfo`.
 struct LicenseView: View {
     var body: some View {
-        ScrollView {
-            Text(Self.licenseText)
-                .font(.footnote)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
-        }
-        .navigationTitle("License")
-        .navigationBarTitleDisplayMode(.inline)
+        LicenseDocumentView(title: "License", text: AppInfo.licenseText)
     }
-
-    private static let licenseText = """
-    MIT License
-
-    Copyright (c) 2026 idoodler
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy \
-    of this software and associated documentation files (the "Software"), to deal \
-    in the Software without restriction, including without limitation the rights \
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell \
-    copies of the Software, and to permit persons to whom the Software is \
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all \
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR \
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE \
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER \
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, \
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \
-    SOFTWARE.
-    """
 }
 
 // MARK: - Previews


### PR DESCRIPTION
## What & why

The app's MIT license text was duplicated — once in the repo-root `LICENSE` file and again hard-coded inside `LicenseView`. On top of that, the app-license and LOINC-license screens were two near-identical views. This PR removes the duplication and consolidates the layout.

## Changes

**1. New shared base — `Views/LicenseDocumentView.swift`**
A single reusable screen that renders a license as a scrollable footnote with an optional bold header line. Both license screens now build on it, so the layout (ScrollView, padding, fonts, nav title style) lives in one place.

**2. App license now reads from the bundled `LICENSE` file**
- `LicenseView` drops its hard-coded copy of the MIT text; it's now just `LicenseDocumentView(title: "License", text: AppInfo.licenseText)`.
- New `AppInfo.licenseText` reads the bundled `LICENSE` at runtime (localized fallback if missing).
- New **"Copy LICENSE"** Xcode build phase copies the repo-root `LICENSE` into the app bundle at build time — mirroring how the `loinc.db` resource is generated. The repo-root `LICENSE` stays the single source of truth.

**3. `LoincLicenseView` refactored onto the same base**
It passes its `LOINC® <version>` line as the base view's `header` and keeps loading its text from `loinc.db` as before.

**4. Project & localization wiring**
- Registered `LicenseDocumentView.swift` in the Xcode project (file reference, Views group, Sources phase).
- Added the `"The license is unavailable in this build."` fallback to `Localizable.xcstrings`, translated into all shipped languages to match the existing LOINC fallback.

## Verification

SwiftLint (`--strict`) passes on all touched Swift files and the `.xcstrings` JSON validates. A build wasn't possible in this environment (needs Xcode 26 / a supported device) — worth a quick Xcode build to confirm the bundled `LICENSE` reads correctly at runtime.

https://claude.ai/code/session_017PXYAmA2txYtk8DKSufham

---
_Generated by [Claude Code](https://claude.ai/code/session_017PXYAmA2txYtk8DKSufham)_