### PR TITLE
Disclose nickname iCloud sync + rename "custom name" to "Nickname"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ LabImporter/
 │   ├── LabValue.swift          # editable in-memory value (used in Review flow)
 │   ├── LabReport.swift         # a saved report (Codable); .asLabValues bridges to LabValue
 │   ├── LabMapping.swift        # thin catalog adapter: LOINC code ↔ display name ↔ CDA export / loinc.org URL
-│   └── LabDisplayPreferences.swift  # pinned/ordered/hidden + custom per-code names (RawRepresentable for @AppStorage)
+│   └── LabDisplayPreferences.swift  # pinned/ordered/hidden + per-code nicknames (RawRepresentable for @AppStorage)
 ├── Services/
 │   ├── OCRService.swift        # actor; Vision text recognition + PDFKit rendering
 │   ├── LabParserService.swift  # actor; Foundation Models @Generable structured parse
@@ -92,10 +92,11 @@ Config.xcconfig  # BUNDLE_IDENTIFIER = dev.idoodler.$(DEVELOPMENT_TEAM).labimpor
   `CodePickerSheet`).
 - **`LabMapping`** is a thin, data-driven adapter over `LoincDirectory` (no curated
   tables of its own):
-  - `displayName(for:)` — the user's custom name for a code if they set one (in
+  - `displayName(for:)` — the user's nickname for a code if they set one (in
     Sort & Visibility), else the localized catalog name, else the raw code. The
-    custom name is a cosmetic display preference (`LabDisplayPreferences.customNames`,
-    synced via iCloud) — it never reaches the exported CDA.
+    nickname is a cosmetic display preference (`LabDisplayPreferences.nicknames`,
+    persisted under the legacy JSON key `customNames`, synced via iCloud) — it
+    never reaches the exported CDA.
   - `loincCode(for:)` — validates the code + returns an English display for CDA
     export; **returns nil → value is not exportable** (unknown/unmapped code).
   - `loincURL(for:)` — the loinc.org details page for a code.

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -3158,78 +3158,78 @@
         }
       }
     },
-    "Choose a short name to show everywhere instead of “%@”." : {
+    "Choose a nickname to show everywhere instead of “%@”." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wähle einen Kurznamen, der überall anstelle von „%@“ angezeigt wird."
+            "value" : "Wähle einen Spitznamen, der überall anstelle von „%@“ angezeigt wird."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elige un nombre corto que se mostrará en todas partes en lugar de «%@»."
+            "value" : "Elige un apodo que se mostrará en todas partes en lugar de «%@»."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Choisissez un nom court à afficher partout à la place de « %@ »."
+            "value" : "Choisissez un surnom à afficher partout à la place de « %@ »."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scegli un nome breve da mostrare ovunque al posto di “%@”."
+            "value" : "Scegli un soprannome da mostrare ovunque al posto di “%@”."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "「%@」の代わりにどこでも表示する短い名前を選んでください。"
+            "value" : "「%@」の代わりにどこでも表示するニックネームを選んでください。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kies een korte naam die overal wordt getoond in plaats van ‘%@’."
+            "value" : "Kies een bijnaam die overal wordt getoond in plaats van ‘%@’."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wybierz krótką nazwę wyświetlaną wszędzie zamiast „%@”."
+            "value" : "Wybierz pseudonim wyświetlany wszędzie zamiast „%@”."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Escolha um nome curto para mostrar em todos os lugares no lugar de “%@”."
+            "value" : "Escolha um apelido para mostrar em todos os lugares no lugar de “%@”."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Выберите короткое название, которое будет отображаться везде вместо «%@»."
+            "value" : "Выберите псевдоним, который будет отображаться везде вместо «%@»."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Her yerde “%@” yerine gösterilecek kısa bir ad seçin."
+            "value" : "Her yerde “%@” yerine gösterilecek bir takma ad seçin."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Виберіть коротку назву, яка відображатиметься всюди замість «%@»."
+            "value" : "Виберіть псевдонім, який відображатиметься всюди замість «%@»."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择一个简短名称，在所有位置代替“%@”显示。"
+            "value" : "选择一个昵称，在所有位置代替“%@”显示。"
           }
         }
       }
@@ -4379,78 +4379,78 @@
         }
       }
     },
-    "Custom name" : {
+    "Nickname" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eigener Name"
+            "value" : "Spitzname"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nombre personalizado"
+            "value" : "Apodo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nom personnalisé"
+            "value" : "Surnom"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nome personalizzato"
+            "value" : "Soprannome"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "カスタム名"
+            "value" : "ニックネーム"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aangepaste naam"
+            "value" : "Bijnaam"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nazwa niestandardowa"
+            "value" : "Pseudonim"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nome personalizado"
+            "value" : "Apelido"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Своё название"
+            "value" : "Псевдоним"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Özel ad"
+            "value" : "Takma Ad"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Власна назва"
+            "value" : "Псевдонім"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义名称"
+            "value" : "昵称"
           }
         }
       }
@@ -12141,78 +12141,78 @@
         }
       }
     },
-    "Only your card layout and the names you give your lab tests sync. Your lab values stay in Apple Health and never leave it." : {
+    "Only your card layout and the nicknames you give your lab tests sync. Your lab values stay in Apple Health and never leave it." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nur dein Karten-Layout und die Namen, die du deinen Labortests gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
+            "value" : "Nur dein Karten-Layout und die Spitznamen, die du deinen Labortests gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo se sincronizan el diseño de tus tarjetas y los nombres que asignas a tus análisis. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
+            "value" : "Solo se sincronizan el diseño de tus tarjetas y los apodos que asignas a tus análisis. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seuls la disposition de vos cartes et les noms que vous donnez à vos analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
+            "value" : "Seuls la disposition de vos cartes et les surnoms que vous donnez à vos analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si sincronizzano solo il layout delle schede e i nomi che assegni alle tue analisi. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
+            "value" : "Si sincronizzano solo il layout delle schede e i soprannomi che assegni alle tue analisi. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同期されるのはカードのレイアウトと、検査項目に付けた名前だけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
+            "value" : "同期されるのはカードのレイアウトと、検査項目に付けたニックネームだけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen je kaartindeling en de namen die je je labtests geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
+            "value" : "Alleen je kaartindeling en de bijnamen die je je labtests geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizowane są tylko układ kart i nazwy, które nadajesz swoim badaniom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
+            "value" : "Synchronizowane są tylko układ kart i pseudonimy, które nadajesz swoim badaniom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apenas o layout dos seus cartões e os nomes que você dá aos seus exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
+            "value" : "Apenas o layout dos seus cartões e os apelidos que você dá aos seus exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируются только оформление карточек и названия, которые вы даёте своим анализам. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
+            "value" : "Синхронизируются только оформление карточек и псевдонимы, которые вы даёте своим анализам. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yalnızca kart düzeniniz ve tahlillerinize verdiğiniz adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
+            "value" : "Yalnızca kart düzeniniz ve tahlillerinize verdiğiniz takma adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізуються лише вигляд карток і назви, які ви даєте своїм аналізам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
+            "value" : "Синхронізуються лише вигляд карток і псевдоніми, які ви даєте своїм аналізам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只有卡片布局和你为检验项目设置的名称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
+            "value" : "只有卡片布局和你为检验项目设置的昵称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
           }
         }
       }
@@ -15871,78 +15871,78 @@
         }
       }
     },
-    "Sync your dashboard layout — the card order, what you pin and hide, and your custom names — across your devices. Your lab values stay in Apple Health." : {
+    "Sync your dashboard layout — the card order, what you pin and hide, and your nicknames — across your devices. Your lab values stay in Apple Health." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronisiere dein Dashboard-Layout – die Kartenreihenfolge, was du anheftest und ausblendest, sowie deine eigenen Namen – über deine Geräte hinweg. Deine Laborwerte bleiben in Apple Health."
+            "value" : "Synchronisiere dein Dashboard-Layout – die Kartenreihenfolge, was du anheftest und ausblendest, sowie deine Spitznamen – über deine Geräte hinweg. Deine Laborwerte bleiben in Apple Health."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincroniza el diseño de tu panel —el orden de las tarjetas, lo que fijas y ocultas, y tus nombres personalizados— entre tus dispositivos. Tus valores de laboratorio permanecen en Apple Salud."
+            "value" : "Sincroniza el diseño de tu panel —el orden de las tarjetas, lo que fijas y ocultas, y tus apodos— entre tus dispositivos. Tus valores de laboratorio permanecen en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronisez la disposition de votre tableau de bord — l’ordre des cartes, ce que vous épinglez et masquez, ainsi que vos noms personnalisés — sur tous vos appareils. Vos valeurs de laboratoire restent dans Apple Santé."
+            "value" : "Synchronisez la disposition de votre tableau de bord — l’ordre des cartes, ce que vous épinglez et masquez, ainsi que vos surnoms — sur tous vos appareils. Vos valeurs de laboratoire restent dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronizza il layout della dashboard — l’ordine delle schede, ciò che fissi e nascondi e i tuoi nomi personalizzati — su tutti i tuoi dispositivi. I tuoi valori di laboratorio restano in Apple Salute."
+            "value" : "Sincronizza il layout della dashboard — l’ordine delle schede, ciò che fissi e nascondi e i tuoi soprannomi — su tutti i tuoi dispositivi. I tuoi valori di laboratorio restano in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ダッシュボードのレイアウト（カードの順序、固定・非表示の設定、カスタム名）をデバイス間で同期します。検査値はAppleヘルスケアに残ります。"
+            "value" : "ダッシュボードのレイアウト（カードの順序、固定・非表示の設定、ニックネーム）をデバイス間で同期します。検査値はAppleヘルスケアに残ります。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde, wat je vastzet en verbergt, plus je eigen namen — op al je apparaten. Je labwaarden blijven in Apple Gezondheid."
+            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde, wat je vastzet en verbergt, plus je bijnamen — op al je apparaten. Je labwaarden blijven in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizuj układ pulpitu — kolejność kart, to, co przypinasz i ukrywasz, oraz własne nazwy — między urządzeniami. Twoje wyniki badań pozostają w Apple Zdrowiu."
+            "value" : "Synchronizuj układ pulpitu — kolejność kart, to, co przypinasz i ukrywasz, oraz pseudonimy — między urządzeniami. Twoje wyniki badań pozostają w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronize o layout do seu painel — a ordem dos cartões, o que você fixa e oculta e seus nomes personalizados — entre seus dispositivos. Seus valores de exames ficam no Apple Saúde."
+            "value" : "Sincronize o layout do seu painel — a ordem dos cartões, o que você fixa e oculta e seus apelidos — entre seus dispositivos. Seus valores de exames ficam no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируйте оформление панели — порядок карточек, что закреплено и скрыто, а также ваши собственные названия — между устройствами. Ваши лабораторные значения остаются в Apple Здоровье."
+            "value" : "Синхронизируйте оформление панели — порядок карточек, что закреплено и скрыто, а также ваши псевдонимы — между устройствами. Ваши лабораторные значения остаются в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pano düzeninizi — kart sırası, sabitlediğiniz ve gizlediğiniz öğeler ile özel adlarınızı — cihazlarınız arasında senkronlayın. Laboratuvar değerleriniz Apple Sağlık’ta kalır."
+            "value" : "Pano düzeninizi — kart sırası, sabitlediğiniz ve gizlediğiniz öğeler ile takma adlarınızı — cihazlarınız arasında senkronlayın. Laboratuvar değerleriniz Apple Sağlık’ta kalır."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізуйте вигляд панелі — порядок карток, що закріплено й приховано, а також ваші власні назви — між пристроями. Ваші лабораторні значення залишаються в Apple Здоров’я."
+            "value" : "Синхронізуйте вигляд панелі — порядок карток, що закріплено й приховано, а також ваші псевдоніми — між пристроями. Ваші лабораторні значення залишаються в Apple Здоров’я."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在你的设备间同步仪表板布局——卡片顺序、置顶和隐藏的设置，以及你的自定名称。你的化验数值保留在 Apple 健康中。"
+            "value" : "在你的设备间同步仪表板布局——卡片顺序、置顶和隐藏的设置，以及你的昵称。你的化验数值保留在 Apple 健康中。"
           }
         }
       }

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -9553,78 +9553,78 @@
         }
       }
     },
-    "Layout Only" : {
+    "Layout & Names" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nur das Layout"
+            "value" : "Layout & Namen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo el diseño"
+            "value" : "Diseño y nombres"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La disposition uniquement"
+            "value" : "Disposition et noms"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo il layout"
+            "value" : "Layout e nomi"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レイアウトのみ"
+            "value" : "レイアウトと名前"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen de indeling"
+            "value" : "Indeling en namen"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tylko układ"
+            "value" : "Układ i nazwy"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apenas o layout"
+            "value" : "Layout e nomes"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Только оформление"
+            "value" : "Оформление и названия"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yalnızca düzen"
+            "value" : "Düzen ve adlar"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Лише вигляд"
+            "value" : "Вигляд і назви"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅布局"
+            "value" : "布局与名称"
           }
         }
       }
@@ -12141,78 +12141,78 @@
         }
       }
     },
-    "Only your card layout syncs. Your lab values stay in Apple Health and never leave it." : {
+    "Only your card layout and the custom names you give labs sync. Your lab values stay in Apple Health and never leave it." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nur dein Karten-Layout wird synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
+            "value" : "Nur dein Karten-Layout und die eigenen Namen, die du Laborwerten gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo se sincroniza el diseño de tus tarjetas. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
+            "value" : "Solo se sincronizan el diseño de tus tarjetas y los nombres personalizados que asignas a los valores. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seule la disposition de vos cartes est synchronisée. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
+            "value" : "Seules la disposition de vos cartes et les noms personnalisés que vous donnez aux analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si sincronizza solo il layout delle schede. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
+            "value" : "Si sincronizzano solo il layout delle schede e i nomi personalizzati che assegni ai valori. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同期されるのはカードのレイアウトだけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
+            "value" : "同期されるのはカードのレイアウトと、検査値に付けたカスタム名だけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen je kaartindeling wordt gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
+            "value" : "Alleen je kaartindeling en de eigen namen die je labwaarden geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizowany jest tylko układ kart. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
+            "value" : "Synchronizowane są tylko układ kart i własne nazwy nadane wynikom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apenas o layout dos seus cartões é sincronizado. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
+            "value" : "Apenas o layout dos seus cartões e os nomes personalizados que você dá aos exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируется только оформление карточек. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
+            "value" : "Синхронизируются только оформление карточек и собственные названия, которые вы даёте показателям. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yalnızca kart düzeniniz senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
+            "value" : "Yalnızca kart düzeniniz ve değerlere verdiğiniz özel adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізується лише вигляд карток. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
+            "value" : "Синхронізуються лише вигляд карток і власні назви, які ви даєте показникам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只有卡片布局会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
+            "value" : "只有卡片布局和你为化验值设置的自定名称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
           }
         }
       }
@@ -16711,78 +16711,78 @@
         }
       }
     },
-    "The order you arrange cards in — plus what you pin and hide — follows you to your other devices." : {
+    "The order you arrange cards in — plus what you pin, hide, and rename — follows you to your other devices." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Reihenfolge deiner Karten – sowie was du anheftest und ausblendest – folgt dir auf deine anderen Geräte."
+            "value" : "Die Reihenfolge deiner Karten – sowie was du anheftest, ausblendest und umbenennst – folgt dir auf deine anderen Geräte."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El orden en que organizas las tarjetas —y lo que fijas y ocultas— te acompaña en tus otros dispositivos."
+            "value" : "El orden en que organizas las tarjetas —y lo que fijas, ocultas y renombras— te acompaña en tus otros dispositivos."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’ordre dans lequel vous classez les cartes — ainsi que ce que vous épinglez et masquez — vous suit sur vos autres appareils."
+            "value" : "L’ordre dans lequel vous classez les cartes — ainsi que ce que vous épinglez, masquez et renommez — vous suit sur vos autres appareils."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’ordine in cui disponi le schede — oltre a ciò che fissi e nascondi — ti segue sugli altri dispositivi."
+            "value" : "L’ordine in cui disponi le schede — oltre a ciò che fissi, nascondi e rinomini — ti segue sugli altri dispositivi."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "カードの並び順、固定・非表示の設定が、ほかのデバイスにも引き継がれます。"
+            "value" : "カードの並び順、固定・非表示・名前の変更が、ほかのデバイスにも引き継がれます。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De volgorde van je kaarten — plus wat je vastzet en verbergt — gaat met je mee naar je andere apparaten."
+            "value" : "De volgorde van je kaarten — plus wat je vastzet, verbergt en hernoemt — gaat met je mee naar je andere apparaten."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kolejność kart oraz to, co przypinasz i ukrywasz, podąża za Tobą na inne urządzenia."
+            "value" : "Kolejność kart oraz to, co przypinasz i ukrywasz — a także własne nazwy — podąża za Tobą na inne urządzenia."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A ordem em que você organiza os cartões — além do que fixa e oculta — acompanha você nos seus outros dispositivos."
+            "value" : "A ordem em que você organiza os cartões — além do que fixa, oculta e renomeia — acompanha você nos seus outros dispositivos."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Порядок карточек, а также что закреплено и скрыто, переносится на другие ваши устройства."
+            "value" : "Порядок карточек, а также что закреплено, скрыто и переименовано, переносится на другие ваши устройства."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kartları dizdiğiniz sıra ile sabitlediğiniz ve gizlediğiniz öğeler diğer cihazlarınıza taşınır."
+            "value" : "Kartları dizdiğiniz sıra ile sabitlediğiniz, gizlediğiniz ve yeniden adlandırdığınız öğeler diğer cihazlarınıza taşınır."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Порядок розташування карток, а також що закріплено й приховано, переходить на інші ваші пристрої."
+            "value" : "Порядок розташування карток, а також що закріплено, приховано й перейменовано, переходить на інші ваші пристрої."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你排列卡片的顺序，以及置顶和隐藏的设置，都会同步到你的其他设备。"
+            "value" : "你排列卡片的顺序，以及置顶、隐藏和重命名的设置，都会同步到你的其他设备。"
           }
         }
       }

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -12141,78 +12141,78 @@
         }
       }
     },
-    "Only your card layout and the custom names you give labs sync. Your lab values stay in Apple Health and never leave it." : {
+    "Only your card layout and the names you give your lab tests sync. Your lab values stay in Apple Health and never leave it." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nur dein Karten-Layout und die eigenen Namen, die du Laborwerten gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
+            "value" : "Nur dein Karten-Layout und die Namen, die du deinen Labortests gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo se sincronizan el diseño de tus tarjetas y los nombres personalizados que asignas a los valores. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
+            "value" : "Solo se sincronizan el diseño de tus tarjetas y los nombres que asignas a tus análisis. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seules la disposition de vos cartes et les noms personnalisés que vous donnez aux analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
+            "value" : "Seuls la disposition de vos cartes et les noms que vous donnez à vos analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si sincronizzano solo il layout delle schede e i nomi personalizzati che assegni ai valori. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
+            "value" : "Si sincronizzano solo il layout delle schede e i nomi che assegni alle tue analisi. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同期されるのはカードのレイアウトと、検査値に付けたカスタム名だけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
+            "value" : "同期されるのはカードのレイアウトと、検査項目に付けた名前だけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen je kaartindeling en de eigen namen die je labwaarden geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
+            "value" : "Alleen je kaartindeling en de namen die je je labtests geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizowane są tylko układ kart i własne nazwy nadane wynikom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
+            "value" : "Synchronizowane są tylko układ kart i nazwy, które nadajesz swoim badaniom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apenas o layout dos seus cartões e os nomes personalizados que você dá aos exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
+            "value" : "Apenas o layout dos seus cartões e os nomes que você dá aos seus exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируются только оформление карточек и собственные названия, которые вы даёте показателям. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
+            "value" : "Синхронизируются только оформление карточек и названия, которые вы даёте своим анализам. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yalnızca kart düzeniniz ve değerlere verdiğiniz özel adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
+            "value" : "Yalnızca kart düzeniniz ve tahlillerinize verdiğiniz adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізуються лише вигляд карток і власні назви, які ви даєте показникам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
+            "value" : "Синхронізуються лише вигляд карток і назви, які ви даєте своїм аналізам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只有卡片布局和你为化验值设置的自定名称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
+            "value" : "只有卡片布局和你为检验项目设置的名称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
           }
         }
       }

--- a/LabImporter/Models/LabDisplayPreferences.swift
+++ b/LabImporter/Models/LabDisplayPreferences.swift
@@ -4,13 +4,14 @@ struct LabDisplayPreferences: RawRepresentable {
     var pinnedCodes: [String] = []
     var orderedCodes: [String] = []
     var hiddenCodes: [String] = []
-    /// User-chosen display names that override the catalog name for a LOINC code,
+    /// User-chosen nicknames that override the catalog name for a LOINC code,
     /// keyed by code (e.g. `"4548-8"` → `"HbA1c %"`). Empty until the user renames
-    /// something. Applied centrally in `LabMapping.displayName(for:)`, so a rename
+    /// something. Applied centrally in `LabMapping.displayName(for:)`, so a nickname
     /// flows to every screen (dashboard, trends, detail, review, history) — but it
     /// is purely cosmetic and never reaches the exported CDA, which keeps the
     /// standard LOINC English display (see `LabMapping.loincCode(for:)`).
-    var customNames: [String: String] = [:]
+    /// Persisted under the legacy JSON key `customNames` (see `Payload`).
+    var nicknames: [String: String] = [:]
 
     init() {}
 
@@ -21,37 +22,37 @@ struct LabDisplayPreferences: RawRepresentable {
         pinnedCodes = decoded.pinnedCodes
         orderedCodes = decoded.orderedCodes
         hiddenCodes = decoded.hiddenCodes
-        customNames = decoded.customNames ?? [:]
+        nicknames = decoded.customNames ?? [:]
     }
 
     var rawValue: String {
         let payload = Payload(pinnedCodes: pinnedCodes, orderedCodes: orderedCodes,
-                              hiddenCodes: hiddenCodes, customNames: customNames)
+                              hiddenCodes: hiddenCodes, customNames: nicknames)
         return (try? JSONEncoder().encode(payload)).flatMap { String(data: $0, encoding: .utf8) } ?? ""
     }
 
     var pinnedSet: Set<String> { Set(pinnedCodes) }
     var hiddenSet: Set<String> { Set(hiddenCodes) }
 
-    /// The user's custom display name for `code`, or `nil` if they haven't set one
+    /// The user's nickname for `code`, or `nil` if they haven't set one
     /// (or set it to blank). Whitespace is trimmed so a stray space never masks a
     /// catalog name.
-    func customName(for code: String) -> String? {
+    func nickname(for code: String) -> String? {
         let trimmed = code.trimmingCharacters(in: .whitespaces)
-        guard let name = customNames[trimmed]?.trimmingCharacters(in: .whitespaces),
+        guard let name = nicknames[trimmed]?.trimmingCharacters(in: .whitespaces),
               !name.isEmpty else { return nil }
         return name
     }
 
-    /// Sets (or, when `name` is `nil`/blank, clears) the custom display name for
+    /// Sets (or, when `name` is `nil`/blank, clears) the nickname for
     /// `code`. Clearing falls the display back to the catalog name.
-    mutating func setCustomName(_ name: String?, for code: String) {
+    mutating func setNickname(_ name: String?, for code: String) {
         let trimmedCode = code.trimmingCharacters(in: .whitespaces)
         let trimmedName = name?.trimmingCharacters(in: .whitespaces)
         if let trimmedName, !trimmedName.isEmpty {
-            customNames[trimmedCode] = trimmedName
+            nicknames[trimmedCode] = trimmedName
         } else {
-            customNames.removeValue(forKey: trimmedCode)
+            nicknames.removeValue(forKey: trimmedCode)
         }
     }
 
@@ -62,9 +63,11 @@ struct LabDisplayPreferences: RawRepresentable {
         var pinnedCodes: [String]
         var orderedCodes: [String]
         var hiddenCodes: [String]
-        // Optional so blobs written before custom names existed — or synced from a
-        // device on an older build — still decode (older builds likewise ignore
-        // this unknown key, so the layout keeps roaming both ways).
+        // The on-disk/iCloud key stays `customNames` — it predates the "nickname"
+        // rename — for backward compatibility. Optional so blobs written before
+        // nicknames existed, or synced from a device on an older build, still
+        // decode (older builds likewise ignore this unknown key, so the layout
+        // keeps roaming both ways).
         var customNames: [String: String]?
     }
 }
@@ -72,7 +75,7 @@ struct LabDisplayPreferences: RawRepresentable {
 extension LabDisplayPreferences {
     /// The `@AppStorage` key the dashboard preferences are persisted under. Shared
     /// so non-View code (e.g. `LabMapping`) can read the same blob the UI binds to,
-    /// keeping custom names in lockstep with the binding — including iCloud sync.
+    /// keeping nicknames in lockstep with the binding — including iCloud sync.
     static let storageKey = "labDisplayPrefs"
 
     /// Loads the current preferences from `UserDefaults` — the very blob the

--- a/LabImporter/Models/LabMapping.swift
+++ b/LabImporter/Models/LabMapping.swift
@@ -11,21 +11,21 @@ enum LabMapping {
 
     // MARK: - LOINC lookups
 
-    // Display name for a LOINC code: a user's custom name (set in Sort &
+    // Display name for a LOINC code: a user's nickname (set in Sort &
     // Visibility) wins, then the localized catalog name, finally the raw code
-    // (e.g. an as-yet-unmapped value). The custom-name override is cosmetic only —
+    // (e.g. an as-yet-unmapped value). The nickname override is cosmetic only —
     // CDA export keeps the standard LOINC English display (see `loincCode(for:)`).
     static func displayName(for code: String) -> String {
         let trimmed = code.trimmingCharacters(in: .whitespaces)
-        if let custom = LabDisplayPreferences.current().customName(for: trimmed) {
-            return custom
+        if let nickname = LabDisplayPreferences.current().nickname(for: trimmed) {
+            return nickname
         }
         return LoincDirectory.shared.term(for: trimmed)?.name ?? code
     }
 
-    // The catalog (non-overridden) display name for a code, ignoring any custom
-    // alias — used where the *default* name must be shown regardless of the user's
-    // rename (the rename field's placeholder, the row subtitle under a custom name,
+    // The catalog (non-overridden) display name for a code, ignoring any nickname
+    // — used where the *default* name must be shown regardless of the user's
+    // rename (the rename field's placeholder, the row subtitle under a nickname,
     // and the canonical name in CDA narrative export).
     static func catalogName(for code: String) -> String {
         let trimmed = code.trimmingCharacters(in: .whitespaces)

--- a/LabImporter/Services/CDAExportService.swift
+++ b/LabImporter/Services/CDAExportService.swift
@@ -39,8 +39,8 @@ struct CDAExportService {
 
         let narrativeRows = exportable.map { labValue in
             // Use the canonical catalog name (not `labValue.name`, which may carry a
-            // user's custom display override) so a personal alias never leaks into
-            // the saved/shared document — only into on-screen display.
+            // user's nickname) so a personal nickname never leaks into the
+            // saved/shared document — only into on-screen display.
             let canonicalName = LoincDirectory.shared.term(for: labValue.code)?.name ?? labValue.name
             return "<tr><td>\(esc(canonicalName))</td><td>\(esc(labValue.displayValue)) \(esc(labValue.unit))</td></tr>"
         }.joined(separator: "\n              ")

--- a/LabImporter/Services/CloudSyncService.swift
+++ b/LabImporter/Services/CloudSyncService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Roams the dashboard card layout (sorting / pinning / hiding / custom names)
+/// Roams the dashboard card layout (sorting / pinning / hiding / nicknames)
 /// across the user's devices via the iCloud key-value store (`NSUbiquitousKeyValueStore`).
 ///
 /// **Opt-in.** Nothing syncs until the user turns it on — the persisted flag
@@ -8,7 +8,7 @@ import Foundation
 /// decision (see `CloudSyncOptInView`) and Settings lets the user change it.
 ///
 /// **What syncs:** only `labDisplayPrefs` (the dashboard card layout plus the
-/// user's custom display names for codes).
+/// user's nicknames for codes).
 /// **What never syncs:** lab values — those live in Apple Health by design (see
 /// CLAUDE.md) — and patient metadata, which stays device-local. No network call
 /// here ever carries lab data; the iCloud KVS holds only the tiny layout blob.
@@ -38,7 +38,7 @@ final class CloudSyncService {
     /// The exact `@AppStorage` keys we roam. Layout only — never lab data or
     /// patient metadata.
     static let syncedKeys: Set<String> = [
-        "labDisplayPrefs"           // dashboard card sorting / pinning / hiding / custom names
+        "labDisplayPrefs"           // dashboard card sorting / pinning / hiding / nicknames
     ]
 
     private let store = NSUbiquitousKeyValueStore.default

--- a/LabImporter/Views/Dashboard/TrendsView.swift
+++ b/LabImporter/Views/Dashboard/TrendsView.swift
@@ -141,7 +141,7 @@ struct TrendsView: View {
     private var moreMenu: some View {
         Menu {
             Button {
-                renameDraft = prefs.customName(for: selectedCode) ?? ""
+                renameDraft = prefs.nickname(for: selectedCode) ?? ""
                 renamingCode = selectedCode
             } label: {
                 Label("Rename", systemImage: "pencil")

--- a/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
+++ b/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
@@ -24,7 +24,7 @@ struct CloudSyncOptInView: View {
                 icon: "icloud.fill",
                 color: LabCategory.cardiac.color,
                 title: "Layout & Names",
-                description: "Only your card layout and the names you give your lab tests sync. Your lab values stay in Apple Health and never leave it."
+                description: "Only your card layout and the nicknames you give your lab tests sync. Your lab values stay in Apple Health and never leave it."
             ),
             Benefit(
                 icon: "slider.horizontal.3",

--- a/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
+++ b/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
@@ -24,7 +24,7 @@ struct CloudSyncOptInView: View {
                 icon: "icloud.fill",
                 color: LabCategory.cardiac.color,
                 title: "Layout & Names",
-                description: "Only your card layout and the custom names you give labs sync. Your lab values stay in Apple Health and never leave it."
+                description: "Only your card layout and the names you give your lab tests sync. Your lab values stay in Apple Health and never leave it."
             ),
             Benefit(
                 icon: "slider.horizontal.3",

--- a/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
+++ b/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
@@ -18,13 +18,13 @@ struct CloudSyncOptInView: View {
                 icon: "square.grid.2x2.fill",
                 color: LabCategory.endocrine.color,
                 title: "Your Dashboard, Everywhere",
-                description: "The order you arrange cards in — plus what you pin and hide — follows you to your other devices."
+                description: "The order you arrange cards in — plus what you pin, hide, and rename — follows you to your other devices."
             ),
             Benefit(
                 icon: "icloud.fill",
                 color: LabCategory.cardiac.color,
-                title: "Layout Only",
-                description: "Only your card layout syncs. Your lab values stay in Apple Health and never leave it."
+                title: "Layout & Names",
+                description: "Only your card layout and the custom names you give labs sync. Your lab values stay in Apple Health and never leave it."
             ),
             Benefit(
                 icon: "slider.horizontal.3",

--- a/LabImporter/Views/Review/AddValueSheet.swift
+++ b/LabImporter/Views/Review/AddValueSheet.swift
@@ -18,7 +18,7 @@ struct AddValueSheet: View {
                 Section {
                     // A LOINC code must be chosen first — every value is LOINC-based,
                     // so the picker drives the name and the canonical unit. The chosen
-                    // test is shown as a rich, category-tinted row (the user's alias
+                    // test is shown as a rich, category-tinted row (the user's nickname
                     // when set, else the catalog name); renaming lives in Sort &
                     // Visibility, not here.
                     NavigationLink {

--- a/LabImporter/Views/Review/CodePickerSheet.swift
+++ b/LabImporter/Views/Review/CodePickerSheet.swift
@@ -6,14 +6,14 @@ import SwiftUI
 // Selecting a row stores the raw LOINC number as the value's code; LabMapping
 // resolves it everywhere.
 
-// Catalog terms whose user-defined alias (custom display name) contains the
-// query, so a manually renamed test stays findable by the name the user gave it.
-// Returns at most the codes that have an alias set, resolved back to full terms.
-private func aliasMatches(_ query: String) -> [LoincTerm] {
+// Catalog terms whose user-defined nickname contains the query, so a manually
+// renamed test stays findable by the name the user gave it. Returns at most the
+// codes that have a nickname set, resolved back to full terms.
+private func nicknameMatches(_ query: String) -> [LoincTerm] {
     let needle = query.trimmingCharacters(in: .whitespaces).lowercased()
     guard !needle.isEmpty else { return [] }
-    return LabDisplayPreferences.current().customNames.compactMap { code, alias in
-        alias.lowercased().contains(needle) ? LoincDirectory.shared.term(for: code) : nil
+    return LabDisplayPreferences.current().nicknames.compactMap { code, nickname in
+        nickname.lowercased().contains(needle) ? LoincDirectory.shared.term(for: code) : nil
     }
 }
 
@@ -33,14 +33,14 @@ private struct LabTestPickerList: View {
         List {
             Section {
                 ForEach(loincResults) { term in
-                    // Surface the user's alias (custom display name) when they've
-                    // renamed this code, so the picker matches what they see
-                    // everywhere else; the catalog name then becomes the subtitle.
-                    let alias = LabDisplayPreferences.current().customName(for: term.code)
+                    // Surface the user's nickname when they've renamed this code,
+                    // so the picker matches what they see everywhere else; the
+                    // catalog name then becomes the subtitle.
+                    let nickname = LabDisplayPreferences.current().nickname(for: term.code)
                     row(rowCode: term.code,
-                        title: alias ?? term.name,
-                        subtitle: alias != nil ? term.name : term.description) {
-                        select(term.code, alias ?? term.name)
+                        title: nickname ?? term.name,
+                        subtitle: nickname != nil ? term.name : term.description) {
+                        select(term.code, nickname ?? term.name)
                     }
                     .listRowBackground(Rectangle().fill(.ultraThinMaterial))
                 }
@@ -66,12 +66,12 @@ private struct LabTestPickerList: View {
         .task(id: query) {
             let current = query
             let found = await Task.detached(priority: .userInitiated) { () -> [LoincTerm] in
-                // Alias matches rank ahead of the catalog's full-text matches so a
-                // renamed test is findable by the name the user gave it.
-                let aliasHits = aliasMatches(current)
+                // Nickname matches rank ahead of the catalog's full-text matches so
+                // a renamed test is findable by the name the user gave it.
+                let nicknameHits = nicknameMatches(current)
                 let catalog = LoincDirectory.shared.search(current)
-                var seen = Set(aliasHits.map(\.code))
-                return aliasHits + catalog.filter { seen.insert($0.code).inserted }
+                var seen = Set(nicknameHits.map(\.code))
+                return nicknameHits + catalog.filter { seen.insert($0.code).inserted }
             }.value
             if current == query {
                 loincResults = found

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -192,7 +192,7 @@ struct LoincTermDetailView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    renameDraft = prefs.customName(for: term.code) ?? ""
+                    renameDraft = prefs.nickname(for: term.code) ?? ""
                     renamingCode = term.code
                 } label: {
                     Label("Rename", systemImage: "pencil")
@@ -236,9 +236,9 @@ struct LoincTermDetailView: View {
                 Spacer(minLength: 0)
             }
 
-            if let custom = prefs.customName(for: term.code) {
+            if let nickname = prefs.nickname(for: term.code) {
                 Divider()
-                customNameRow(custom)
+                nicknameRow(nickname)
             }
 
             if let description = detail?.description ?? term.description, !description.isEmpty {
@@ -273,17 +273,17 @@ struct LoincTermDetailView: View {
         )
     }
 
-    // The user's own name for this test, shown as a plainly-labelled read-only
+    // The user's nickname for this test, shown as a plainly-labelled read-only
     // field (renaming happens via the toolbar) — a "tag" glyph, not a pencil, so
     // it never reads as an inline edit button.
-    private func customNameRow(_ name: String) -> some View {
+    private func nicknameRow(_ name: String) -> some View {
         HStack(spacing: 10) {
             Image(systemName: "tag.fill")
                 .font(.subheadline)
                 .foregroundStyle(category.color)
                 .frame(width: 20)
             VStack(alignment: .leading, spacing: 1) {
-                Text("Custom name")
+                Text("Nickname")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .textCase(.uppercase)

--- a/LabImporter/Views/Settings/LabSortEditor.swift
+++ b/LabImporter/Views/Settings/LabSortEditor.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - LabSortEditor
 
 /// Per-metric management for the dashboard: reorder, pin, hide, and rename the
-/// LOINC codes the user has data for. Custom names are written straight into the
+/// LOINC codes the user has data for. Nicknames are written straight into the
 /// bound `LabDisplayPreferences` (so they persist and roam via iCloud) and are
 /// applied everywhere through `LabMapping.displayName(for:)`.
 struct LabSortEditor: View {
@@ -56,7 +56,7 @@ struct LabSortEditor: View {
     }
 
     private func startRename(_ code: String) {
-        renameDraft = prefs.customName(for: code) ?? ""
+        renameDraft = prefs.nickname(for: code) ?? ""
         renamingCode = code
     }
 
@@ -104,10 +104,10 @@ struct LabSortEditor: View {
                 .fill(LabCategory.forCode(item.code).color.gradient)
                 .frame(width: 9, height: 9)
             // Resolve live (not the captured `item.name`) so a rename updates the
-            // row immediately; show the catalog default beneath a custom name.
+            // row immediately; show the catalog default beneath a nickname.
             VStack(alignment: .leading, spacing: 1) {
                 Text(LabMapping.displayName(for: item.code))
-                if prefs.customName(for: item.code) != nil {
+                if prefs.nickname(for: item.code) != nil {
                     Text(LabMapping.catalogName(for: item.code))
                         .font(.caption2)
                         .foregroundStyle(.secondary)

--- a/LabImporter/Views/Settings/RenameLabAlert.swift
+++ b/LabImporter/Views/Settings/RenameLabAlert.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
 extension View {
-    /// The shared "Rename" alert that sets a custom display name for a LOINC `code`
+    /// The shared "Rename" alert that sets a nickname for a LOINC `code`
     /// — reused by the Sort & Visibility editor, the trends screen, and the LOINC
     /// detail screen so the wording and behaviour stay identical everywhere.
     ///
     /// Present it by setting `code` to the LOINC code (seed `draft` first with the
-    /// current custom name so the field shows it for editing); dismissing clears
-    /// `code`. The chosen name is written to `prefs.customNames` and applied across
+    /// current nickname so the field shows it for editing); dismissing clears
+    /// `code`. The chosen name is written to `prefs.nicknames` and applied across
     /// the app via `LabMapping.displayName`. Saving a blank name (or "Reset to
-    /// Default") clears the override and falls back to the catalog name.
+    /// Default") clears the nickname and falls back to the catalog name.
     func renameLabAlert(code: Binding<String?>,
                         draft: Binding<String>,
                         prefs: Binding<LabDisplayPreferences>) -> some View {
@@ -19,15 +19,15 @@ extension View {
         )
         return alert("Rename", isPresented: isPresented, presenting: code.wrappedValue) { code in
             TextField(LabMapping.catalogName(for: code), text: draft)
-            Button("Save") { prefs.wrappedValue.setCustomName(draft.wrappedValue, for: code) }
-            if prefs.wrappedValue.customName(for: code) != nil {
+            Button("Save") { prefs.wrappedValue.setNickname(draft.wrappedValue, for: code) }
+            if prefs.wrappedValue.nickname(for: code) != nil {
                 Button("Reset to Default", role: .destructive) {
-                    prefs.wrappedValue.setCustomName(nil, for: code)
+                    prefs.wrappedValue.setNickname(nil, for: code)
                 }
             }
             Button("Cancel", role: .cancel) {}
         } message: { code in
-            Text("Choose a short name to show everywhere instead of “\(LabMapping.catalogName(for: code))”.")
+            Text("Choose a nickname to show everywhere instead of “\(LabMapping.catalogName(for: code))”.")
         }
     }
 }

--- a/LabImporter/Views/Settings/SettingsView.swift
+++ b/LabImporter/Views/Settings/SettingsView.swift
@@ -110,7 +110,7 @@ struct SettingsView: View {
                 } footer: {
                     Text("""
                     Sync your dashboard layout — the card order, what you pin and hide, and your \
-                    custom names — across your devices. Your lab values stay in Apple Health.
+                    nicknames — across your devices. Your lab values stay in Apple Health.
                     """)
                 }
 


### PR DESCRIPTION
## Why

The iCloud opt-in onboarding screen (`CloudSyncOptInView`) claimed **"Only your card layout syncs"**, but the user's per-LOINC display overrides (`LabDisplayPreferences.customNames`) are part of the same synced `labDisplayPrefs` blob (`CloudSyncService.syncedKeys`). Settings already disclosed this; onboarding did not. While fixing the disclosure, the vague term "custom name" was renamed to **"Nickname"** for clarity and consistency across the app.

## What changed

**1. Disclose the synced names in onboarding**
- `CloudSyncOptInView` benefits now state that the names you give your lab tests sync too (not just card layout). "Layout Only" → "Layout & Names".

**2. Make the disclosure specific**
- Clarified these are the names for your **lab tests** (the renamed metric labels), kept distinct from the **lab values** that never leave Apple Health — across all 12 languages.

**3. Rename the feature to "Nickname"** (term + scope chosen by the maintainer)
- **UI (12 languages):** the "Custom name" row label → "Nickname"; the rename alert message and both iCloud‑sync disclosures now say "nickname". The noun uses Apple's own system localizations (de *Spitzname*, fr *Surnom*, es *Apodo*, it *Soprannome*, nl *Bijnaam*, pt‑BR *Apelido*, ru/uk *Псевдонім*, pl *Pseudonim*, tr *Takma Ad*, ja *ニックネーム*, zh‑Hans *昵称*).
- **Code:** `customNames` → `nicknames`, `customName(for:)` → `nickname(for:)`, `setCustomName` → `setNickname`, `customNameRow` → `nicknameRow`, `CodePickerSheet` `alias*` → `nickname*`; comments in `LabMapping`/`CloudSyncService`/`CDAExportService`/etc. and `CLAUDE.md` updated.

## Backward compatibility

The persisted/iCloud **JSON key stays `customNames`** (kept on the private `Payload` type; the encode/decode bridge maps `nicknames ↔ customNames`), so existing stored layouts and cross‑device sync from older builds keep decoding unchanged — no migration needed. The "Rename" action verb is unchanged.

## Notes

- No lab values, results, or patient/personal data are affected — only the cosmetic display nickname (which never reaches the exported CDA).
- `swiftlint lint --strict` passes. Not compiled (no Xcode on the runner); verified there are no remaining references to the old symbols.

https://claude.ai/code/session_01L3R6DPPC8dgAzHLUcgtV5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3R6DPPC8dgAzHLUcgtV5M)_