### PR TITLE
Fix MorphingCategoryBackground not filling its container

### DIFF
--- a/LabImporter/Views/Shared/MorphingCategoryBackground.swift
+++ b/LabImporter/Views/Shared/MorphingCategoryBackground.swift
@@ -44,37 +44,33 @@ struct MorphingCategoryBackground: View {
         .init(0, 1), .init(0.5, 1), .init(1, 1)
     ]
 
-    /// Radius of the softening blur. The mesh is drawn larger than the canvas by
-    /// a comfortable multiple of this so the blur's faded edges fall outside the
-    /// visible area (see `body`).
+    /// Radius of the softening blur. The mesh is over-drawn past the canvas by a
+    /// comfortable multiple of this (via negative padding) so the blur's faded
+    /// edges fall outside the visible area (see `mesh(at:)`).
     private let blurRadius: CGFloat = 60
 
     var body: some View {
-        GeometryReader { proxy in
-            let size = proxy.size
-            ZStack {
-                Color(.systemBackground)
-                if reduceMotion {
-                    mesh(at: 0)
-                } else {
-                    TimelineView(.animation) { context in
-                        mesh(at: context.date.timeIntervalSinceReferenceDate)
+        // Fill exactly like `CategoryBackground`: a flexible view that bleeds
+        // into the safe area. Deliberately *no* `GeometryReader`/fixed frame —
+        // when used as a `.background`, the proxy reports the safe-area-inset
+        // size, and pinning the mesh to it (then `.ignoresSafeArea()`) can't
+        // bleed an already-fixed frame, which left a margin around the wash.
+        // Instead the mesh is over-drawn and clipped back to the bounds.
+        Color(.systemBackground)
+            .overlay {
+                Group {
+                    if reduceMotion {
+                        mesh(at: 0)
+                    } else {
+                        TimelineView(.animation) { context in
+                            mesh(at: context.date.timeIntervalSinceReferenceDate)
+                        }
                     }
                 }
+                .clipped()
             }
-            // Draw the gradient larger than the canvas on every side, then clip
-            // back to it. Blurring a gradient fades its edges toward transparent;
-            // pushing those edges well beyond the visible bounds means only the
-            // fully-saturated interior shows, so the wash reaches every edge.
-            .frame(
-                width: size.width + blurRadius * 4,
-                height: size.height + blurRadius * 4
-            )
-            .frame(width: size.width, height: size.height)
-            .clipped()
-        }
-        .ignoresSafeArea()
-        .allowsHitTesting(false)
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
     }
 
     private func mesh(at time: TimeInterval) -> some View {
@@ -84,6 +80,11 @@ struct MorphingCategoryBackground: View {
             points: Self.points,
             colors: (0..<9).map { color(forVertex: $0, time: time) }
         )
+        // Over-draw the mesh beyond the visible bounds (negative padding) so
+        // that, once blurred, its edges fade toward transparent *outside* the
+        // clip — only the fully-saturated interior shows and the wash reaches
+        // every edge.
+        .padding(-blurRadius * 2)
         // A wide blur melts the nine color zones into one another so the result
         // reads as an organic wash rather than a visible grid.
         .blur(radius: blurRadius)


### PR DESCRIPTION
## Problem

`MorphingCategoryBackground` left a margin around its wash, whereas the Dashboard's `CategoryBackground` fills its container edge-to-edge — even though both are applied the same way (`.background { … }`).

## Root cause

`MorphingCategoryBackground` wrapped its mesh in a `GeometryReader` and pinned it to a fixed `.frame(width: proxy.size.width, height: proxy.size.height)`. When a view is used as a `.background`, the geometry proxy reports the **safe-area-inset** size of the host, so the mesh was hard-sized to that smaller rect. The trailing `.ignoresSafeArea()` cannot bleed a frame that's already fixed, leaving a gutter exactly the size of the safe-area insets (notch / home-indicator) — the "padding" that was visible.

`CategoryBackground` works because it is a *flexible* `ZStack` of gradients + `.ignoresSafeArea()`, and flexible content bleeds out to cover the whole screen.

## Fix

Rebuilt `MorphingCategoryBackground` to mirror `CategoryBackground`'s flexible approach — no `GeometryReader`, no measured frame:

- A flexible `Color(.systemBackground)` overlaid with the mesh, bleeding via `.ignoresSafeArea()`.
- The blur's faded edges (previously hidden by the over-sized measured frame) are now pushed outside the visible bounds with `.padding(-blurRadius * 2)` and clipped back, so the fully-saturated interior reaches every edge.

Reduce Motion path and animation behavior are unchanged. SwiftLint passes; doc comments updated to match.

## Verification

Verified the layout reasoning statically. There are no tests in this project, so confirm visually by building in Xcode on a supported device (onboarding / import screens).

https://claude.ai/code/session_013jC1HfkHVGqhEhm2Rm1SJy

---
_Generated by [Claude Code](https://claude.ai/code/session_013jC1HfkHVGqhEhm2Rm1SJy)_