### PR TITLE
Polish LOINC detail screen with category background and clearer custom name

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -3470,6 +3470,82 @@
         }
       }
     },
+    "Custom name" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigener Name"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre personalizado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom personnalisé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome personalizzato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム名"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aangepaste naam"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nazwa niestandardowa"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome personalizado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Своё название"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özel ad"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Власна назва"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义名称"
+          }
+        }
+      }
+    },
     "Component" : {
       "localizations" : {
         "de" : {

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -105,18 +105,17 @@ struct LoincTermDetailView: View {
     @State private var renamingCode: String?
     @State private var renameDraft = ""
 
+    // The clinical category drives the accent color used for the header icon,
+    // the category chip and the background wash — the same palette charts use.
+    private var category: LabCategory { LabCategory.forCode(term.code) }
+
     var body: some View {
         List {
             Section {
-                Text(detail?.name ?? term.name).font(.headline)
-                if let custom = prefs.customName(for: term.code) {
-                    Label(custom, systemImage: "pencil")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                if let description = detail?.description ?? term.description, !description.isEmpty {
-                    Text(description).foregroundStyle(.secondary)
-                }
+                headerCard
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
             }
             if let detail {
                 Section("Details") {
@@ -130,11 +129,13 @@ struct LoincTermDetailView: View {
                     attribute("Class", detail.loincClass)
                     attribute("Status", detail.status)
                 }
+                .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                 Section {
                     attribute("Long name", detail.longName)
                     attribute("Short name", detail.shortName)
                     attribute("Units", detail.ucum)
                 }
+                .listRowBackground(Rectangle().fill(.ultraThinMaterial))
             }
             if let url = LabMapping.loincURL(for: term.code) {
                 Section {
@@ -146,8 +147,12 @@ struct LoincTermDetailView: View {
                 } footer: {
                     Text("Opens the full description and references on loinc.org.")
                 }
+                .listRowBackground(Rectangle().fill(.ultraThinMaterial))
             }
         }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background { CategoryBackground(colors: [category.color]) }
         .navigationTitle(Text(verbatim: term.code))
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -165,6 +170,93 @@ struct LoincTermDetailView: View {
         .sheet(item: $browserURL) { item in
             SafariView(url: item.url)
                 .ignoresSafeArea()
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [category.color, category.color.opacity(0.65)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                    Image(systemName: "testtube.2")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                .frame(width: 54, height: 54)
+                .shadow(color: category.color.opacity(0.35), radius: 5, x: 0, y: 2)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(detail?.name ?? term.name)
+                        .font(.headline)
+                    categoryChip
+                }
+                Spacer(minLength: 0)
+            }
+
+            if let custom = prefs.customName(for: term.code) {
+                Divider()
+                customNameRow(custom)
+            }
+
+            if let description = detail?.description ?? term.description, !description.isEmpty {
+                Divider()
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22))
+        .overlay(
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+        )
+    }
+
+    private var categoryChip: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(category.color)
+                .frame(width: 8, height: 8)
+            Text(category.displayName)
+                .font(.caption.weight(.medium))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(category.color.opacity(0.12), in: Capsule())
+        .overlay(
+            Capsule().stroke(category.color.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+
+    // The user's own name for this test, shown as a plainly-labelled read-only
+    // field (renaming happens via the toolbar) — a "tag" glyph, not a pencil, so
+    // it never reads as an inline edit button.
+    private func customNameRow(_ name: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "tag.fill")
+                .font(.subheadline)
+                .foregroundStyle(category.color)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Custom name")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                Text(name)
+                    .font(.subheadline.weight(.medium))
+            }
+            Spacer(minLength: 0)
         }
     }
 


### PR DESCRIPTION
## Summary

Restyles the LOINC term detail screen (`LoincTermDetailView`) to match the app's report-detail aesthetic, fixes a misleading affordance, and tints the screen with the term's clinical category color.

### Changes
- **Removed the misleading pencil glyph.** The custom name was rendered as `Label(custom, systemImage: "pencil")`, which looked like a tappable "edit this name" control. It's now a clearly labelled, read-only field — a `tag.fill` glyph in the category color, an uppercased **"Custom name"** caption, and the value beneath. Renaming still lives in the top-right toolbar where it belongs.
- **Added the category background gradient.** The screen derives the term's clinical category via `LabCategory.forCode(term.code)` and paints the shared `CategoryBackground(colors: [category.color])` behind the list (`scrollContentBackground(.hidden)`) — the same wash used on the Dashboard and report-detail screens.
- **Restyled the layout** to match `ReportDetailView`:
  - A material header card (rounded 22pt, hairline stroke) with a gradient-filled circular `testtube.2` icon in the category color, the long name as the headline, and a category chip underneath.
  - Description and custom-name rows sit inside that card, cleanly divided.
  - The Details / names / loinc.org sections use `.ultraThinMaterial` row backgrounds so they float over the gradient.

### Localization
- Added a new `"Custom name"` key to `Localizable.xcstrings`, translated across all 12 shipped languages. The category chip and other strings were already localized.

### Testing
- `swiftlint lint --strict` passes (0 violations).
- No test suite exists and the Foundation Models build requires Xcode on a supported device, so verify the look via the `#Preview "Term Detail"` / simulator.

https://claude.ai/code/session_01FsggPGdPsrJZvW7j3FPNcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsggPGdPsrJZvW7j3FPNcy)_