### PR TITLE
Add user-defined reference ranges with out-of-range flagging

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		AABB000000000000000040AA /* LabImporterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000020AA /* LabImporterApp.swift */; };
 		AABB000000000000000041AA /* LabValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000021AA /* LabValue.swift */; };
 		AABB000000000000000042AA /* LabMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000022AA /* LabMapping.swift */; };
+		AAFF0000000000000000F102 /* ReferenceRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF0000000000000000F101 /* ReferenceRange.swift */; };
+		AAFF0000000000000000F202 /* RangeStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF0000000000000000F201 /* RangeStatusBadge.swift */; };
+		AAFF0000000000000000F302 /* ReferenceRangeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF0000000000000000F301 /* ReferenceRangeEditor.swift */; };
+		AAFF0000000000000000F402 /* ValueDescriptionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF0000000000000000F401 /* ValueDescriptionCard.swift */; };
+		AAFF0000000000000000F502 /* TrendWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF0000000000000000F501 /* TrendWindow.swift */; };
 		AABB000000000000000043AA /* OCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000023AA /* OCRService.swift */; };
 		AABB000000000000000044AA /* LabParserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000024AA /* LabParserService.swift */; };
 		AABB000000000000000045AA /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000025AA /* HealthKitService.swift */; };
@@ -67,6 +72,11 @@
 		AABB000000000000000020AA /* LabImporterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabImporterApp.swift; sourceTree = "<group>"; };
 		AABB000000000000000021AA /* LabValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabValue.swift; sourceTree = "<group>"; };
 		AABB000000000000000022AA /* LabMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabMapping.swift; sourceTree = "<group>"; };
+		AAFF0000000000000000F101 /* ReferenceRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceRange.swift; sourceTree = "<group>"; };
+		AAFF0000000000000000F201 /* RangeStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeStatusBadge.swift; sourceTree = "<group>"; };
+		AAFF0000000000000000F301 /* ReferenceRangeEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceRangeEditor.swift; sourceTree = "<group>"; };
+		AAFF0000000000000000F401 /* ValueDescriptionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueDescriptionCard.swift; sourceTree = "<group>"; };
+		AAFF0000000000000000F501 /* TrendWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendWindow.swift; sourceTree = "<group>"; };
 		AABB000000000000000023AA /* OCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRService.swift; sourceTree = "<group>"; };
 		AABB000000000000000024AA /* LabParserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabParserService.swift; sourceTree = "<group>"; };
 		AABB000000000000000025AA /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
@@ -262,6 +272,7 @@
 			children = (
 				AABB000000000000000021AA /* LabValue.swift */,
 				AABB000000000000000022AA /* LabMapping.swift */,
+				AAFF0000000000000000F101 /* ReferenceRange.swift */,
 				AABB000000000000000096AA /* LabCategory.swift */,
 				AABB000000000000000061AA /* LabReport.swift */,
 				AABB000000000000000075AA /* LabDisplayPreferences.swift */,
@@ -346,6 +357,8 @@
 			children = (
 				AABB000000000000000071AA /* DashboardView.swift */,
 				AABB0000000000000000CC02 /* MetricCard.swift */,
+				AAFF0000000000000000F401 /* ValueDescriptionCard.swift */,
+				AAFF0000000000000000F501 /* TrendWindow.swift */,
 				AABB000000000000000069AA /* TrendsView.swift */,
 			);
 			path = Dashboard;
@@ -366,6 +379,7 @@
 				AABB000000000000000087AA /* SettingsView.swift */,
 				AABBCC0000000000000002AA /* LabSortEditor.swift */,
 				AABBCC0000000000000004AA /* RenameLabAlert.swift */,
+				AAFF0000000000000000F301 /* ReferenceRangeEditor.swift */,
 				AABBCC0000000000000006AA /* BuildInfoCard.swift */,
 			);
 			path = Settings;
@@ -378,6 +392,7 @@
 				AABB0000000000000000C1AA /* MorphingCategoryBackground.swift */,
 				AACC000000000000000004AA /* PreviewSampleData.swift */,
 				AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */,
+				AAFF0000000000000000F201 /* RangeStatusBadge.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -520,6 +535,11 @@
 				AABB000000000000000040AA /* LabImporterApp.swift in Sources */,
 				AABB000000000000000041AA /* LabValue.swift in Sources */,
 				AABB000000000000000042AA /* LabMapping.swift in Sources */,
+				AAFF0000000000000000F102 /* ReferenceRange.swift in Sources */,
+				AAFF0000000000000000F202 /* RangeStatusBadge.swift in Sources */,
+				AAFF0000000000000000F302 /* ReferenceRangeEditor.swift in Sources */,
+				AAFF0000000000000000F402 /* ValueDescriptionCard.swift in Sources */,
+				AAFF0000000000000000F502 /* TrendWindow.swift in Sources */,
 				AABB000000000000000097AA /* LabCategory.swift in Sources */,
 				AABB000000000000000043AA /* OCRService.swift in Sources */,
 				AABB000000000000000044AA /* LabParserService.swift in Sources */,

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -10161,78 +10161,78 @@
         }
       }
     },
-    "Layout & Names" : {
+    "Layout, Names & Ranges" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Layout & Namen"
+            "value" : "Layout, Namen & Bereiche"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diseño y nombres"
+            "value" : "Diseño, nombres y rangos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Disposition et noms"
+            "value" : "Disposition, noms et plages"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Layout e nomi"
+            "value" : "Layout, nomi e intervalli"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レイアウトと名前"
+            "value" : "レイアウト・名前・基準範囲"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indeling en namen"
+            "value" : "Indeling, namen en bereiken"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Układ i nazwy"
+            "value" : "Układ, nazwy i zakresy"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Layout e nomes"
+            "value" : "Layout, nomes e faixas"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Оформление и названия"
+            "value" : "Оформление, названия и диапазоны"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Düzen ve adlar"
+            "value" : "Düzen, adlar ve aralıklar"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Вигляд і назви"
+            "value" : "Вигляд, назви та діапазони"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "布局与名称"
+            "value" : "布局、名称与范围"
           }
         }
       }
@@ -12749,78 +12749,78 @@
         }
       }
     },
-    "Only your card layout and the nicknames you give your lab tests sync. Your lab values stay in Apple Health and never leave it." : {
+    "Only your card layout, the nicknames you give your lab tests, and the reference ranges you set sync. Your lab values stay in Apple Health and never leave it." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nur dein Karten-Layout und die Spitznamen, die du deinen Labortests gibst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
+            "value" : "Nur dein Karten-Layout, die Spitznamen, die du deinen Labortests gibst, und die Referenzbereiche, die du festlegst, werden synchronisiert. Deine Laborwerte bleiben in Apple Health und verlassen es nie."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Solo se sincronizan el diseño de tus tarjetas y los apodos que asignas a tus análisis. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
+            "value" : "Solo se sincronizan el diseño de tus tarjetas, los apodos que asignas a tus análisis y los rangos de referencia que defines. Tus valores de laboratorio permanecen en Apple Salud y nunca salen de ahí."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seuls la disposition de vos cartes et les surnoms que vous donnez à vos analyses sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
+            "value" : "Seuls la disposition de vos cartes, les surnoms que vous donnez à vos analyses et les plages de référence que vous définissez sont synchronisés. Vos valeurs de laboratoire restent dans Apple Santé et n’en sortent jamais."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si sincronizzano solo il layout delle schede e i soprannomi che assegni alle tue analisi. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
+            "value" : "Si sincronizzano solo il layout delle schede, i soprannomi che assegni alle tue analisi e gli intervalli di riferimento che imposti. I tuoi valori di laboratorio restano in Apple Salute e non ne escono mai."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同期されるのはカードのレイアウトと、検査項目に付けたニックネームだけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
+            "value" : "同期されるのはカードのレイアウト、検査項目に付けたニックネーム、設定した基準範囲だけです。検査値はAppleヘルスケアに残り、外に出ることはありません。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alleen je kaartindeling en de bijnamen die je je labtests geeft, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
+            "value" : "Alleen je kaartindeling, de bijnamen die je je labtests geeft, en de referentiebereiken die je instelt, worden gesynchroniseerd. Je labwaarden blijven in Apple Gezondheid en verlaten het nooit."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizowane są tylko układ kart i pseudonimy, które nadajesz swoim badaniom. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
+            "value" : "Synchronizowane są tylko układ kart, pseudonimy, które nadajesz swoim badaniom, oraz zakresy referencyjne, które ustawiasz. Twoje wyniki badań pozostają w Apple Zdrowiu i nigdy go nie opuszczają."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apenas o layout dos seus cartões e os apelidos que você dá aos seus exames são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
+            "value" : "Apenas o layout dos seus cartões, os apelidos que você dá aos seus exames e as faixas de referência que você define são sincronizados. Seus valores de exames ficam no Apple Saúde e nunca saem de lá."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируются только оформление карточек и псевдонимы, которые вы даёте своим анализам. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
+            "value" : "Синхронизируются только оформление карточек, псевдонимы, которые вы даёте своим анализам, и референсные диапазоны, которые вы задаёте. Ваши лабораторные значения остаются в Apple Здоровье и никогда его не покидают."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yalnızca kart düzeniniz ve tahlillerinize verdiğiniz takma adlar senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
+            "value" : "Yalnızca kart düzeniniz, tahlillerinize verdiğiniz takma adlar ve belirlediğiniz referans aralıkları senkronlanır. Laboratuvar değerleriniz Apple Sağlık’ta kalır ve oradan asla çıkmaz."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізуються лише вигляд карток і псевдоніми, які ви даєте своїм аналізам. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
+            "value" : "Синхронізуються лише вигляд карток, псевдоніми, які ви даєте своїм аналізам, і референсні діапазони, які ви задаєте. Ваші лабораторні значення залишаються в Apple Здоров’я й ніколи його не покидають."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只有卡片布局和你为检验项目设置的昵称会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
+            "value" : "只有卡片布局、你为检验项目设置的昵称，以及你设置的参考范围会同步。你的化验数值保留在 Apple 健康中，绝不会离开。"
           }
         }
       }
@@ -16479,78 +16479,78 @@
         }
       }
     },
-    "Sync your dashboard layout — the card order, what you pin and hide, and your nicknames — across your devices. Your lab values stay in Apple Health." : {
+    "Sync your dashboard layout — the card order, what you pin and hide, your nicknames, and your reference ranges — across your devices. Your lab values stay in Apple Health." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronisiere dein Dashboard-Layout – die Kartenreihenfolge, was du anheftest und ausblendest, sowie deine Spitznamen – über deine Geräte hinweg. Deine Laborwerte bleiben in Apple Health."
+            "value" : "Synchronisiere dein Dashboard-Layout – die Kartenreihenfolge, was du anheftest und ausblendest, deine Spitznamen sowie deine Referenzbereiche – über deine Geräte hinweg. Deine Laborwerte bleiben in Apple Health."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincroniza el diseño de tu panel —el orden de las tarjetas, lo que fijas y ocultas, y tus apodos— entre tus dispositivos. Tus valores de laboratorio permanecen en Apple Salud."
+            "value" : "Sincroniza el diseño de tu panel —el orden de las tarjetas, lo que fijas y ocultas, tus apodos y tus rangos de referencia— entre tus dispositivos. Tus valores de laboratorio permanecen en Apple Salud."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronisez la disposition de votre tableau de bord — l’ordre des cartes, ce que vous épinglez et masquez, ainsi que vos surnoms — sur tous vos appareils. Vos valeurs de laboratoire restent dans Apple Santé."
+            "value" : "Synchronisez la disposition de votre tableau de bord — l’ordre des cartes, ce que vous épinglez et masquez, vos surnoms et vos plages de référence — sur tous vos appareils. Vos valeurs de laboratoire restent dans Apple Santé."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronizza il layout della dashboard — l’ordine delle schede, ciò che fissi e nascondi e i tuoi soprannomi — su tutti i tuoi dispositivi. I tuoi valori di laboratorio restano in Apple Salute."
+            "value" : "Sincronizza il layout della dashboard — l’ordine delle schede, ciò che fissi e nascondi, i tuoi soprannomi e i tuoi intervalli di riferimento — su tutti i tuoi dispositivi. I tuoi valori di laboratorio restano in Apple Salute."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ダッシュボードのレイアウト（カードの順序、固定・非表示の設定、ニックネーム）をデバイス間で同期します。検査値はAppleヘルスケアに残ります。"
+            "value" : "ダッシュボードのレイアウト（カードの順序、固定・非表示の設定、ニックネーム、基準範囲）をデバイス間で同期します。検査値はAppleヘルスケアに残ります。"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde, wat je vastzet en verbergt, plus je bijnamen — op al je apparaten. Je labwaarden blijven in Apple Gezondheid."
+            "value" : "Synchroniseer je dashboardindeling — de kaartvolgorde, wat je vastzet en verbergt, je bijnamen plus je referentiebereiken — op al je apparaten. Je labwaarden blijven in Apple Gezondheid."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizuj układ pulpitu — kolejność kart, to, co przypinasz i ukrywasz, oraz pseudonimy — między urządzeniami. Twoje wyniki badań pozostają w Apple Zdrowiu."
+            "value" : "Synchronizuj układ pulpitu — kolejność kart, to, co przypinasz i ukrywasz, pseudonimy oraz zakresy referencyjne — między urządzeniami. Twoje wyniki badań pozostają w Apple Zdrowiu."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronize o layout do seu painel — a ordem dos cartões, o que você fixa e oculta e seus apelidos — entre seus dispositivos. Seus valores de exames ficam no Apple Saúde."
+            "value" : "Sincronize o layout do seu painel — a ordem dos cartões, o que você fixa e oculta, seus apelidos e suas faixas de referência — entre seus dispositivos. Seus valores de exames ficam no Apple Saúde."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизируйте оформление панели — порядок карточек, что закреплено и скрыто, а также ваши псевдонимы — между устройствами. Ваши лабораторные значения остаются в Apple Здоровье."
+            "value" : "Синхронизируйте оформление панели — порядок карточек, что закреплено и скрыто, ваши псевдонимы, а также референсные диапазоны — между устройствами. Ваши лабораторные значения остаются в Apple Здоровье."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pano düzeninizi — kart sırası, sabitlediğiniz ve gizlediğiniz öğeler ile takma adlarınızı — cihazlarınız arasında senkronlayın. Laboratuvar değerleriniz Apple Sağlık’ta kalır."
+            "value" : "Pano düzeninizi — kart sırası, sabitlediğiniz ve gizlediğiniz öğeler, takma adlarınız ve referans aralıklarınızı — cihazlarınız arasında senkronlayın. Laboratuvar değerleriniz Apple Sağlık’ta kalır."
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронізуйте вигляд панелі — порядок карток, що закріплено й приховано, а також ваші псевдоніми — між пристроями. Ваші лабораторні значення залишаються в Apple Здоров’я."
+            "value" : "Синхронізуйте вигляд панелі — порядок карток, що закріплено й приховано, ваші псевдоніми, а також референсні діапазони — між пристроями. Ваші лабораторні значення залишаються в Apple Здоров’я."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在你的设备间同步仪表板布局——卡片顺序、置顶和隐藏的设置，以及你的昵称。你的化验数值保留在 Apple 健康中。"
+            "value" : "在你的设备间同步仪表板布局——卡片顺序、置顶和隐藏的设置、你的昵称，以及你的参考范围。你的化验数值保留在 Apple 健康中。"
           }
         }
       }

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,6 +1,614 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "High" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élevé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高い"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoog"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysoki"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высокий"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yüksek"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Високий"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏高"
+          }
+        }
+      }
+    },
+    "Low" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niedrig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低い"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laag"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niski"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низкий"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Düşük"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низький"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏低"
+          }
+        }
+      }
+    },
+    "In range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Normbereich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En rango"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans la plage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nell’intervallo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲内"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Binnen bereik"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W normie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na faixa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В норме"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aralıkta"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "У нормі"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "范围内"
+          }
+        }
+      }
+    },
+    "Reference Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango de referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage de référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo di riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakres referencyjny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa de referência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсный диапазон"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans Aralığı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсний діапазон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考范围"
+          }
+        }
+      }
+    },
+    "Set Reference Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich festlegen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Establecer rango de referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définir la plage de référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta intervallo di riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲を設定"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik instellen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw zakres referencyjny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definir faixa de referência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задать референсный диапазон"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans Aralığı Belirle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задати референсний діапазон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置参考范围"
+          }
+        }
+      }
+    },
+    "Reference range %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango de referencia %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage de référence %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo di riferimento %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakres referencyjny %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa de referência %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсный диапазон %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans aralığı %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсний діапазон %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考范围 %@"
+          }
+        }
+      }
+    },
+    "Set the normal range for “%@”. Results outside it are flagged across the app. Leave a field blank for no limit." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normbereich für „%@“ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Define el rango normal de «%@». Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez la plage normale de « %@ ». Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta l’intervallo normale per “%@”. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」の基準範囲を設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stel het normale bereik voor ‘%@’ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw normalny zakres dla „%@”. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina a faixa normal de “%@”. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальный диапазон для «%@». Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” için normal aralığı belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальний діапазон для «%@». Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置“%@”的正常范围。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
+          }
+        }
+      }
+    },
+    "Set the normal range for “%@” in %@. Results outside it are flagged across the app. Leave a field blank for no limit." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normbereich für „%@“ in %@ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Define el rango normal de «%@» en %@. Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez la plage normale de « %@ » en %@. Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta l’intervallo normale per “%@” in %@. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」の基準範囲を %@ で設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stel het normale bereik voor ‘%@’ in %@ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw normalny zakres dla „%@” w %@. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina a faixa normal de “%@” em %@. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальный диапазон для «%@» в %@. Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” için normal aralığı %@ cinsinden belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальний діапазон для «%@» у %@. Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置“%@”的正常范围（单位：%@）。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
+          }
+        }
+      }
+    },
     "" : {
 
     },

--- a/LabImporter/Models/LabDisplayPreferences.swift
+++ b/LabImporter/Models/LabDisplayPreferences.swift
@@ -12,6 +12,13 @@ struct LabDisplayPreferences: RawRepresentable {
     /// standard LOINC English display (see `LabMapping.loincCode(for:)`).
     /// Persisted under the legacy JSON key `customNames` (see `Payload`).
     var nicknames: [String: String] = [:]
+    /// User-defined reference (normal) ranges, keyed by LOINC code. Empty until
+    /// the user sets one in Sort & Visibility (or the trends screen). Like
+    /// nicknames these are cosmetic — they drive the out-of-range badges across
+    /// the app via `LabMapping.referenceRange(for:)` but never reach the exported
+    /// CDA. There is no bundled default: LOINC ships no ranges (see
+    /// `ReferenceRange`), so clearing one simply removes the flagging.
+    var referenceRanges: [String: ReferenceRange] = [:]
 
     init() {}
 
@@ -23,11 +30,13 @@ struct LabDisplayPreferences: RawRepresentable {
         orderedCodes = decoded.orderedCodes
         hiddenCodes = decoded.hiddenCodes
         nicknames = decoded.customNames ?? [:]
+        referenceRanges = decoded.referenceRanges ?? [:]
     }
 
     var rawValue: String {
         let payload = Payload(pinnedCodes: pinnedCodes, orderedCodes: orderedCodes,
-                              hiddenCodes: hiddenCodes, customNames: nicknames)
+                              hiddenCodes: hiddenCodes, customNames: nicknames,
+                              referenceRanges: referenceRanges)
         return (try? JSONEncoder().encode(payload)).flatMap { String(data: $0, encoding: .utf8) } ?? ""
     }
 
@@ -56,6 +65,25 @@ struct LabDisplayPreferences: RawRepresentable {
         }
     }
 
+    /// The user's reference range for `code`, or `nil` if none is set (or the
+    /// stored one is empty, i.e. constrains nothing).
+    func referenceRange(for code: String) -> ReferenceRange? {
+        let trimmed = code.trimmingCharacters(in: .whitespaces)
+        guard let range = referenceRanges[trimmed], !range.isEmpty else { return nil }
+        return range
+    }
+
+    /// Sets (or, when `range` is `nil`/empty, clears — the per-code "reset") the
+    /// reference range for `code`. Clearing removes out-of-range flagging.
+    mutating func setReferenceRange(_ range: ReferenceRange?, for code: String) {
+        let trimmedCode = code.trimmingCharacters(in: .whitespaces)
+        if let range, !range.isEmpty {
+            referenceRanges[trimmedCode] = range
+        } else {
+            referenceRanges.removeValue(forKey: trimmedCode)
+        }
+    }
+
     // Separate Codable type breaks the Codable+RawRepresentable encoding cycle.
     // If LabDisplayPreferences itself were Codable, the stdlib's RawRepresentable
     // default encode(to:) would call self.rawValue → JSONEncoder.encode(self) → infinite recursion.
@@ -69,6 +97,10 @@ struct LabDisplayPreferences: RawRepresentable {
         // decode (older builds likewise ignore this unknown key, so the layout
         // keeps roaming both ways).
         var customNames: [String: String]?
+        // Optional for the same forward/backward-compat reason as `customNames`:
+        // blobs written before ranges existed (or synced from an older build)
+        // decode fine, and older builds ignore this unknown key when roaming.
+        var referenceRanges: [String: ReferenceRange]?
     }
 }
 

--- a/LabImporter/Models/LabMapping.swift
+++ b/LabImporter/Models/LabMapping.swift
@@ -48,4 +48,20 @@ enum LabMapping {
         guard let term = LoincDirectory.shared.term(for: trimmed) else { return nil }
         return (term.code, term.englishName)
     }
+
+    // MARK: - Reference ranges
+
+    // The user's reference range for a code, or nil if they haven't set one.
+    // Read centrally (like `displayName`) so the range flows to every screen that
+    // shows a value. Ranges are a display preference only and never reach the CDA.
+    static func referenceRange(for code: String) -> ReferenceRange? {
+        LabDisplayPreferences.current().referenceRange(for: code)
+    }
+
+    // Classifies `value` against the user's range for `code`. Returns nil when
+    // there is no value or no range, so callers can skip the badge entirely.
+    static func rangeStatus(for value: Double?, code: String) -> RangeStatus? {
+        guard let value, let range = referenceRange(for: code) else { return nil }
+        return range.status(for: value)
+    }
 }

--- a/LabImporter/Models/ReferenceRange.swift
+++ b/LabImporter/Models/ReferenceRange.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A user-defined reference (normal) range for a single LOINC code, used to flag
+/// results as out of range across the app. LOINC deliberately ships **no**
+/// reference ranges — they depend on the lab's instrument, method, population,
+/// age and sex — so there is no bundled default to fall back to. Ranges are
+/// therefore purely the user's own: set per code in the dashboard's Sort &
+/// Visibility editor (or the trends screen), stored alongside nicknames in
+/// `LabDisplayPreferences`, and synced via iCloud. Like nicknames, a range is a
+/// cosmetic display preference — it is **never** written to the exported CDA.
+///
+/// Either bound may be `nil` to express a one-sided limit (e.g. only an upper
+/// bound for a marker that has no meaningful floor). An all-`nil` range is
+/// "empty" and is treated as no range at all (see `LabDisplayPreferences`).
+struct ReferenceRange: Codable, Equatable {
+    /// Lower bound, inclusive. `nil` means "no lower limit".
+    var low: Double?
+    /// Upper bound, inclusive. `nil` means "no upper limit".
+    var high: Double?
+
+    /// A range that constrains nothing — equivalent to having no range. Used to
+    /// decide whether to persist or clear an entry.
+    var isEmpty: Bool { low == nil && high == nil }
+
+    /// Classifies `value` against this range. Bounds are inclusive, so a value
+    /// equal to a limit counts as in range.
+    func status(for value: Double) -> RangeStatus {
+        if let high, value > high { return .high }
+        if let low, value < low { return .low }
+        return .normal
+    }
+
+    /// A localized, human-readable rendering of the range for subtitles and chart
+    /// labels: `3.5–5.3`, `≤ 5.3` (upper bound only), or `≥ 3.5` (lower only),
+    /// with `unit` appended when given. Numbers use the current locale's decimal
+    /// separator. Returns an empty string for an empty range.
+    func formatted(unit: String = "") -> String {
+        let suffix = unit.isEmpty ? "" : " \(unit)"
+        let body: String
+        switch (low, high) {
+        case let (low?, high?): body = "\(Self.number(low))–\(Self.number(high))"
+        case let (nil, high?):  body = "≤ \(Self.number(high))"
+        case let (low?, nil):   body = "≥ \(Self.number(low))"
+        case (nil, nil):        return ""
+        }
+        return body + suffix
+    }
+
+    private static let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 4
+        return formatter
+    }()
+
+    private static func number(_ value: Double) -> String {
+        formatter.string(from: value as NSNumber) ?? String(value)
+    }
+}
+
+/// Where a result sits relative to its reference range. `.normal` covers both an
+/// in-range value and the absence of either bound on that side.
+enum RangeStatus: Equatable {
+    case low
+    case normal
+    case high
+
+    /// True for `.low`/`.high` — the cases the UI surfaces with a badge.
+    var isOutOfRange: Bool { self != .normal }
+}

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -25,6 +25,18 @@ struct MetricCard: View {
         LabCategory.forCode(metric.entry.code).color
     }
 
+    /// Out-of-range status of the latest reading against the user's reference
+    /// range for this code, or `nil` when there's no value or no range.
+    private var rangeStatus: RangeStatus? {
+        LabMapping.rangeStatus(for: metric.entry.numericValue, code: metric.entry.code)
+    }
+
+    /// The value's colour: tinted by its out-of-range status, else primary.
+    private var valueForeground: Color {
+        if let rangeStatus, rangeStatus.isOutOfRange { return rangeStatus.color }
+        return .primary
+    }
+
     /// Direction of the latest reading relative to the previous one, used to show
     /// a small trend arrow in the overview. `nil` when there is no prior value to
     /// compare against.
@@ -100,7 +112,7 @@ struct MetricCard: View {
             HStack(alignment: .firstTextBaseline, spacing: 3) {
                 Text(metric.entry.displayValue)
                     .font(.title2.bold())
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(valueForeground)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
                 if !metric.entry.unit.isEmpty {
@@ -110,6 +122,11 @@ struct MetricCard: View {
                         .lineLimit(1)
                 }
                 Spacer(minLength: 0)
+                if let rangeStatus {
+                    RangeStatusBadge(status: rangeStatus,
+                                     range: LabMapping.referenceRange(for: metric.entry.code),
+                                     unit: metric.entry.unit)
+                }
             }
 
             if metric.history.count > 1 {

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -149,35 +149,52 @@ struct MetricCard: View {
         )
     }
 
-    /// Y-axis domain pinned to the readings (with a little padding) so reference
-    /// guides drawn outside it clip rather than rescaling and flattening the
-    /// trend. A flat series gets a unit window so it doesn't collapse to a line.
+    /// Reference bounds to draw on the sparkline: only those close enough to the
+    /// readings that showing them won't squash the trend (or stray off-card). A
+    /// bound farther than the tolerance from the data is dropped. The tolerance
+    /// is half the reading span, with a floor so a flat/near-flat series still
+    /// admits a nearby bound.
+    private var sparklineBounds: (low: Double?, high: Double?) {
+        let values = metric.history.map(\.value)
+        guard let dataLo = values.min(), let dataHi = values.max(), let range = referenceRange else {
+            return (nil, nil)
+        }
+        let tolerance = max((dataHi - dataLo) * 0.5, abs(dataHi) * 0.1, 0.5)
+        return (low: range.low.flatMap { $0 >= dataLo - tolerance ? $0 : nil },
+                high: range.high.flatMap { $0 <= dataHi + tolerance ? $0 : nil })
+    }
+
+    /// Y-axis domain covering the readings *and* any drawn reference bound, padded
+    /// so nothing hugs an edge. Folding the bound into the scale (rather than
+    /// pinning to the data alone) keeps a near-the-max threshold from cramming
+    /// against the top. A flat series gets a unit window so it doesn't collapse.
     private var sparklineDomain: ClosedRange<Double> {
         let values = metric.history.map(\.value)
-        let low = values.min() ?? 0
-        let high = values.max() ?? 1
-        guard low < high else { return (low - 1)...(high + 1) }
-        let pad = (high - low) * 0.15
-        return (low - pad)...(high + pad)
+        var dataLo = values.min() ?? 0
+        var dataHi = values.max() ?? 1
+        let bounds = sparklineBounds
+        if let low = bounds.low { dataLo = min(dataLo, low) }
+        if let high = bounds.high { dataHi = max(dataHi, high) }
+        guard dataLo < dataHi else { return (dataLo - 1)...(dataHi + 1) }
+        let pad = (dataHi - dataLo) * 0.15
+        return (dataLo - pad)...(dataHi + pad)
     }
 
     private var sparkline: some View {
-        Chart {
-            // Faint dashed guides at the reference bounds. Only drawn when the
-            // bound falls inside the data-pinned Y scale (below): a bound far from
-            // the readings is omitted rather than rescaling and flattening the
-            // trend — or drawing a stray line past the card edge.
-            if let range = referenceRange {
-                if let low = range.low, sparklineDomain.contains(low) {
-                    RuleMark(y: .value("Low", low))
-                        .foregroundStyle(RangeStatus.low.color.opacity(0.35))
-                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
-                }
-                if let high = range.high, sparklineDomain.contains(high) {
-                    RuleMark(y: .value("High", high))
-                        .foregroundStyle(RangeStatus.high.color.opacity(0.35))
-                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
-                }
+        let bounds = sparklineBounds
+        return Chart {
+            // Faint dashed guides at the reference bounds (those near the readings;
+            // see `sparklineBounds`). Both are folded into the Y scale, so a guide
+            // always sits inside the frame with margin.
+            if let low = bounds.low {
+                RuleMark(y: .value("Low", low))
+                    .foregroundStyle(RangeStatus.low.color.opacity(0.35))
+                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
+            }
+            if let high = bounds.high {
+                RuleMark(y: .value("High", high))
+                    .foregroundStyle(RangeStatus.high.color.opacity(0.35))
+                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
             }
 
             ForEach(metric.history) { point in

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -149,24 +149,8 @@ struct MetricCard: View {
         )
     }
 
-    /// Reference bounds to draw on the sparkline: only those that fall *strictly
-    /// within* the readings' own range. Such a guide marks where the trend crosses
-    /// a threshold without touching the chart's automatic scale — so the sparkline
-    /// renders exactly as it does with no range set. A bound outside the data is
-    /// dropped (drawing it would either rescale and flatten the line or just sit
-    /// uselessly on an edge); the value tint and badge already convey that case.
-    private var sparklineBounds: (low: Double?, high: Double?) {
-        let values = metric.history.map(\.value)
-        guard let dataLo = values.min(), let dataHi = values.max(), let range = referenceRange else {
-            return (nil, nil)
-        }
-        let inside: (Double) -> Double? = { $0 > dataLo && $0 < dataHi ? $0 : nil }
-        return (low: range.low.flatMap(inside), high: range.high.flatMap(inside))
-    }
-
     private var sparkline: some View {
-        let bounds = sparklineBounds
-        return Chart {
+        Chart {
             ForEach(metric.history) { point in
                 LineMark(
                     x: .value("Date", point.date),
@@ -194,15 +178,16 @@ struct MetricCard: View {
                 .symbolSize(20)
             }
 
-            // Faint dashed guides at the reference bounds. Only the bounds that lie
-            // within the readings (see `sparklineBounds`) are drawn, so they never
-            // disturb the automatic Y scale.
-            if let low = bounds.low {
+            // Faint dashed guides at the reference bounds. No explicit Y scale is
+            // set, so Charts auto-includes these in the domain — the marks stay
+            // inside the plot (never spilling past the card) and the data simply
+            // shares the height with them.
+            if let low = referenceRange?.low {
                 RuleMark(y: .value("Low", low))
                     .foregroundStyle(RangeStatus.low.color.opacity(0.4))
                     .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
             }
-            if let high = bounds.high {
+            if let high = referenceRange?.high {
                 RuleMark(y: .value("High", high))
                     .foregroundStyle(RangeStatus.high.color.opacity(0.4))
                     .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -143,6 +143,10 @@ struct MetricCard: View {
         .padding(14)
         .frame(maxWidth: .infinity, minHeight: 158, alignment: .topLeading)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        // Keep all content — notably the chart — inside the card outline, so a
+        // mark drawn to the frame edge follows the rounded corners instead of
+        // spilling past the bottom.
+        .clipShape(RoundedRectangle(cornerRadius: 20))
         .overlay(
             RoundedRectangle(cornerRadius: 20)
                 .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
@@ -231,8 +235,5 @@ struct MetricCard: View {
         // fixed-height chart with blank padding beneath it. `minHeight` keeps a
         // sensible floor when a card's row is short.
         .frame(minHeight: 44, maxHeight: .infinity)
-        // Belt-and-suspenders: clip to the final frame so no mark can draw past
-        // the chart (and the card edge) regardless of scale.
-        .clipped()
     }
 }

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -25,6 +25,11 @@ struct MetricCard: View {
         LabCategory.forCode(metric.entry.code).color
     }
 
+    /// The user's reference range for this metric's code, if set.
+    private var referenceRange: ReferenceRange? {
+        LabMapping.referenceRange(for: metric.entry.code)
+    }
+
     /// Out-of-range status of the latest reading against the user's reference
     /// range for this code, or `nil` when there's no value or no range.
     private var rangeStatus: RangeStatus? {
@@ -124,7 +129,7 @@ struct MetricCard: View {
                 Spacer(minLength: 0)
                 if let rangeStatus {
                     RangeStatusBadge(status: rangeStatus,
-                                     range: LabMapping.referenceRange(for: metric.entry.code),
+                                     range: referenceRange,
                                      unit: metric.entry.unit)
                 }
             }
@@ -144,33 +149,64 @@ struct MetricCard: View {
         )
     }
 
+    /// Y-axis domain pinned to the readings (with a little padding) so reference
+    /// guides drawn outside it clip rather than rescaling and flattening the
+    /// trend. A flat series gets a unit window so it doesn't collapse to a line.
+    private var sparklineDomain: ClosedRange<Double> {
+        let values = metric.history.map(\.value)
+        let low = values.min() ?? 0
+        let high = values.max() ?? 1
+        guard low < high else { return (low - 1)...(high + 1) }
+        let pad = (high - low) * 0.15
+        return (low - pad)...(high + pad)
+    }
+
     private var sparkline: some View {
-        Chart(metric.history) { point in
-            LineMark(
-                x: .value("Date", point.date),
-                y: .value("Value", point.value)
-            )
-            .foregroundStyle(categoryColor.opacity(0.85))
+        Chart {
+            // Faint dashed guides at the reference bounds. The Y scale is pinned to
+            // the data range (below), so a bound far from the data clips instead of
+            // flattening the trend — it only shows when the readings approach it.
+            if let range = referenceRange {
+                if let low = range.low {
+                    RuleMark(y: .value("Low", low))
+                        .foregroundStyle(RangeStatus.low.color.opacity(0.35))
+                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
+                }
+                if let high = range.high {
+                    RuleMark(y: .value("High", high))
+                        .foregroundStyle(RangeStatus.high.color.opacity(0.35))
+                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
+                }
+            }
 
-            AreaMark(
-                x: .value("Date", point.date),
-                y: .value("Value", point.value)
-            )
-            .foregroundStyle(
-                LinearGradient(
-                    colors: [categoryColor.opacity(0.3), categoryColor.opacity(0.05)],
-                    startPoint: .top,
-                    endPoint: .bottom
+            ForEach(metric.history) { point in
+                LineMark(
+                    x: .value("Date", point.date),
+                    y: .value("Value", point.value)
                 )
-            )
+                .foregroundStyle(categoryColor.opacity(0.85))
 
-            PointMark(
-                x: .value("Date", point.date),
-                y: .value("Value", point.value)
-            )
-            .foregroundStyle(categoryColor)
-            .symbolSize(20)
+                AreaMark(
+                    x: .value("Date", point.date),
+                    y: .value("Value", point.value)
+                )
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [categoryColor.opacity(0.3), categoryColor.opacity(0.05)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+
+                PointMark(
+                    x: .value("Date", point.date),
+                    y: .value("Value", point.value)
+                )
+                .foregroundStyle(categoryColor)
+                .symbolSize(20)
+            }
         }
+        .chartYScale(domain: sparklineDomain)
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         // Grow to absorb the card's remaining vertical space instead of leaving a

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -163,16 +163,17 @@ struct MetricCard: View {
 
     private var sparkline: some View {
         Chart {
-            // Faint dashed guides at the reference bounds. The Y scale is pinned to
-            // the data range (below), so a bound far from the data clips instead of
-            // flattening the trend — it only shows when the readings approach it.
+            // Faint dashed guides at the reference bounds. Only drawn when the
+            // bound falls inside the data-pinned Y scale (below): a bound far from
+            // the readings is omitted rather than rescaling and flattening the
+            // trend — or drawing a stray line past the card edge.
             if let range = referenceRange {
-                if let low = range.low {
+                if let low = range.low, sparklineDomain.contains(low) {
                     RuleMark(y: .value("Low", low))
                         .foregroundStyle(RangeStatus.low.color.opacity(0.35))
                         .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
                 }
-                if let high = range.high {
+                if let high = range.high, sparklineDomain.contains(high) {
                     RuleMark(y: .value("High", high))
                         .foregroundStyle(RangeStatus.high.color.opacity(0.35))
                         .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
@@ -213,5 +214,8 @@ struct MetricCard: View {
         // fixed-height chart with blank padding beneath it. `minHeight` keeps a
         // sensible floor when a card's row is short.
         .frame(minHeight: 44, maxHeight: .infinity)
+        // Belt-and-suspenders: clip to the final frame so no mark can draw past
+        // the chart (and the card edge) regardless of scale.
+        .clipped()
     }
 }

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -143,64 +143,30 @@ struct MetricCard: View {
         .padding(14)
         .frame(maxWidth: .infinity, minHeight: 158, alignment: .topLeading)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-        // Keep all content — notably the chart — inside the card outline, so a
-        // mark drawn to the frame edge follows the rounded corners instead of
-        // spilling past the bottom.
-        .clipShape(RoundedRectangle(cornerRadius: 20))
         .overlay(
             RoundedRectangle(cornerRadius: 20)
                 .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
         )
     }
 
-    /// Reference bounds to draw on the sparkline: only those close enough to the
-    /// readings that showing them won't squash the trend (or stray off-card). A
-    /// bound farther than the tolerance from the data is dropped. The tolerance
-    /// is half the reading span, with a floor so a flat/near-flat series still
-    /// admits a nearby bound.
+    /// Reference bounds to draw on the sparkline: only those that fall *strictly
+    /// within* the readings' own range. Such a guide marks where the trend crosses
+    /// a threshold without touching the chart's automatic scale — so the sparkline
+    /// renders exactly as it does with no range set. A bound outside the data is
+    /// dropped (drawing it would either rescale and flatten the line or just sit
+    /// uselessly on an edge); the value tint and badge already convey that case.
     private var sparklineBounds: (low: Double?, high: Double?) {
         let values = metric.history.map(\.value)
         guard let dataLo = values.min(), let dataHi = values.max(), let range = referenceRange else {
             return (nil, nil)
         }
-        let tolerance = max((dataHi - dataLo) * 0.5, abs(dataHi) * 0.1, 0.5)
-        return (low: range.low.flatMap { $0 >= dataLo - tolerance ? $0 : nil },
-                high: range.high.flatMap { $0 <= dataHi + tolerance ? $0 : nil })
-    }
-
-    /// Y-axis domain covering the readings *and* any drawn reference bound, padded
-    /// so nothing hugs an edge. Folding the bound into the scale (rather than
-    /// pinning to the data alone) keeps a near-the-max threshold from cramming
-    /// against the top. A flat series gets a unit window so it doesn't collapse.
-    private var sparklineDomain: ClosedRange<Double> {
-        let values = metric.history.map(\.value)
-        var dataLo = values.min() ?? 0
-        var dataHi = values.max() ?? 1
-        let bounds = sparklineBounds
-        if let low = bounds.low { dataLo = min(dataLo, low) }
-        if let high = bounds.high { dataHi = max(dataHi, high) }
-        guard dataLo < dataHi else { return (dataLo - 1)...(dataHi + 1) }
-        let pad = (dataHi - dataLo) * 0.15
-        return (dataLo - pad)...(dataHi + pad)
+        let inside: (Double) -> Double? = { $0 > dataLo && $0 < dataHi ? $0 : nil }
+        return (low: range.low.flatMap(inside), high: range.high.flatMap(inside))
     }
 
     private var sparkline: some View {
         let bounds = sparklineBounds
         return Chart {
-            // Faint dashed guides at the reference bounds (those near the readings;
-            // see `sparklineBounds`). Both are folded into the Y scale, so a guide
-            // always sits inside the frame with margin.
-            if let low = bounds.low {
-                RuleMark(y: .value("Low", low))
-                    .foregroundStyle(RangeStatus.low.color.opacity(0.35))
-                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
-            }
-            if let high = bounds.high {
-                RuleMark(y: .value("High", high))
-                    .foregroundStyle(RangeStatus.high.color.opacity(0.35))
-                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
-            }
-
             ForEach(metric.history) { point in
                 LineMark(
                     x: .value("Date", point.date),
@@ -227,8 +193,21 @@ struct MetricCard: View {
                 .foregroundStyle(categoryColor)
                 .symbolSize(20)
             }
+
+            // Faint dashed guides at the reference bounds. Only the bounds that lie
+            // within the readings (see `sparklineBounds`) are drawn, so they never
+            // disturb the automatic Y scale.
+            if let low = bounds.low {
+                RuleMark(y: .value("Low", low))
+                    .foregroundStyle(RangeStatus.low.color.opacity(0.4))
+                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
+            }
+            if let high = bounds.high {
+                RuleMark(y: .value("High", high))
+                    .foregroundStyle(RangeStatus.high.color.opacity(0.4))
+                    .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [3, 2]))
+            }
         }
-        .chartYScale(domain: sparklineDomain)
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         // Grow to absorb the card's remaining vertical space instead of leaving a

--- a/LabImporter/Views/Dashboard/TrendWindow.swift
+++ b/LabImporter/Views/Dashboard/TrendWindow.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+extension TrendsView {
+    /// Selectable time window; a finite case fixes the visible x-span, `.all` fits everything.
+    enum TrendWindow: String, CaseIterable, Identifiable {
+        case month3, month6, year1, all
+        var id: Self { self }
+
+        /// Visible span in days, or `nil` for "fit everything".
+        var days: Int? {
+            switch self {
+            case .month3: return 92
+            case .month6: return 183
+            case .year1: return 366
+            case .all: return nil
+            }
+        }
+
+        var label: LocalizedStringKey {
+            switch self {
+            case .month3: return "3M"
+            case .month6: return "6M"
+            case .year1: return "1Y"
+            case .all: return "All"
+            }
+        }
+    }
+}

--- a/LabImporter/Views/Dashboard/TrendsView.swift
+++ b/LabImporter/Views/Dashboard/TrendsView.swift
@@ -24,6 +24,9 @@ struct TrendsView: View {
     @State private var showHideConfirmation = false
     @State private var renamingCode: String?
     @State private var renameDraft = ""
+    @State private var rangingCode: String?
+    @State private var rangeLowDraft = ""
+    @State private var rangeHighDraft = ""
     private let selectionFeedback = UISelectionFeedbackGenerator()
     private let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
 
@@ -82,6 +85,17 @@ struct TrendsView: View {
 
     private var isPinned: Bool { prefs.pinnedSet.contains(selectedCode) }
 
+    /// The user's reference range for the metric on screen, or `nil` if unset.
+    /// Drives the dashed band lines and the per-point out-of-range tinting.
+    private var referenceRange: ReferenceRange? { prefs.referenceRange(for: selectedCode) }
+
+    /// Colour for a plotted point: the out-of-range status tint when the value
+    /// falls outside the reference range, otherwise the metric's category colour.
+    private func pointColor(_ value: Double) -> Color {
+        if let status = referenceRange?.status(for: value), status.isOutOfRange { return status.color }
+        return valueColor
+    }
+
     private var selectedName: String {
         availableCodes.first(where: { $0.code == selectedCode })?.name ?? "Trends"
     }
@@ -115,6 +129,8 @@ struct TrendsView: View {
             Text("This metric will no longer appear on your dashboard. You can show it again from Settings.")
         }
         .renameLabAlert(code: $renamingCode, draft: $renameDraft, prefs: $prefs)
+        .referenceRangeAlert(code: $rangingCode, low: $rangeLowDraft, high: $rangeHighDraft,
+                             unit: currentUnit, prefs: $prefs)
         .onAppear {
             let codes = availableCodes.map(\.code)
             if let initial = initialCode, codes.contains(initial) {
@@ -145,6 +161,11 @@ struct TrendsView: View {
                 renamingCode = selectedCode
             } label: {
                 Label("Rename", systemImage: "pencil")
+            }
+            Button {
+                startSetRange()
+            } label: {
+                Label("Set Reference Range", systemImage: "ruler")
             }
             Button {
                 togglePin(selectedCode)
@@ -206,8 +227,26 @@ struct TrendsView: View {
         }
     }
 
+}
+
+// MARK: - Chart
+
+extension TrendsView {
     private var trendChart: some View {
         Chart {
+            if let range = referenceRange {
+                if let low = range.low {
+                    RuleMark(y: .value(String(localized: "Low"), low))
+                        .foregroundStyle(RangeStatus.low.color.opacity(0.45))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                }
+                if let high = range.high {
+                    RuleMark(y: .value(String(localized: "High"), high))
+                        .foregroundStyle(RangeStatus.high.color.opacity(0.45))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                }
+            }
+
             ForEach(dataPoints) { point in
                 LineMark(
                     x: .value(String(localized: "Date"), point.date),
@@ -219,7 +258,7 @@ struct TrendsView: View {
                     x: .value(String(localized: "Date"), point.date),
                     y: .value(currentUnit, point.value)
                 )
-                .foregroundStyle(valueColor)
+                .foregroundStyle(pointColor(point.value))
 
                 AreaMark(
                     x: .value(String(localized: "Date"), point.date),
@@ -336,31 +375,6 @@ struct TrendsView: View {
 // MARK: - Helpers
 
 extension TrendsView {
-    /// Selectable time window; a finite case fixes the visible x-span, `.all` fits everything.
-    enum TrendWindow: String, CaseIterable, Identifiable {
-        case month3, month6, year1, all
-        var id: Self { self }
-
-        /// Visible span in days, or `nil` for "fit everything".
-        var days: Int? {
-            switch self {
-            case .month3: return 92
-            case .month6: return 183
-            case .year1: return 366
-            case .all: return nil
-            }
-        }
-
-        var label: LocalizedStringKey {
-            switch self {
-            case .month3: return "3M"
-            case .month6: return "6M"
-            case .year1: return "1Y"
-            case .all: return "All"
-            }
-        }
-    }
-
     /// Static unit caption pinned to the card (`chartYAxisLabel` rides the scrollable plot).
     @ViewBuilder
     var unitBadge: some View {
@@ -421,6 +435,19 @@ extension TrendsView {
         impactFeedback.impactOccurred()
     }
 
+    /// Seeds the range fields from the current range (if any) and opens the editor
+    /// for the metric on screen.
+    func startSetRange() {
+        let range = prefs.referenceRange(for: selectedCode)
+        rangeLowDraft = range?.low.map { Self.fieldText($0) } ?? ""
+        rangeHighDraft = range?.high.map { Self.fieldText($0) } ?? ""
+        rangingCode = selectedCode
+    }
+
+    private static func fieldText(_ value: Double) -> String {
+        value == value.rounded() ? String(format: "%.0f", value) : String(value)
+    }
+
     /// Hides the selected metric from the dashboard and dismisses the trend view,
     /// since the value is no longer surfaced in the overview after hiding.
     private func hideSelected() {
@@ -433,55 +460,6 @@ extension TrendsView {
         prefs = updated
         impactFeedback.impactOccurred()
         onDismiss?()
-    }
-}
-
-// MARK: - ValueDescriptionCard
-
-/// Tappable summary of the selected value's LOINC term shown beneath the trend
-/// chart; navigates to the full structured details (and the loinc.org link).
-private struct ValueDescriptionCard: View {
-    let term: LoincTerm
-
-    var body: some View {
-        NavigationLink {
-            LoincTermDetailView(term: term)
-        } label: {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text("About this value")
-                        .font(.subheadline.weight(.semibold))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-                if let description {
-                    Text(description)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                Text(verbatim: "LOINC \(term.code)")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-            .overlay(
-                RoundedRectangle(cornerRadius: 20)
-                    .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-            )
-            .padding(.horizontal)
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var description: String? {
-        if let description = term.description, !description.isEmpty { return description }
-        // Fall back to the English name when it adds detail beyond the title.
-        return term.englishName == term.name ? nil : term.englishName
     }
 }
 

--- a/LabImporter/Views/Dashboard/ValueDescriptionCard.swift
+++ b/LabImporter/Views/Dashboard/ValueDescriptionCard.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+// MARK: - ValueDescriptionCard
+
+/// Tappable summary of the selected value's LOINC term shown beneath the trend
+/// chart; navigates to the full structured details (and the loinc.org link).
+struct ValueDescriptionCard: View {
+    let term: LoincTerm
+
+    var body: some View {
+        NavigationLink {
+            LoincTermDetailView(term: term)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("About this value")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                if let description {
+                    Text(description)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Text(verbatim: "LOINC \(term.code)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+            )
+            .padding(.horizontal)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var description: String? {
+        if let description = term.description, !description.isEmpty { return description }
+        // Fall back to the English name when it adds detail beyond the title.
+        return term.englishName == term.name ? nil : term.englishName
+    }
+}

--- a/LabImporter/Views/History/ReportDetailView.swift
+++ b/LabImporter/Views/History/ReportDetailView.swift
@@ -222,15 +222,28 @@ struct ReportDetailView: View {
 
             Spacer()
 
+            let status = LabMapping.rangeStatus(for: entry.numericValue, code: entry.code)
+            if let status {
+                RangeStatusBadge(status: status,
+                                 range: LabMapping.referenceRange(for: entry.code),
+                                 unit: entry.unit)
+            }
+
             let valueText = entry.displayValue == "-"
                 ? "–"
                 : "\(entry.displayValue) \(entry.unit)".trimmingCharacters(in: .whitespaces)
 
             Text(valueText)
                 .font(.body.monospacedDigit().weight(.medium))
-                .foregroundStyle(entry.displayValue == "-" ? .secondary : .primary)
+                .foregroundStyle(valueColor(for: entry, status: status))
         }
         .padding(.vertical, 2)
+    }
+
+    private func valueColor(for entry: LabReport.Entry, status: RangeStatus?) -> Color {
+        if entry.displayValue == "-" { return .secondary }
+        if let status, status.isOutOfRange { return status.color }
+        return .primary
     }
 
     // MARK: - Derived data

--- a/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
+++ b/LabImporter/Views/Onboarding/CloudSyncOptInView.swift
@@ -23,8 +23,11 @@ struct CloudSyncOptInView: View {
             Benefit(
                 icon: "icloud.fill",
                 color: LabCategory.cardiac.color,
-                title: "Layout & Names",
-                description: "Only your card layout and the nicknames you give your lab tests sync. Your lab values stay in Apple Health and never leave it."
+                title: "Layout, Names & Ranges",
+                description: """
+                Only your card layout, the nicknames you give your lab tests, and the reference \
+                ranges you set sync. Your lab values stay in Apple Health and never leave it.
+                """
             ),
             Benefit(
                 icon: "slider.horizontal.3",

--- a/LabImporter/Views/Review/LabValueRowView.swift
+++ b/LabImporter/Views/Review/LabValueRowView.swift
@@ -13,6 +13,12 @@ struct LabValueRowView: View {
         LabMapping.loincCode(for: value.code) != nil
     }
 
+    /// Where this row's value sits relative to the user's reference range for the
+    /// code, or `nil` when there is no value or no range (so no badge shows).
+    private var rangeStatus: RangeStatus? {
+        LabMapping.rangeStatus(for: value.numericValue, code: value.code)
+    }
+
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Button {
@@ -52,6 +58,12 @@ struct LabValueRowView: View {
                             .background(Color.orange.opacity(0.15), in: Capsule())
                             .foregroundStyle(.orange)
                             .help("Another value uses the same LOINC code — keep only one")
+                    }
+
+                    if let rangeStatus {
+                        RangeStatusBadge(status: rangeStatus,
+                                         range: LabMapping.referenceRange(for: value.code),
+                                         unit: value.unit)
                     }
                 }
 

--- a/LabImporter/Views/Review/LoincBrowserView.swift
+++ b/LabImporter/Views/Review/LoincBrowserView.swift
@@ -138,6 +138,9 @@ struct LoincTermDetailView: View {
     @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
     @State private var renamingCode: String?
     @State private var renameDraft = ""
+    @State private var rangingCode: String?
+    @State private var rangeLowDraft = ""
+    @State private var rangeHighDraft = ""
 
     // The clinical category drives the accent color used for the header icon,
     // the category chip and the background wash — the same palette charts use.
@@ -191,15 +194,21 @@ struct LoincTermDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    renameDraft = prefs.nickname(for: term.code) ?? ""
-                    renamingCode = term.code
+                Menu {
+                    Button { startRename() } label: {
+                        Label("Rename", systemImage: "pencil")
+                    }
+                    Button { startSetRange() } label: {
+                        Label("Set Reference Range", systemImage: "ruler")
+                    }
                 } label: {
-                    Label("Rename", systemImage: "pencil")
+                    Label("More", systemImage: "ellipsis")
                 }
             }
         }
         .renameLabAlert(code: $renamingCode, draft: $renameDraft, prefs: $prefs)
+        .referenceRangeAlert(code: $rangingCode, low: $rangeLowDraft, high: $rangeHighDraft,
+                             unit: detail?.ucum ?? "", prefs: $prefs)
         .task { detail = LoincDirectory.shared.detail(for: term.code) }
         .sheet(item: $browserURL) { item in
             SafariView(url: item.url)
@@ -241,6 +250,11 @@ struct LoincTermDetailView: View {
                 nicknameRow(nickname)
             }
 
+            if let range = prefs.referenceRange(for: term.code) {
+                Divider()
+                referenceRangeRow(range)
+            }
+
             if let description = detail?.description ?? term.description, !description.isEmpty {
                 Divider()
                 Text(description)
@@ -271,6 +285,47 @@ struct LoincTermDetailView: View {
         .overlay(
             Capsule().stroke(category.color.opacity(0.25), lineWidth: 0.5)
         )
+    }
+
+    // MARK: - Editing
+
+    private func startRename() {
+        renameDraft = prefs.nickname(for: term.code) ?? ""
+        renamingCode = term.code
+    }
+
+    private func startSetRange() {
+        let range = prefs.referenceRange(for: term.code)
+        rangeLowDraft = range?.low.map { Self.fieldText($0) } ?? ""
+        rangeHighDraft = range?.high.map { Self.fieldText($0) } ?? ""
+        rangingCode = term.code
+    }
+
+    /// Renders a stored bound back into an editable field string (trailing zeros
+    /// trimmed) so reopening the editor shows what the user previously entered.
+    private static func fieldText(_ value: Double) -> String {
+        value == value.rounded() ? String(format: "%.0f", value) : String(value)
+    }
+
+    // The user's reference range for this test, shown read-only (editing happens
+    // via the toolbar menu) with a "ruler" glyph, mirroring the nickname row. The
+    // LOINC example unit is appended when known.
+    private func referenceRangeRow(_ range: ReferenceRange) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "ruler")
+                .font(.subheadline)
+                .foregroundStyle(category.color)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Reference Range")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                Text(range.formatted(unit: detail?.ucum ?? ""))
+                    .font(.subheadline.weight(.medium))
+            }
+            Spacer(minLength: 0)
+        }
     }
 
     // The user's nickname for this test, shown as a plainly-labelled read-only

--- a/LabImporter/Views/Settings/LabSortEditor.swift
+++ b/LabImporter/Views/Settings/LabSortEditor.swift
@@ -16,6 +16,11 @@ struct LabSortEditor: View {
     /// The code currently being renamed (drives the rename alert), plus its draft.
     @State private var renamingCode: String?
     @State private var renameDraft = ""
+    /// The code whose reference range is being edited (drives the range alert),
+    /// plus the low/high field drafts.
+    @State private var rangingCode: String?
+    @State private var rangeLowDraft = ""
+    @State private var rangeHighDraft = ""
 
     init(prefs: Binding<LabDisplayPreferences>, allCodes: [CodeName]) {
         _prefs = prefs
@@ -53,11 +58,25 @@ struct LabSortEditor: View {
         .onChange(of: hiddenSet) { save() }
         .onChange(of: pinnedSet) { save() }
         .renameLabAlert(code: $renamingCode, draft: $renameDraft, prefs: $prefs)
+        .referenceRangeAlert(code: $rangingCode, low: $rangeLowDraft, high: $rangeHighDraft, prefs: $prefs)
     }
 
     private func startRename(_ code: String) {
         renameDraft = prefs.nickname(for: code) ?? ""
         renamingCode = code
+    }
+
+    private func startSetRange(_ code: String) {
+        let range = prefs.referenceRange(for: code)
+        rangeLowDraft = range?.low.map { fieldText($0) } ?? ""
+        rangeHighDraft = range?.high.map { fieldText($0) } ?? ""
+        rangingCode = code
+    }
+
+    /// Renders a stored bound back into an editable field string (trailing zeros
+    /// trimmed) so reopening the editor shows what the user previously entered.
+    private func fieldText(_ value: Double) -> String {
+        value == value.rounded() ? String(format: "%.0f", value) : String(value)
     }
 
     /// Visible codes split by pin state. Both partitions preserve their relative
@@ -112,8 +131,20 @@ struct LabSortEditor: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
+                if let range = prefs.referenceRange(for: item.code) {
+                    Label(range.formatted(), systemImage: "ruler")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
+            Button { startSetRange(item.code) } label: {
+                Image(systemName: "ruler")
+                    .foregroundStyle(prefs.referenceRange(for: item.code) != nil
+                                     ? Color.accentColor : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Set Reference Range")
             Button { startRename(item.code) } label: {
                 Image(systemName: "pencil")
                     .foregroundStyle(Color.secondary)

--- a/LabImporter/Views/Settings/LabSortEditor.swift
+++ b/LabImporter/Views/Settings/LabSortEditor.swift
@@ -13,14 +13,10 @@ struct LabSortEditor: View {
     @State private var visibleOrdered: [CodeName]
     @State private var hiddenSet: Set<String>
     @State private var pinnedSet: Set<String>
-    /// The code currently being renamed (drives the rename alert), plus its draft.
-    @State private var renamingCode: String?
-    @State private var renameDraft = ""
-    /// The code whose reference range is being edited (drives the range alert),
-    /// plus the low/high field drafts.
-    @State private var rangingCode: String?
-    @State private var rangeLowDraft = ""
-    @State private var rangeHighDraft = ""
+    /// The LOINC code pushed onto the detail screen, where the user renames the
+    /// metric and sets its reference range. `nil` until they tap a row's info
+    /// button.
+    @State private var detailCode: String?
 
     init(prefs: Binding<LabDisplayPreferences>, allCodes: [CodeName]) {
         _prefs = prefs
@@ -57,26 +53,18 @@ struct LabSortEditor: View {
         .onChange(of: visibleOrdered.map(\.code)) { save() }
         .onChange(of: hiddenSet) { save() }
         .onChange(of: pinnedSet) { save() }
-        .renameLabAlert(code: $renamingCode, draft: $renameDraft, prefs: $prefs)
-        .referenceRangeAlert(code: $rangingCode, low: $rangeLowDraft, high: $rangeHighDraft, prefs: $prefs)
+        .navigationDestination(item: $detailCode) { code in
+            if let term = LoincDirectory.shared.term(for: code) {
+                LoincTermDetailView(term: term)
+            }
+        }
     }
 
-    private func startRename(_ code: String) {
-        renameDraft = prefs.nickname(for: code) ?? ""
-        renamingCode = code
-    }
-
-    private func startSetRange(_ code: String) {
-        let range = prefs.referenceRange(for: code)
-        rangeLowDraft = range?.low.map { fieldText($0) } ?? ""
-        rangeHighDraft = range?.high.map { fieldText($0) } ?? ""
-        rangingCode = code
-    }
-
-    /// Renders a stored bound back into an editable field string (trailing zeros
-    /// trimmed) so reopening the editor shows what the user previously entered.
-    private func fieldText(_ value: Double) -> String {
-        value == value.rounded() ? String(format: "%.0f", value) : String(value)
+    /// Opens the LOINC detail screen for `code`, where renaming and reference
+    /// range editing live. Codes the catalog doesn't know have no detail screen,
+    /// so the info button is hidden for them (see `row(for:)`).
+    private func showDetail(_ code: String) {
+        detailCode = code
     }
 
     /// Visible codes split by pin state. Both partitions preserve their relative
@@ -138,18 +126,16 @@ struct LabSortEditor: View {
                 }
             }
             Spacer()
-            Button { startSetRange(item.code) } label: {
-                Image(systemName: "ruler")
-                    .foregroundStyle(prefs.referenceRange(for: item.code) != nil
-                                     ? Color.accentColor : Color.secondary)
+            // The catalog detail screen hosts renaming and reference-range
+            // editing; only LOINC codes the catalog knows have one.
+            if LoincDirectory.shared.term(for: item.code) != nil {
+                Button { showDetail(item.code) } label: {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Details")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Set Reference Range")
-            Button { startRename(item.code) } label: {
-                Image(systemName: "pencil")
-                    .foregroundStyle(Color.secondary)
-            }
-            .buttonStyle(.plain)
             Button { hideCode(item.code) } label: {
                 Image(systemName: "eye.slash")
                     .foregroundStyle(Color.secondary)

--- a/LabImporter/Views/Settings/ReferenceRangeEditor.swift
+++ b/LabImporter/Views/Settings/ReferenceRangeEditor.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+extension View {
+    /// The shared "Reference Range" alert that sets a user-defined normal range
+    /// for a LOINC `code` — reused by the Sort & Visibility editor and the trends
+    /// screen so the wording and behaviour stay identical everywhere.
+    ///
+    /// LOINC ships no reference ranges, so this is purely the user's own value
+    /// (see `ReferenceRange`). Present it by setting `code`; seed `low`/`high`
+    /// first with the current range so the fields show it for editing. Either
+    /// field may be left blank for a one-sided limit; leaving both blank — or
+    /// tapping "Reset to Default" — clears the range (the per-code reset) and
+    /// removes out-of-range flagging. The chosen range is written to
+    /// `prefs.referenceRanges` and applied across the app via
+    /// `LabMapping.referenceRange(for:)`. `unit`, when known, is shown in the
+    /// message so the user enters bounds in the right unit.
+    func referenceRangeAlert(code: Binding<String?>,
+                             low: Binding<String>,
+                             high: Binding<String>,
+                             unit: String = "",
+                             prefs: Binding<LabDisplayPreferences>) -> some View {
+        let isPresented = Binding(
+            get: { code.wrappedValue != nil },
+            set: { if !$0 { code.wrappedValue = nil } }
+        )
+        return alert("Reference Range", isPresented: isPresented, presenting: code.wrappedValue) { code in
+            TextField("Low", text: low)
+                .keyboardType(.decimalPad)
+            TextField("High", text: high)
+                .keyboardType(.decimalPad)
+            Button("Save") {
+                prefs.wrappedValue.setReferenceRange(
+                    ReferenceRange(low: parse(low.wrappedValue), high: parse(high.wrappedValue)),
+                    for: code
+                )
+            }
+            if prefs.wrappedValue.referenceRange(for: code) != nil {
+                Button("Reset to Default", role: .destructive) {
+                    prefs.wrappedValue.setReferenceRange(nil, for: code)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { code in
+            Text(message(for: code, unit: unit))
+        }
+    }
+}
+
+/// Parses a user-entered bound, tolerating the locale's comma decimal separator
+/// and treating a blank field as "no limit" (`nil`).
+private func parse(_ text: String) -> Double? {
+    let trimmed = text.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: ",", with: ".")
+    return trimmed.isEmpty ? nil : Double(trimmed)
+}
+
+private func message(for code: String, unit: String) -> String {
+    let name = LabMapping.displayName(for: code)
+    if unit.isEmpty {
+        return String(localized: """
+        Set the normal range for “\(name)”. Results outside it are flagged across the app. \
+        Leave a field blank for no limit.
+        """)
+    }
+    return String(localized: """
+    Set the normal range for “\(name)” in \(unit). Results outside it are flagged across the app. \
+    Leave a field blank for no limit.
+    """)
+}

--- a/LabImporter/Views/Settings/SettingsView.swift
+++ b/LabImporter/Views/Settings/SettingsView.swift
@@ -109,8 +109,9 @@ struct SettingsView: View {
                     }
                 } footer: {
                     Text("""
-                    Sync your dashboard layout — the card order, what you pin and hide, and your \
-                    nicknames — across your devices. Your lab values stay in Apple Health.
+                    Sync your dashboard layout — the card order, what you pin and hide, your \
+                    nicknames, and your reference ranges — across your devices. Your lab values \
+                    stay in Apple Health.
                     """)
                 }
 

--- a/LabImporter/Views/Shared/RangeStatusBadge.swift
+++ b/LabImporter/Views/Shared/RangeStatusBadge.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+// MARK: - RangeStatus styling
+
+extension RangeStatus {
+    /// Tint for the badge and for emphasising an out-of-range value. `.normal`
+    /// has no dedicated colour (it is never badged) and falls back to secondary.
+    var color: Color {
+        switch self {
+        case .high: return .orange
+        case .low: return .blue
+        case .normal: return .secondary
+        }
+    }
+
+    /// Directional glyph: a value above its range points up, below points down.
+    var symbolName: String {
+        switch self {
+        case .high: return "arrow.up"
+        case .low: return "arrow.down"
+        case .normal: return "checkmark"
+        }
+    }
+
+    /// Short, localized label shown in the capsule.
+    var label: LocalizedStringKey {
+        switch self {
+        case .high: return "High"
+        case .low: return "Low"
+        case .normal: return "In range"
+        }
+    }
+}
+
+// MARK: - RangeStatusBadge
+
+/// A compact "High"/"Low" capsule shown next to an out-of-range value, matching
+/// the visual language of the existing "Suggested"/"Duplicate" badges. Renders
+/// nothing for an in-range (`.normal`) status, so callers can place it
+/// unconditionally. Drive it from `LabMapping.rangeStatus(for:code:)`.
+struct RangeStatusBadge: View {
+    let status: RangeStatus
+    /// The reference range behind the flag, used for the accessibility hint so
+    /// VoiceOver reads e.g. "High, reference range 3.5–5.3". Optional.
+    var range: ReferenceRange?
+    var unit: String = ""
+
+    var body: some View {
+        if status.isOutOfRange {
+            Label(status.label, systemImage: status.symbolName)
+                .labelStyle(.titleAndIcon)
+                .font(.caption2.weight(.medium))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(status.color.opacity(0.15), in: Capsule())
+                .foregroundStyle(status.color)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilityText)
+        }
+    }
+
+    private var accessibilityText: Text {
+        let prefix = Text(status.label)
+        guard let range, !range.isEmpty else { return prefix }
+        return prefix + Text(verbatim: ", ") + Text("Reference range \(range.formatted(unit: unit))")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(alignment: .leading, spacing: 12) {
+        RangeStatusBadge(status: .high, range: ReferenceRange(low: 3.5, high: 5.3), unit: "%")
+        RangeStatusBadge(status: .low, range: ReferenceRange(low: 3.5, high: 5.3))
+        RangeStatusBadge(status: .normal)
+    }
+    .padding()
+}


### PR DESCRIPTION
## Summary

Adds per-LOINC-code **reference ranges** that the user sets themselves, and flags out-of-range results across the app.

LOINC ships no reference ranges (verified against the bundled `Loinc_2.82.zip` — none of the 40 `Loinc.csv` columns nor any of the 93 release files carry intervals; they're method/population dependent by design). So ranges are the user's own, modelled exactly like the existing **nicknames**: stored in `LabDisplayPreferences`, synced via iCloud, and **never written to the exported CDA**. This means no AI-parser change and no CDA schema migration were needed.

## What's included

**Model & storage**
- New `ReferenceRange` (`low`/`high`, either optional) + `RangeStatus` classifier (inclusive bounds).
- `LabDisplayPreferences.referenceRanges` map with `referenceRange(for:)` / `setReferenceRange(_:for:)`; clearing a code is the per-code "reset". Persisted under a new optional `referenceRanges` payload key (forward/backward compatible, roams via iCloud).
- `LabMapping.referenceRange(for:)` / `rangeStatus(for:code:)` convenience.

**Editing** — consolidated onto the LOINC detail screen
- `LoincTermDetailView` gains a toolbar menu (Rename / Set Reference Range), shows the current range in the header, and seeds the editor from the existing value.
- In **Sort & Visibility**, the per-row ruler/pencil buttons are replaced by a single **info** button that opens the LOINC detail screen (shown only for catalog codes).
- Shared `referenceRangeAlert` modifier (parallels `renameLabAlert`).

**Flagging / visualization**
- High/Low badge + tinted value in **Review**, **Dashboard cards**, and **History detail**.
- **Trends graph**: dashed low/high reference lines + points tinted by status.
- **Card sparklines**: dashed low/high guides drawn via the chart's automatic Y-scale (stays inside the card; no manual scaling).

**Localization**
- New strings (High/Low, Reference Range, editor copy, etc.) localized into all 13 shipped languages.
- The iCloud sync copy (Settings footer + onboarding "Layout, Names & Ranges") now states that ranges sync too — source + 12 translations updated.

## Notes / caveats
- **Not compile-verified**: this environment has no Xcode, so changes are SwiftLint-clean (`--strict`) and brace-balanced but not built. Worth a build + a pass through import → set range → see flagging on a supported device.
- `TrendsView` was split (`ValueDescriptionCard`, `TrendWindow`, a chart extension) to stay within the file/type length limits.
- Ranges are unitless numbers compared directly against the value — they assume the same unit as the reading (no conversion).

https://claude.ai/code/session_013v7n12sCnD7R8U1sy9cR8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013v7n12sCnD7R8U1sy9cR8Z)_