### PR TITLE
Match report detail menu button style to TrendView

### DIFF
--- a/LabImporter/Views/History/ReportDetailView.swift
+++ b/LabImporter/Views/History/ReportDetailView.swift
@@ -51,7 +51,7 @@ struct ReportDetailView: View {
                         Label("Delete", systemImage: "trash")
                     }
                 } label: {
-                    Image(systemName: "ellipsis.circle")
+                    Label("More", systemImage: "ellipsis")
                 }
             }
         }


### PR DESCRIPTION
## Summary

The "more" toolbar button in `ReportDetailView` rendered with a circle around it (`ellipsis.circle`), inconsistent with the equivalent button in `TrendsView`, which uses a plain ellipsis.

This change updates the `ReportDetailView` menu label to use `Label("More", systemImage: "ellipsis")` — matching `TrendsView.moreMenu` exactly — so the button now appears as a plain ellipsis with no surrounding circle.

## Changes
- `ReportDetailView.swift`: `Image(systemName: "ellipsis.circle")` → `Label("More", systemImage: "ellipsis")`

The `"More"` string is already present in `Localizable.xcstrings` (used by `TrendsView`), so no new strings were needed. `swiftlint lint --strict` passes.

https://claude.ai/code/session_01UsrdWgZESb48XqacrsuNb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsrdWgZESb48XqacrsuNb3)_