### PR TITLE
Auto-focus lab test search and restyle pickers + Add Value sheet

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -2783,6 +2783,82 @@
         }
       }
     },
+    "Choose a lab test" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Labortest auswählen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir una prueba de laboratorio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir une analyse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli un test di laboratorio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検査項目を選択"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kies een labtest"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz badanie laboratoryjne"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolher um exame laboratorial"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите анализ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir laboratuvar testi seçin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть лабораторний тест"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择检验项目"
+          }
+        }
+      }
+    },
     "Choose a short name to show everywhere instead of “%@”." : {
       "localizations" : {
         "de" : {
@@ -10087,6 +10163,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匹配项"
+          }
+        }
+      }
+    },
+    "Measurement" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messwert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medición"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mesure"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Misurazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測定値"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meting"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pomiar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medição"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Измерение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ölçüm"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вимірювання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "测量值"
           }
         }
       }

--- a/LabImporter/Models/LabCategory.swift
+++ b/LabImporter/Models/LabCategory.swift
@@ -67,10 +67,35 @@ enum LabCategory: String, CaseIterable, Sendable {
     }
 
     /// Best-effort category for a LOINC code, resolved via the bundled catalog.
+    ///
+    /// Codes repeat heavily across the UI (every dashboard card, history row and
+    /// search result re-derives a category from the same handful of codes), and
+    /// each miss costs a SQLite lookup in `LoincDirectory`, so the resolved
+    /// category is memoized. The cache is guarded by a lock because `forCode` is
+    /// called from both the main actor (view bodies) and background search tasks.
     static func forCode(_ code: String) -> LabCategory {
-        guard let info = LoincDirectory.shared.classification(for: code) else { return .other }
-        return category(loincClass: info.loincClass, component: info.component)
+        cacheLock.lock()
+        if let cached = cache[code] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let resolved: LabCategory
+        if let info = LoincDirectory.shared.classification(for: code) {
+            resolved = category(loincClass: info.loincClass, component: info.component)
+        } else {
+            resolved = .other
+        }
+
+        cacheLock.lock()
+        cache[code] = resolved
+        cacheLock.unlock()
+        return resolved
     }
+
+    private static let cacheLock = NSLock()
+    nonisolated(unsafe) private static var cache: [String: LabCategory] = [:]
 
     // swiftlint:disable:next cyclomatic_complexity
     static func category(loincClass: String, component: String) -> LabCategory {

--- a/LabImporter/Views/Review/AddValueSheet.swift
+++ b/LabImporter/Views/Review/AddValueSheet.swift
@@ -17,30 +17,41 @@ struct AddValueSheet: View {
             Form {
                 Section {
                     // A LOINC code must be chosen first — every value is LOINC-based,
-                    // so the picker drives the name and the canonical unit. The name
-                    // is shown read-only (the user's alias when set, else the catalog
-                    // name); renaming lives in Sort & Visibility, not here.
+                    // so the picker drives the name and the canonical unit. The chosen
+                    // test is shown as a rich, category-tinted row (the user's alias
+                    // when set, else the catalog name); renaming lives in Sort &
+                    // Visibility, not here.
                     NavigationLink {
                         AddCodePickerPage(code: $code, name: $name)
                     } label: {
-                        HStack {
-                            Text("Lab Test")
-                            Spacer()
-                            Text(code.isEmpty ? "Required" : code)
-                                .foregroundStyle(code.isEmpty ? .secondary : .primary)
-                        }
+                        testRow
                     }
-                    if !code.isEmpty {
-                        LabeledContent("Name", value: LabMapping.displayName(for: code))
-                    }
+                    .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                 }
                 Section {
-                    TextField("Value", text: $displayValue)
-                        .keyboardType(.decimalPad)
-                    TextField("Unit (optional)", text: $unit)
-                        .autocorrectionDisabled()
+                    HStack(spacing: 12) {
+                        Image(systemName: "number")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(accent)
+                            .frame(width: 24)
+                        TextField("Value", text: $displayValue)
+                            .keyboardType(.decimalPad)
+                    }
+                    HStack(spacing: 12) {
+                        Image(systemName: "ruler")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(accent)
+                            .frame(width: 24)
+                        TextField("Unit (optional)", text: $unit)
+                            .autocorrectionDisabled()
+                    }
+                } header: {
+                    Text("Measurement")
                 }
+                .listRowBackground(Rectangle().fill(.ultraThinMaterial))
             }
+            .scrollContentBackground(.hidden)
+            .background { CategoryBackground(colors: backgroundColors) }
             .navigationTitle("Add Value")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -57,6 +68,68 @@ struct AddValueSheet: View {
                 fillUnit(for: newCode)
             }
         }
+    }
+
+    // MARK: - Test row
+
+    /// The chosen lab test, or a prompt to pick one — a category-tinted icon with
+    /// the resolved name and a category chip, matching the term-detail and history
+    /// rows so a test reads the same everywhere.
+    private var testRow: some View {
+        HStack(spacing: 14) {
+            CategoryIcon(color: accent, size: 44)
+            VStack(alignment: .leading, spacing: 4) {
+                if code.isEmpty {
+                    Text("Choose a lab test")
+                        .font(.headline)
+                    Text("Required")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(LabMapping.displayName(for: code))
+                        .font(.headline)
+                        .lineLimit(2)
+                    HStack(spacing: 8) {
+                        if let category {
+                            categoryChip(category)
+                        }
+                        Text(code)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .textCase(.uppercase)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func categoryChip(_ category: LabCategory) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(category.color)
+                .frame(width: 7, height: 7)
+            Text(category.displayName)
+                .font(.caption2.weight(.medium))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(category.color.opacity(0.12), in: Capsule())
+        .overlay(Capsule().stroke(category.color.opacity(0.25), lineWidth: 0.5))
+    }
+
+    // The chosen test's clinical category (nil until a code is picked) drives the
+    // icon tint, the chip and the background wash.
+    private var category: LabCategory? {
+        code.isEmpty ? nil : LabCategory.forCode(code)
+    }
+
+    private var accent: Color {
+        category?.color ?? .accentColor
+    }
+
+    private var backgroundColors: [Color] {
+        category.map { [$0.color] } ?? []
     }
 
     /// Prefills the unit from the LOINC catalog's example UCUM unit when a lab

--- a/LabImporter/Views/Review/AddValueSheet.swift
+++ b/LabImporter/Views/Review/AddValueSheet.swift
@@ -77,15 +77,17 @@ struct AddValueSheet: View {
     /// rows so a test reads the same everywhere.
     private var testRow: some View {
         HStack(spacing: 14) {
-            CategoryIcon(color: accent, size: 44)
-            VStack(alignment: .leading, spacing: 4) {
-                if code.isEmpty {
+            if code.isEmpty {
+                placeholderIcon
+                VStack(alignment: .leading, spacing: 5) {
                     Text("Choose a lab test")
                         .font(.headline)
-                    Text("Required")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
+                        .foregroundStyle(Color.accentColor)
+                    requiredBadge
+                }
+            } else {
+                CategoryIcon(color: accent, size: 44)
+                VStack(alignment: .leading, spacing: 4) {
                     Text(LabMapping.displayName(for: code))
                         .font(.headline)
                         .lineLimit(2)
@@ -102,6 +104,34 @@ struct AddValueSheet: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    /// Empty-state glyph — a dashed ring around a magnifying glass, deliberately
+    /// unlike the filled `CategoryIcon` disc so the row clearly reads as "nothing
+    /// picked yet" rather than an already-chosen test.
+    private var placeholderIcon: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(
+                    Color.accentColor.opacity(0.5),
+                    style: StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+                )
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+        }
+        .frame(width: 44, height: 44)
+    }
+
+    private var requiredBadge: some View {
+        Text("Required")
+            .font(.caption2.weight(.semibold))
+            .textCase(.uppercase)
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Color.accentColor.opacity(0.12), in: Capsule())
+            .overlay(Capsule().stroke(Color.accentColor.opacity(0.25), lineWidth: 0.5))
     }
 
     private func categoryChip(_ category: LabCategory) -> some View {

--- a/LabImporter/Views/Review/CodePickerSheet.swift
+++ b/LabImporter/Views/Review/CodePickerSheet.swift
@@ -26,6 +26,7 @@ private struct LabTestPickerList: View {
 
     @State private var query = ""
     @State private var loincResults: [LoincTerm] = []
+    @FocusState private var searchFocused: Bool
 
     var body: some View {
         List {
@@ -50,6 +51,8 @@ private struct LabTestPickerList: View {
             }
         }
         .searchable(text: $query, prompt: Text("Search lab tests"))
+        .searchFocused($searchFocused)
+        .onAppear { searchFocused = true }
         .task(id: query) {
             let current = query
             let found = await Task.detached(priority: .userInitiated) { () -> [LoincTerm] in

--- a/LabImporter/Views/Review/CodePickerSheet.swift
+++ b/LabImporter/Views/Review/CodePickerSheet.swift
@@ -26,6 +26,7 @@ private struct LabTestPickerList: View {
 
     @State private var query = ""
     @State private var loincResults: [LoincTerm] = []
+    @State private var backgroundColors: [Color] = []
     @FocusState private var searchFocused: Bool
 
     var body: some View {
@@ -72,16 +73,20 @@ private struct LabTestPickerList: View {
                 var seen = Set(aliasHits.map(\.code))
                 return aliasHits + catalog.filter { seen.insert($0.code).inserted }
             }.value
-            if current == query { loincResults = found }
+            if current == query {
+                loincResults = found
+                backgroundColors = Self.washColors(for: found)
+            }
         }
     }
 
     // Up to three distinct category colors from the current results, mirroring the
-    // Dashboard/History wash so the picker shares the app's color system.
-    private var backgroundColors: [Color] {
+    // Dashboard/History wash so the picker shares the app's color system. Computed
+    // once per result set (not on every body pass) and stored in `backgroundColors`.
+    private static func washColors(for terms: [LoincTerm]) -> [Color] {
         var seen = Set<LabCategory>()
         var result: [Color] = []
-        for term in loincResults {
+        for term in terms {
             let category = LabCategory.forCode(term.code)
             if seen.insert(category).inserted { result.append(category.color) }
             if result.count == 3 { break }

--- a/LabImporter/Views/Review/CodePickerSheet.swift
+++ b/LabImporter/Views/Review/CodePickerSheet.swift
@@ -41,6 +41,7 @@ private struct LabTestPickerList: View {
                         subtitle: alias != nil ? term.name : term.description) {
                         select(term.code, alias ?? term.name)
                     }
+                    .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                 }
             } header: {
                 if query.isEmpty {
@@ -48,6 +49,14 @@ private struct LabTestPickerList: View {
                 } else {
                     Text("Matches")
                 }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background { CategoryBackground(colors: backgroundColors) }
+        .overlay {
+            if loincResults.isEmpty && !query.isEmpty {
+                ContentUnavailableView.search(text: query)
             }
         }
         .searchable(text: $query, prompt: Text("Search lab tests"))
@@ -67,9 +76,26 @@ private struct LabTestPickerList: View {
         }
     }
 
+    // Up to three distinct category colors from the current results, mirroring the
+    // Dashboard/History wash so the picker shares the app's color system.
+    private var backgroundColors: [Color] {
+        var seen = Set<LabCategory>()
+        var result: [Color] = []
+        for term in loincResults {
+            let category = LabCategory.forCode(term.code)
+            if seen.insert(category).inserted { result.append(category.color) }
+            if result.count == 3 { break }
+        }
+        return result
+    }
+
     private func row(rowCode: String, title: String, subtitle: String?, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack {
+        let category = LabCategory.forCode(rowCode)
+        let isSelected = code.uppercased() == rowCode.uppercased()
+        return Button(action: action) {
+            HStack(spacing: 14) {
+                CategoryIcon(color: category.color)
+
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                     if let subtitle, !subtitle.isEmpty {
@@ -83,12 +109,14 @@ private struct LabTestPickerList: View {
                         .foregroundStyle(.tertiary)
                         .textCase(.uppercase)
                 }
-                Spacer()
-                if code.uppercased() == rowCode.uppercased() {
+                Spacer(minLength: 0)
+                if isSelected {
                     Image(systemName: "checkmark")
-                        .foregroundStyle(Color.accentColor)
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(category.color)
                 }
             }
+            .padding(.vertical, 2)
         }
         .foregroundStyle(.primary)
     }
@@ -99,6 +127,34 @@ private struct LabTestPickerList: View {
             name = newName
         }
         onSelect()
+    }
+}
+
+// MARK: - CategoryIcon
+
+/// A category-tinted gradient disc with a test-tube glyph — the same rounded,
+/// shadowed icon used by `LoincTermDetailView`'s header and the History rows, so
+/// lab tests read consistently wherever they're listed.
+struct CategoryIcon: View {
+    let color: Color
+    var size: CGFloat = 38
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [color, color.opacity(0.65)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Image(systemName: "testtube.2")
+                .font(.system(size: size * 0.42, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .frame(width: size, height: size)
+        .shadow(color: color.opacity(0.35), radius: 4, x: 0, y: 2)
     }
 }
 

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -28,6 +28,7 @@ struct LoincCatalogView: View {
     @State private var query = ""
     @State private var results: [LoincTerm] = []
     @State private var reachedEnd = false
+    @FocusState private var searchFocused: Bool
 
     private let pageSize = 100
 
@@ -56,6 +57,8 @@ struct LoincCatalogView: View {
             }
         }
         .searchable(text: $query, prompt: Text("Search lab tests"))
+        .searchFocused($searchFocused)
+        .onAppear { searchFocused = true }
         .navigationTitle("LOINC catalog")
         .navigationBarTitleDisplayMode(.inline)
         .overlay {

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -35,27 +35,37 @@ struct LoincCatalogView: View {
     var body: some View {
         List {
             ForEach(results) { term in
+                let category = LabCategory.forCode(term.code)
                 NavigationLink {
                     LoincTermDetailView(term: term)
                 } label: {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(term.name)
-                        if let description = term.description, !description.isEmpty {
-                            Text(description)
+                    HStack(spacing: 14) {
+                        CategoryIcon(color: category.color)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(term.name)
+                            if let description = term.description, !description.isEmpty {
+                                Text(description)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                            Text(term.code)
                                 .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
+                                .foregroundStyle(.tertiary)
                         }
-                        Text(term.code)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
                     }
+                    .padding(.vertical, 2)
                 }
+                .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                 .onAppear {
                     if term.id == results.last?.id { loadMore() }
                 }
             }
         }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background { CategoryBackground(colors: backgroundColors) }
         .searchable(text: $query, prompt: Text("Search lab tests"))
         .searchFocused($searchFocused)
         .onAppear { searchFocused = true }
@@ -67,6 +77,19 @@ struct LoincCatalogView: View {
             }
         }
         .task(id: query) { await reload() }
+    }
+
+    // Up to three distinct category colors from the loaded terms — the same
+    // background wash the Dashboard and History screens use.
+    private var backgroundColors: [Color] {
+        var seen = Set<LabCategory>()
+        var result: [Color] = []
+        for term in results {
+            let category = LabCategory.forCode(term.code)
+            if seen.insert(category).inserted { result.append(category.color) }
+            if result.count == 3 { break }
+        }
+        return result
     }
 
     private func reload() async {

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -28,6 +28,7 @@ struct LoincCatalogView: View {
     @State private var query = ""
     @State private var results: [LoincTerm] = []
     @State private var reachedEnd = false
+    @State private var backgroundColors: [Color] = []
     @FocusState private var searchFocused: Bool
 
     private let pageSize = 100
@@ -80,11 +81,12 @@ struct LoincCatalogView: View {
     }
 
     // Up to three distinct category colors from the loaded terms — the same
-    // background wash the Dashboard and History screens use.
-    private var backgroundColors: [Color] {
+    // background wash the Dashboard and History screens use. Recomputed only when
+    // the result set changes (reload / loadMore), not on every body pass.
+    private static func washColors(for terms: [LoincTerm]) -> [Color] {
         var seen = Set<LabCategory>()
         var result: [Color] = []
-        for term in results {
+        for term in terms {
             let category = LabCategory.forCode(term.code)
             if seen.insert(category).inserted { result.append(category.color) }
             if result.count == 3 { break }
@@ -100,6 +102,7 @@ struct LoincCatalogView: View {
         }.value
         guard current == query else { return }
         results = page
+        backgroundColors = Self.washColors(for: page)
         reachedEnd = page.count < size
     }
 
@@ -114,6 +117,11 @@ struct LoincCatalogView: View {
             }.value
             guard current == query, offset == results.count else { return }
             results.append(contentsOf: page)
+            // The wash only needs three distinct colors; once it has them, later
+            // pages can't change it, so skip the rescan in the common case.
+            if backgroundColors.count < 3 {
+                backgroundColors = Self.washColors(for: results)
+            }
             reachedEnd = page.count < size
         }
     }


### PR DESCRIPTION
## What & why

The lab test search screens opened without focus (extra tap to start typing) and looked plain next to the rest of the app. This brings them — and the manual **Add Value** sheet — in line with the app's design system, and tightens the per-row category lookups they rely on.

## Changes

**Keyboard focus**
- Both lab test search screens (`LabTestPickerList` behind `CodePickerSheet`/`AddCodePickerPage`, and `LoincCatalogView`) now auto-focus the search field and raise the keyboard on appear via the iOS 18+ `searchFocused(_:)` modifier.

**Restyle to match the app (Dashboard/History/term-detail look)**
- Soft `CategoryBackground` wash (up to three distinct clinical-category colors from the visible results) behind a hidden scroll background.
- Glass (`.ultraThinMaterial`) rows, inset-grouped lists.
- A shared `CategoryIcon` — the category-tinted gradient test-tube disc — per row, plus category-colored selection checkmarks and `ContentUnavailableView.search` empty states.
- **Add Value sheet**: category wash + glass rows, a rich category-tinted header row (icon + name + category chip + code) that folds in the previously separate read-only Name row, and Value/Unit fields with leading glyphs under a *Measurement* section. The empty state reads clearly as unfilled — a dashed-ring magnifying glass with an accent-colored prompt and a *Required* badge — rather than an already-chosen test.

**Performance**
- Memoized `LabCategory.forCode` behind a lock so repeated code→category lookups (every dashboard card, history row, and search result) skip the SQLite query after the first; the bundled LOINC catalog is static, so the mapping never changes within a run.
- Compute each screen's background wash once per result set into `@State` instead of on every view body pass; the catalog browser skips the rescan once it has three distinct colors.

**Localization**
- Added `Measurement` and `Choose a lab test` across all 12 shipped languages.

## Notes
- No tests exist in the project; `swiftlint lint --strict` passes on all changed files. I could not compile against the iOS 26 SDK in this environment, so a build + quick on-device pass through the import/review flow is worth doing before merge — particularly the glass rows over the wash and the focus-on-appear timing (if the keyboard ever doesn't pop reliably on device, deferring the focus by one runloop tick is the usual fix).

https://claude.ai/code/session_01AAy4aqxtbc2ZvbRH67GFuF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAy4aqxtbc2ZvbRH67GFuF)_