### PR TITLE
Simplify README: remove Trio references and clarify build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Scan, import, or paste your lab report — the app uses Vision OCR and the on-de
 
 ## Building with GitHub Actions (no Mac required)
 
-This repository uses the same Fastlane + Fastlane Match infrastructure as [Trio](https://github.com/idoodler-s-Diabetes-Management/Trio). If you have already configured secrets for Trio in your organisation, they are reused here without any changes.
+This repository uses Fastlane + Fastlane Match for fully automated, Mac-free builds.
 
 ### Required secrets
 
@@ -71,7 +71,7 @@ Add these to your repository (or organisation) under **Settings → Secrets and 
 | `FASTLANE_KEY` | App Store Connect API key contents (the `.p8` file, paste the full text including header/footer) |
 | `MATCH_PASSWORD` | A strong password used to encrypt certificates in the `Match-Secrets` repository |
 
-> All six secrets are shared with Trio — if they are already set at the organisation level you have nothing extra to do.
+> Secrets can be set at the organisation level — if they are already configured there you have nothing extra to do.
 
 ### Optional repository variables
 
@@ -96,7 +96,7 @@ Go to **Actions → 2. Add Identifiers → Run workflow**.
 
 This registers your app's bundle ID in App Store Connect and enables the **HealthKit** and **iCloud (key-value storage)** capabilities on it. The iCloud capability backs the opt-in dashboard-layout sync; if you enable it after a profile already exists, re-run **3. Create Certificates** (with `ENABLE_NUKE_CERTS` or `FORCE_NUKE_CERTS` set) so the provisioning profile is regenerated to include it.
 
-The bundle identifier is `dev.idoodler.<TEAMID>.labimporter` — the same pattern as Trio (`org.nightscout.<TEAMID>.trio`). The `<TEAMID>` placeholder is substituted automatically from the `TEAMID` secret at build time via `Config.xcconfig`.
+The bundle identifier is `dev.idoodler.<TEAMID>.labimporter`. The `<TEAMID>` placeholder is substituted automatically from the `TEAMID` secret at build time via `Config.xcconfig`.
 
 After this step, go to [App Store Connect](https://appstoreconnect.apple.com) and create a new app record for **LabImporter** using the bundle ID shown in the workflow log. This is required before the first build can upload to TestFlight.
 


### PR DESCRIPTION
## Summary
Updated README.md to remove references to the Trio project and simplify documentation around the GitHub Actions build infrastructure. The changes make the build setup instructions more self-contained and easier to follow for new contributors.

## Changes
- **Removed Trio project references** from the GitHub Actions section, replacing the comparison with a clearer standalone description of the build system
- **Simplified secrets documentation** to indicate that secrets can be shared at the organisation level without requiring prior Trio setup
- **Removed bundle ID pattern comparison** to Trio, keeping only the relevant information about LabImporter's identifier format

## Details
The README previously assumed familiarity with the Trio project's build infrastructure and suggested that secrets/configuration would be inherited from it. These changes make the documentation more accessible by:
1. Describing the Fastlane + Match setup as a standalone feature rather than a shared pattern
2. Clarifying that organisation-level secrets are optional (not required)
3. Focusing bundle ID documentation on LabImporter's own conventions rather than comparative examples

No functional changes to the build system or configuration — this is purely documentation clarification.

https://claude.ai/code/session_01LRFUX1Dojj7eBrtDDVbdQn