### PR TITLE
Fix TestFlight builds reporting as App Store in the build-info card

### DIFF
--- a/LabImporter/Views/Settings/BuildInfoCard.swift
+++ b/LabImporter/Views/Settings/BuildInfoCard.swift
@@ -1,4 +1,3 @@
-import StoreKit
 import SwiftUI
 import UIKit
 
@@ -17,12 +16,6 @@ extension AppInfo {
         case simulator
     }
 
-    /// A build's provenance plus, when knowable on device, when it stops working.
-    struct Installation: Sendable {
-        let kind: InstallKind
-        let expirationDate: Date?
-    }
-
     /// The app's primary icon, loaded from the asset catalog at runtime so the
     /// build-info card can show it. Prefers the generated icon-file names Xcode
     /// injects into `CFBundleIcons` in the built `Info.plist`, then the asset name.
@@ -38,51 +31,51 @@ extension AppInfo {
         return UIImage(named: "AppIcon")
     }
 
-    /// Resolves where this build came from and, when it's knowable on device, when
-    /// it stops working:
-    /// - development / ad-hoc builds expire with their embedded provisioning
-    ///   profile (`ExpirationDate`);
-    /// - TestFlight builds expire 90 days after they were built;
-    /// - App Store builds don't expire.
-    static func installation() async -> Installation {
-        let kind = await installKind()
-        let expiration: Date?
-        switch kind {
-        case .development:
-            expiration = provisioningProfileExpiration()
-        case .testFlight:
-            expiration = buildDate.flatMap { Calendar.current.date(byAdding: .day, value: 90, to: $0) }
-        case .appStore, .simulator:
-            expiration = nil
-        }
-        return Installation(kind: kind, expirationDate: expiration)
-    }
-
     /// Where this build came from. Order matters: a build carrying an embedded
     /// provisioning profile (development / ad-hoc) is reported as `.development`
-    /// even though it may also report a sandbox StoreKit environment.
-    ///
-    /// The App Store vs TestFlight distinction comes from StoreKit's
-    /// `AppTransaction` environment — the modern replacement for the deprecated
-    /// `Bundle.main.appStoreReceiptURL` sandbox-receipt check. We only read the
-    /// environment, so the unverified payload is enough.
-    private static func installKind() async -> InstallKind {
+    /// before the receipt is consulted.
+    static var installKind: InstallKind {
         #if targetEnvironment(simulator)
         return .simulator
         #else
         if provisioningProfileExpiration() != nil {
             return .development
         }
-        guard let result = try? await AppTransaction.shared else {
-            return .appStore
-        }
-        switch result.unsafePayloadValue.environment {
-        case .sandbox:
-            return .testFlight
-        default:
-            return .appStore
-        }
+        return hasSandboxReceipt ? .testFlight : .appStore
         #endif
+    }
+
+    /// The date this build stops working, when that is knowable on device:
+    /// - development / ad-hoc builds expire with their embedded provisioning
+    ///   profile (`ExpirationDate`);
+    /// - TestFlight builds expire 90 days after they were built.
+    /// App Store builds don't expire, so this is `nil` for them.
+    static var expirationDate: Date? {
+        switch installKind {
+        case .development:
+            return provisioningProfileExpiration()
+        case .testFlight:
+            return buildDate.flatMap { Calendar.current.date(byAdding: .day, value: 90, to: $0) }
+        case .appStore, .simulator:
+            return nil
+        }
+    }
+
+    /// Whether the bundle carries a TestFlight / App Store *sandbox* receipt —
+    /// the reliable, offline, prompt-free signal that this is a TestFlight build.
+    ///
+    /// `appStoreReceiptURL` was deprecated in iOS 18 in favour of StoreKit's
+    /// `AppTransaction`, but that API isn't readable synchronously and proved
+    /// unreliable here (it throws before the app transaction is cached and then
+    /// falls back to App Store, so TestFlight mis-reads as App Store). We keep the
+    /// receipt check and read it inside a deprecated-scoped helper so the warning
+    /// stays contained rather than leaking into the build.
+    private static var hasSandboxReceipt: Bool {
+        @available(iOS, deprecated: 18.0, message: "appStoreReceiptURL is intentional: the reliable TestFlight signal.")
+        func receiptName() -> String? {
+            Bundle.main.appStoreReceiptURL?.lastPathComponent
+        }
+        return receiptName() == "sandboxReceipt"
     }
 
     /// Best-effort build timestamp: the modification date of the main executable,
@@ -123,10 +116,6 @@ extension AppInfo {
 /// of the review and history headers, and computes everything on device (no
 /// network), matching the app's no-server design.
 struct BuildInfoCard: View {
-    /// Resolved asynchronously (the App Store / TestFlight split needs StoreKit's
-    /// `AppTransaction`); the badge and expiry appear once it's known.
-    @State private var installation: AppInfo.Installation?
-
     private var displayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
@@ -150,7 +139,7 @@ struct BuildInfoCard: View {
                     Text("Version \(AppInfo.version) (\(AppInfo.build))")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    if let expiry = installation?.expirationDate {
+                    if let expiry = AppInfo.expirationDate {
                         Label {
                             Text("Expires \(expiry.formatted(date: .abbreviated, time: .omitted))")
                         } icon: {
@@ -163,9 +152,7 @@ struct BuildInfoCard: View {
 
                 Spacer(minLength: 8)
 
-                if let kind = installation?.kind {
-                    buildTypeBadge(kind)
-                }
+                buildTypeBadge
             }
 
             if hasGitInfo {
@@ -184,11 +171,6 @@ struct BuildInfoCard: View {
             RoundedRectangle(cornerRadius: 20)
                 .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
         )
-        .task {
-            if installation == nil {
-                installation = await AppInfo.installation()
-            }
-        }
     }
 
     /// A compact key/value line for the source strip — a glyph + label on the
@@ -237,8 +219,8 @@ struct BuildInfoCard: View {
         }
     }
 
-    @ViewBuilder private func buildTypeBadge(_ kind: AppInfo.InstallKind) -> some View {
-        switch kind {
+    @ViewBuilder private var buildTypeBadge: some View {
+        switch AppInfo.installKind {
         case .appStore: badge("App Store", color: .blue)
         case .testFlight: badge("TestFlight", color: .indigo)
         case .development: badge("Development", color: .orange)


### PR DESCRIPTION
## Summary

Fixes TestFlight builds showing the **App Store** badge in the Settings build-info card.

## Cause

The detection used StoreKit's `AppTransaction.shared`, which **throws before the app transaction is cached** (it can need a network refresh). The `try?` swallowed that into a fallback of `.appStore`, so TestFlight read as App Store.

## Fix

Switch back to the **sandbox receipt check** (`appStoreReceiptURL.lastPathComponent == "sandboxReceipt"`) — the reliable, offline, prompt-free TestFlight signal.

- `appStoreReceiptURL` was deprecated in iOS 18, so it's read inside a **deprecated-scoped nested helper** (`@available(iOS, deprecated: 18.0)`) to keep the warning contained rather than leaking into the build.
- Detection is **synchronous again**: removed the StoreKit import, the `Installation` struct, the view's `@State`, and the `.task`, so the badge/expiry render immediately with no async pop-in.

## Verification

- `swiftlint lint --strict` clean.
- ⚠️ Not compiled against the iOS SDK here — worth confirming in Xcode that (a) TestFlight now shows the TestFlight badge and (b) the deprecated-scoped helper fully silences the iOS 18 warning on your toolchain.

https://claude.ai/code/session_01TYo4ZKJhnLAdJ2zz1vBdnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYo4ZKJhnLAdJ2zz1vBdnR)_