### PR TITLE
Add personalized welcome greeting to dashboard

### DIFF
--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -19451,6 +19451,82 @@
         }
       }
     },
+    "Welcome back, %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen zurück, %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Bienvenido](inflect: true) de nuevo, %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Heureux](inflect: true) de vous revoir, %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Bentornato](inflect: true), %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おかえりなさい、%@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welkom terug, %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Witaj ponownie, %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[Bem-vindo](inflect: true) de volta, %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "С возвращением, %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekrar hoş geldiniz, %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "З поверненням, %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欢迎回来，%@"
+          }
+        }
+      }
+    },
     "Welcome to" : {
       "localizations" : {
         "de" : {
@@ -19462,7 +19538,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bienvenido a"
+            "value" : "^[Bienvenido](inflect: true) a"
           }
         },
         "fr" : {
@@ -19474,7 +19550,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Benvenuto in"
+            "value" : "^[Benvenuto](inflect: true) in"
           }
         },
         "ja" : {
@@ -19498,7 +19574,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bem-vindo ao"
+            "value" : "^[Bem-vindo](inflect: true) ao"
           }
         },
         "ru" : {

--- a/LabImporter/Views/Dashboard/DashboardView.swift
+++ b/LabImporter/Views/Dashboard/DashboardView.swift
@@ -19,6 +19,7 @@ struct DashboardView: View {
     var showsLibraryToolbarItems = true
 
     @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
+    @AppStorage("patientName") private var patientName: String = ""
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showSettings = false
     @State private var showHistorySheet = false
@@ -32,6 +33,7 @@ struct DashboardView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
+                greeting
                 metricSections
                 if showsFewValuesHint {
                     fewValuesHint
@@ -355,6 +357,35 @@ struct DashboardView: View {
             updated.pinnedCodes.append(code)
         }
         prefs = updated
+    }
+}
+
+// MARK: - Greeting
+
+private extension DashboardView {
+    /// The first whitespace-separated component of the saved patient name, used to
+    /// greet the user by name. Empty when no name has been entered yet, in which
+    /// case the greeting is omitted entirely rather than shown impersonally.
+    var firstName: String {
+        patientName
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .first
+            .map(String.init) ?? ""
+    }
+
+    /// A warm, personal welcome above the metrics. The localized greeting carries
+    /// `^[…](inflect: true)` markup, so on languages with grammatical gender it
+    /// agrees with the reader's system Term of Address automatically — no stored
+    /// gender of our own is consulted.
+    @ViewBuilder
+    var greeting: some View {
+        if !firstName.isEmpty {
+            Text("Welcome back, \(firstName)")
+                .font(.title3.weight(.semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 2)
+                .accessibilityAddTraits(.isHeader)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a warm, personalized greeting to the top of the Dashboard that displays the patient's first name when available. The greeting uses localized strings with grammatical gender inflection markup for languages that require it.

## Changes
- **Localizable.xcstrings**: Added new localized string `"Welcome back, %@"` with translations for 12 languages (German, Spanish, French, Italian, Japanese, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, Ukrainian, and Simplified Chinese). Also updated existing `"Welcome to"` translations to include `^[…](inflect: true)` markup for gender agreement in Spanish, Italian, and Brazilian Portuguese.

- **DashboardView.swift**: 
  - Added `@AppStorage("patientName")` property to read the patient's name from UserDefaults
  - Extracted `firstName` computed property that safely extracts the first whitespace-separated component of the patient name
  - Added `greeting` view builder that conditionally displays a localized welcome message when a patient name is available
  - Integrated the greeting into the main body at the top of the dashboard (above metric sections)
  - Greeting is styled as `.title3.weight(.semibold)`, left-aligned with horizontal padding, and marked as a header for accessibility

## Implementation Details
- The greeting only appears when a patient name has been entered; it is omitted entirely rather than shown impersonally
- The localized string uses `^[…](inflect: true)` markup to automatically agree with the reader's system Term of Address in languages with grammatical gender, without requiring stored gender metadata
- The greeting is positioned prominently at the top of the scrollable dashboard content

https://claude.ai/code/session_013JPb9pufq3EDb3F8aXHYLb