### PR TITLE
Import CDA documents directly (values, patient, lab/doctor)

### DIFF
--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -64,6 +64,18 @@
 				<string>com.adobe.pdf</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>CDA Lab Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -4,6 +4,234 @@
     "" : {
 
     },
+    "Importing lab document…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labordokument wird importiert…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importando documento de laboratorio…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation du document de laboratoire…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importazione del documento di laboratorio…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検査書類をインポート中…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labdocument importeren…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importowanie dokumentu laboratoryjnego…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importando documento laboratorial…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт лабораторного документа…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laboratuvar belgesi içe aktarılıyor…"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Імпорт лабораторного документа…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在导入检验文稿…"
+          }
+        }
+      }
+    },
+    "Reading values directly" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werte werden direkt gelesen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leyendo los valores directamente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture directe des valeurs"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura diretta dei valori"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数値を直接読み取り中"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waarden rechtstreeks lezen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bezpośrednie odczytywanie wartości"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lendo os valores diretamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прямое чтение значений"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değerler doğrudan okunuyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пряме читання значень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接读取数值"
+          }
+        }
+      }
+    },
+    "This file isn't a lab report this app can read. Choose a CDA document that contains lab results." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Datei ist kein Laborbericht, den diese App lesen kann. Wähle ein CDA-Dokument mit Laborwerten."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este archivo no es un informe de laboratorio que esta app pueda leer. Elige un documento CDA que contenga resultados de laboratorio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier n'est pas un rapport de laboratoire que cette app peut lire. Choisissez un document CDA contenant des résultats de laboratoire."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo file non è un referto di laboratorio leggibile da questa app. Scegli un documento CDA che contenga risultati di laboratorio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このファイルは、このAppが読み取れる検査結果ではありません。検査結果を含むCDA書類を選択してください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit bestand is geen labrapport dat deze app kan lezen. Kies een CDA-document met labresultaten."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten plik nie jest wynikiem badań, który ta aplikacja może odczytać. Wybierz dokument CDA zawierający wyniki badań."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este arquivo não é um laudo laboratorial que este app possa ler. Escolha um documento CDA que contenha resultados de laboratório."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот файл не является лабораторным отчётом, который может прочитать это приложение. Выберите документ CDA с результатами анализов."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu dosya, bu uygulamanın okuyabileceği bir laboratuvar raporu değil. Laboratuvar sonuçları içeren bir CDA belgesi seçin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цей файл не є лабораторним звітом, який може прочитати цей застосунок. Виберіть документ CDA з результатами аналізів."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件不是此 App 可读取的检验报告。请选择包含检验结果的 CDA 文稿。"
+          }
+        }
+      }
+    },
     "1Y" : {
       "comment" : "Segmented control: trend chart time window of one year",
       "localizations" : {

--- a/LabImporter/Services/HealthKitService.swift
+++ b/LabImporter/Services/HealthKitService.swift
@@ -260,9 +260,12 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
 
         let entries = delegate.observations.map { obs -> LabReport.Entry in
             // The stored code is the LOINC code itself; prefer our localized name,
-            // falling back to the display name carried in the CDA document.
+            // falling back to the display name carried in the CDA document, then to
+            // the raw code (an imported LOINC the catalog doesn't list still shows
+            // the code rather than a blank name, and stays manually re-mappable).
             let mappedName = LabMapping.displayName(for: obs.loinc)
-            let name = mappedName == obs.loinc ? obs.display : mappedName
+            let cdaName = obs.display.isEmpty ? obs.loinc : obs.display
+            let name = mappedName == obs.loinc ? cdaName : mappedName
             let display = obs.value.truncatingRemainder(dividingBy: 1) == 0
                 ? String(format: "%.0f", obs.value)
                 : String(format: "%.4g", obs.value)
@@ -314,8 +317,12 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
             obsLoinc = nil; obsDisplay = nil
             obsValue = nil; obsUnit = nil
 
-        case "code" where inObservation:
-            if attrs["codeSystem"] == "2.16.840.1.113883.6.1" {
+        // The observation's LOINC identity. We accept it from the primary <code>
+        // or, when that uses a local coding system, from a <translation> child —
+        // a common shape in lab-system CDAs. The primary LOINC wins (the guard
+        // keeps the first one seen, and the primary <code> is parsed first).
+        case "code" where inObservation, "translation" where inObservation:
+            if attrs["codeSystem"] == "2.16.840.1.113883.6.1", obsLoinc == nil {
                 obsLoinc = attrs["code"]
                 obsDisplay = attrs["displayName"]
             }
@@ -356,9 +363,12 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
             schemaVersion = Self.parseSchemaVersion(currentText)
 
         case "observation" where inObservation:
-            if let loinc = obsLoinc, let display = obsDisplay,
-               let value = obsValue, let unit = obsUnit {
-                observations.append(CDAObservation(loinc: loinc, display: display, value: value, unit: unit))
+            // A LOINC code is required — observations coded in any other system
+            // are skipped, since without LOINC the value can't be mapped or
+            // exported. The display name is optional: it's resolved from the
+            // bundled catalog (the CDA's own displayName is only a fallback).
+            if let loinc = obsLoinc, let value = obsValue, let unit = obsUnit {
+                observations.append(CDAObservation(loinc: loinc, display: obsDisplay ?? "", value: value, unit: unit))
             }
             inObservation = false
 

--- a/LabImporter/Services/HealthKitService.swift
+++ b/LabImporter/Services/HealthKitService.swift
@@ -226,8 +226,15 @@ private struct CDAObservation {
 private final class CDADocumentParser: NSObject, XMLParserDelegate {
 
     private var reportDate: Date?
+    // Patient name parts (CDA splits a person's name into given + family).
+    private var patientGiven: [String] = []
     private var patientFamily = ""
+    // The report's author/lab: an organization, an individual person (given +
+    // family), or — as a last resort — the document's custodian organization.
     private var authorOrg = ""
+    private var authorGiven: [String] = []
+    private var authorFamily = ""
+    private var custodianOrg = ""
     private var observations: [CDAObservation] = []
 
     private var elementStack: [String] = []
@@ -279,11 +286,32 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
             )
         }
 
+        // Join the patient's given name(s) + family into a full name. App-written
+        // exports store the whole name in <family> (no <given>), so this still
+        // yields exactly that; foreign CDAs that split the name are reassembled.
+        let patientName = (delegate.patientGiven + [delegate.patientFamily])
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        // The "Lab / Doctor" field: prefer the author organization, then a named
+        // author person, then the custodian organization.
+        let authorPerson = (delegate.authorGiven + [delegate.authorFamily])
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let authorName: String
+        if !delegate.authorOrg.isEmpty {
+            authorName = delegate.authorOrg
+        } else if !authorPerson.isEmpty {
+            authorName = authorPerson
+        } else {
+            authorName = delegate.custodianOrg
+        }
+
         let report = LabReport(
             id: id,
             date: date,
-            patientName: delegate.patientFamily,
-            authorName: delegate.authorOrg,
+            patientName: patientName,
+            authorName: authorName,
             entries: entries
         )
 
@@ -343,6 +371,30 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
         currentText += string
     }
 
+    /// Routes a person-name part (`<given>`/`<family>`) by its ancestor: the
+    /// patient lives under `<patientRole>`, a named author/doctor under
+    /// `<assignedAuthor>`. "Unknown" is the export's null placeholder, so skip it.
+    private func captureNamePart(_ element: String, ancestors: ArraySlice<String>, text: String) {
+        guard !text.isEmpty, text != "Unknown" else { return }
+        if ancestors.contains("patientRole") {
+            if element == "given" { patientGiven.append(text) } else { patientFamily = text }
+        } else if ancestors.contains("assignedAuthor") {
+            if element == "given" { authorGiven.append(text) } else { authorFamily = text }
+        }
+    }
+
+    /// Captures an organization name: the author's is the lab/doctor, the
+    /// custodian's a fallback. The "LabImporter" sentinel (this app's own
+    /// custodian/author stamp) is ignored so it never surfaces as a real lab name.
+    private func captureOrganizationName(ancestors: ArraySlice<String>, text: String) {
+        guard !text.isEmpty, text != "LabImporter" else { return }
+        if ancestors.contains("author"), ancestors.contains("representedOrganization") {
+            authorOrg = text
+        } else if ancestors.contains("representedCustodianOrganization") {
+            custodianOrg = text
+        }
+    }
+
     func parser(_ parser: XMLParser, didEndElement element: String,
                 namespaceURI: String?, qualifiedName: String?) {
         defer {
@@ -350,14 +402,15 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
             currentText = ""
         }
 
-        switch element {
-        case "family" where elementStack.dropLast().contains("patientRole"):
-            let trimmed = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty && trimmed != "Unknown" { patientFamily = trimmed }
+        let ancestors = elementStack.dropLast()
+        let trimmedText = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        case "name" where elementStack.dropLast().contains("representedOrganization"):
-            let trimmed = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty && trimmed != "LabImporter" { authorOrg = trimmed }
+        switch element {
+        case "given", "family":
+            captureNamePart(element, ancestors: ancestors, text: trimmedText)
+
+        case "name":
+            captureOrganizationName(ancestors: ancestors, text: trimmedText)
 
         case "softwareName":
             schemaVersion = Self.parseSchemaVersion(currentText)

--- a/LabImporter/Services/HealthKitService.swift
+++ b/LabImporter/Services/HealthKitService.swift
@@ -101,6 +101,20 @@ actor HealthKitService {
         }
     }
 
+    // MARK: - File import
+
+    /// Reconstructs a `LabReport` from a CDA document supplied as a file the user
+    /// explicitly chose to import (Files / share sheet), reading its values
+    /// structurally — no OCR and no on-device AI. Unlike Health read-back
+    /// (`loadCDADocuments`), an explicitly imported file is accepted even when it
+    /// carries no recognized LabImporter schema version: foreign or legacy C-CDA
+    /// lab reports have no migration history to honor, and the user deliberately
+    /// picked this file, so there's no implicit-migration concern. Returns `nil`
+    /// when the data isn't a parseable CDA lab document.
+    nonisolated static func report(fromCDAFileData data: Data) -> LabReport? {
+        CDADocumentParser.parse(data: data, id: UUID(), allowUnversioned: true)
+    }
+
     // MARK: - Characteristics
 
     struct PatientCharacteristics {
@@ -231,7 +245,12 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
     /// versioning, which are ignored on read-back.
     private var schemaVersion: Int?
 
-    static func parse(data: Data, id: UUID) -> LabReport? {
+    /// - Parameter allowUnversioned: when `true`, a document that carries no
+    ///   recognized LabImporter schema version is still accepted (parsed as-is)
+    ///   rather than dropped. Used for explicit file imports — see
+    ///   `HealthKitService.report(fromCDAFileData:)`. Health read-back leaves it
+    ///   `false`, preserving the "ignore unversioned legacy exports" invariant.
+    static func parse(data: Data, id: UUID, allowUnversioned: Bool = false) -> LabReport? {
         let delegate = CDADocumentParser()
         let parser = XMLParser(data: data)
         parser.delegate = delegate
@@ -265,8 +284,13 @@ private final class CDADocumentParser: NSObject, XMLParserDelegate {
             entries: entries
         )
 
-        // Ignore documents with no recognized version, and upgrade older ones to
-        // the current schema (no-op today). Returns nil → the sample is skipped.
+        // An explicitly imported file with no version stamp (a foreign or legacy
+        // C-CDA) has no migration history to honor and was deliberately chosen by
+        // the user, so take it as-is. Health read-back keeps `allowUnversioned`
+        // false: unversioned documents are skipped and versioned ones migrated.
+        if delegate.schemaVersion == nil && allowUnversioned {
+            return report
+        }
         return CDAMigrator.upgrade(report, fromSchemaVersion: delegate.schemaVersion)
     }
 

--- a/LabImporter/Views/Import/LabImportEngine.swift
+++ b/LabImporter/Views/Import/LabImportEngine.swift
@@ -72,11 +72,17 @@ final class LabImportEngine {
             removeInboxCopy(at: url)
         }
 
-        let isPDF = url.pathExtension.lowercased() == "pdf"
-            || (try? url.resourceValues(forKeys: [.contentTypeKey]).contentType?.conforms(to: .pdf)) == true
+        let contentType = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType
+        let ext = url.pathExtension.lowercased()
+        let isPDF = ext == "pdf" || contentType?.conforms(to: .pdf) == true
+        // A CDA document is XML; recognize it by extension or UTType so it's read
+        // structurally rather than (mis)handed to OCR + the AI parse.
+        let isCDA = ["xml", "cda", "ccda"].contains(ext) || contentType?.conforms(to: .xml) == true
 
         if isPDF {
             await processPDF(at: url)
+        } else if isCDA {
+            await processCDA(at: url)
         } else if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
             await processImages([image])
         } else {
@@ -135,6 +141,38 @@ final class LabImportEngine {
         }
     }
 
+    /// Imports a CDA (clinical document) file directly: its observations are
+    /// structured data, so they're read straight into `LabValue`s — no OCR, no
+    /// on-device AI. The resolved LOINC codes are authoritative (not fuzzy name
+    /// matches), so the values arrive confident rather than flagged as suggestions.
+    private func processCDA(at url: URL) async {
+        phase = .importingDocument
+        isProcessing = true
+        defer { isProcessing = false }
+
+        guard let data = try? Data(contentsOf: url) else {
+            errorMessage = String(localized: "Could not load the selected file.")
+            return
+        }
+        guard let report = HealthKitService.report(fromCDAFileData: data) else {
+            errorMessage = String(localized: "This file isn't a lab report this app can read. Choose a CDA document that contains lab results.")
+            return
+        }
+
+        // Collapse any duplicate-LOINC rows defensively, mirroring the AI path.
+        let values = report.asLabValues.deduplicatedByLoinc()
+        if values.isEmpty {
+            errorMessage = emptyMessage
+            return
+        }
+        onParsed?(ParseResult(
+            values: values,
+            reportDate: report.date,
+            patientName: report.patientName.isEmpty ? nil : report.patientName,
+            authorName: report.authorName.isEmpty ? nil : report.authorName
+        ))
+    }
+
     private func handleExtractedText(_ text: String) async throws {
         // Text is in hand; the remaining (and longest) work is the AI parse.
         phase = .analyzing
@@ -156,6 +194,16 @@ final class LabImportEngine {
 private struct LabImportModifier: ViewModifier {
     @Bindable var engine: LabImportEngine
 
+    /// File types the importer accepts: scanned/photographed reports (image, PDF)
+    /// plus CDA clinical documents (XML), which are read structurally. `.cda` /
+    /// `.ccda` extensions are included explicitly so files that the system doesn't
+    /// type as `public.xml` still appear in the picker.
+    static let importableTypes: [UTType] = {
+        var types: [UTType] = [.pdf, .image, .xml]
+        types += ["cda", "ccda"].compactMap { UTType(filenameExtension: $0) }
+        return types
+    }()
+
     func body(content: Content) -> some View {
         content
             .fullScreenCover(isPresented: $engine.showScanner) {
@@ -171,7 +219,7 @@ private struct LabImportModifier: ViewModifier {
             }
             .fileImporter(
                 isPresented: $engine.showFileImporter,
-                allowedContentTypes: [.pdf, .image],
+                allowedContentTypes: Self.importableTypes,
                 allowsMultipleSelection: false
             ) { result in
                 switch result {
@@ -332,11 +380,15 @@ extension View {
 enum ImportPhase: CaseIterable {
     case extractingText
     case analyzing
+    /// A CDA file is structured data, so there's no OCR or AI step — its values
+    /// are read straight in. This phase labels that direct import.
+    case importingDocument
 
     var title: LocalizedStringKey {
         switch self {
         case .extractingText: "Reading document…"
         case .analyzing: "Analyzing lab report…"
+        case .importingDocument: "Importing lab document…"
         }
     }
 
@@ -344,6 +396,7 @@ enum ImportPhase: CaseIterable {
         switch self {
         case .extractingText: "Extracting text on device"
         case .analyzing: "Using on-device AI"
+        case .importingDocument: "Reading values directly"
         }
     }
 
@@ -351,6 +404,7 @@ enum ImportPhase: CaseIterable {
         switch self {
         case .extractingText: "doc.text.viewfinder"
         case .analyzing: "sparkles"
+        case .importingDocument: "doc.badge.arrow.up"
         }
     }
 
@@ -358,6 +412,7 @@ enum ImportPhase: CaseIterable {
         switch self {
         case .extractingText: 0.45
         case .analyzing: 0.9
+        case .importingDocument: 0.9
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a direct **CDA (clinical document) import** path. A `.xml` / `.cda` / `.ccda` file picked via the file importer or share sheet is now read **structurally** straight into `LabValue`s — no OCR and no on-device AI. Previously such a file couldn't even be selected, and if forced through it was misrouted to OCR + the model (failing to load as an image).

## What's included

**1. Direct CDA file import**
- New `HealthKitService.report(fromCDAFileData:)` reconstructs a `LabReport` from explicitly imported file data via the existing `CDADocumentParser`.
- `LabImportEngine.processFile` detects XML/CDA (by extension or `UTType.xml`) and routes it to a new `processCDA` path *before* the image fallback. The result flows through `onParsed` → `HomeView` → Review exactly like the scan/AI path.
- The file importer and `Info.plist` `CFBundleDocumentTypes` now accept `public.xml` (`.xml` / `.cda` / `.ccda`).
- New `ImportPhase.importingDocument` labels the direct (no-AI) import in the HUD; new HUD strings + the unreadable-file error are localized into all 12 shipped languages.
- An explicitly imported file is accepted even when it carries no LabImporter schema version (foreign/legacy C-CDA), via an `allowUnversioned` flag. Health read-back keeps its "ignore unversioned legacy exports" invariant unchanged.

**2. LOINC requirement for mapping**
- An observation imports **only** when it carries a LOINC code, so `LabMapping` / display / export work — observations coded in any other system are skipped.
- Robust LOINC capture for real-world CDAs: accept LOINC from a `<translation>` child when the primary `<code>` uses a local coding system (primary LOINC wins); no longer require the `displayName` attribute (the name is resolved from the bundled catalog, falling back to the CDA display, then the raw code).

**3. Patient and lab/doctor import**
- Patient: combine `<given>` name(s) + `<family>` into a full name (was family only). App exports store the whole name in `<family>`, so they round-trip unchanged; foreign CDAs that split the name are reassembled.
- Lab/Doctor: prefer the author's `<representedOrganization>`, then a named author person (`<assignedAuthor>` given+family), then the custodian organization (`<representedCustodianOrganization>`). The `LabImporter` sentinel stamp is still ignored.
- These surface as the Review screen's existing "Detected in report" suggestions, like the OCR/AI path; empty values never overwrite user input.

## Compatibility notes

- The parser is shared with Health read-back, but all changes are backward-compatible: the app's own exports always carry a LOINC primary `<code>` + `displayName`, a `<family>` full name, and an author `<representedOrganization>`, so their behavior is unchanged. The new branches only add capture for foreign/edge documents.
- Name/org parsing is routed by ancestor element and factored into helpers to stay within the SwiftLint complexity limit.

## Testing

SwiftLint `--strict` passes. There's no Swift toolchain in the web environment (iOS-only project) and no test suite, so this was **not** verified by building or running. Recommend exercising the import flow on a supported device with both a LabImporter-exported CDA and a real lab CDA before merge.

https://claude.ai/code/session_01TPvowRHFYd6MtY35ss2xA6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPvowRHFYd6MtY35ss2xA6)_