### PR TITLE
Hide "Report an Issue" when repository has Issues disabled

### DIFF
--- a/.github/workflows/build_labimporter.yml
+++ b/.github/workflows/build_labimporter.yml
@@ -41,13 +41,20 @@ jobs:
           fi
 
       - name: Stamp Git metadata into Info.plist
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           PLIST="LabImporter/Info.plist"
           REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+          # Whether this repo has Issues enabled drives the "Report an Issue"
+          # row in Settings; query the API and fall back to empty (unknown).
+          HAS_ISSUES=$(gh api "repos/${{ github.repository }}" --jq '.has_issues' 2>/dev/null || true)
+          case "$HAS_ISSUES" in true|false) ;; *) HAS_ISSUES="" ;; esac
           for entry in \
             "GitBranch:${{ github.ref_name }}" \
             "GitCommit:${GITHUB_SHA:0:7}" \
-            "GitRepositoryURL:${REPO_URL}"; do
+            "GitRepositoryURL:${REPO_URL}" \
+            "GitHasIssues:${HAS_ISSUES}"; do
             key="${entry%%:*}"
             value="${entry#*:}"
             /usr/libexec/PlistBuddy -c "Set :${key} ${value}" "$PLIST" \

--- a/LabImporter/Info.plist
+++ b/LabImporter/Info.plist
@@ -26,6 +26,8 @@
 	<string>unknown</string>
 	<key>GitRepositoryURL</key>
 	<string></string>
+	<key>GitHasIssues</key>
+	<string></string>
 	<key>FundingConfig</key>
 	<string></string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/LabImporter/Views/Settings/SettingsView.swift
+++ b/LabImporter/Views/Settings/SettingsView.swift
@@ -70,10 +70,23 @@ enum AppInfo {
         return webURL(from: value)
     }
 
+    /// Whether the source repository has GitHub Issues enabled, stamped into
+    /// `Info.plist` at build time (`GitHasIssues`) by querying the GitHub API.
+    /// Returns `nil` when the build couldn't determine it (e.g. a local Xcode
+    /// build, a non-GitHub remote, or no network) — callers treat `nil` as
+    /// "unknown" and keep showing issue affordances rather than hiding them.
+    static var repositoryHasIssues: Bool? {
+        guard let value = string("GitHasIssues") else { return nil }
+        return (value as NSString).boolValue
+    }
+
     /// URL that opens the "new issue" composer for `repositoryURL`, pre-filling
-    /// the body with build metadata to help triage reports.
+    /// the body with build metadata to help triage reports. Returns `nil` when
+    /// the repository has Issues disabled (`repositoryHasIssues == false`) so
+    /// the "Report an Issue" row is hidden.
     static var newIssueURL: URL? {
-        guard let base = repositoryURL?.appendingPathComponent("issues/new"),
+        guard repositoryHasIssues != false,
+              let base = repositoryURL?.appendingPathComponent("issues/new"),
               var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
         let body = """
 
@@ -254,6 +267,9 @@ struct SettingsView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
             }
+            // Make the whole row (including the gap the Spacer opens up)
+            // tappable, not just the label and trailing glyph.
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
## Summary
Add support for detecting whether the source repository has GitHub Issues enabled, and conditionally hide the "Report an Issue" affordance in Settings when Issues are disabled.

## Key changes
- **New `AppInfo.repositoryHasIssues` property:** Reads the `GitHasIssues` key from `Info.plist` (stamped at build time by querying the GitHub API). Returns `nil` when the value is unknown (local builds, non-GitHub remotes, or network failures), allowing callers to treat `nil` as "unknown" and keep showing issue affordances.
- **Updated `AppInfo.newIssueURL`:** Now returns `nil` when `repositoryHasIssues == false`, causing the "Report an Issue" row to be hidden from the Settings view.
- **Build workflow enhancement:** Modified `.github/workflows/build_labimporter.yml` to query the GitHub API (`gh api repos/…`) and stamp the `has_issues` boolean into `Info.plist` during the "Stamp Git metadata" step. Falls back to an empty string (unknown) if the query fails or returns an unexpected value.
- **Info.plist template:** Added `GitHasIssues` key with an empty default value for local/non-CI builds.
- **UI improvement:** Added `.contentShape(Rectangle())` to the settings row to make the entire row (including the gap opened by the `Spacer`) tappable, not just the label and trailing glyph.

## Implementation details
- The GitHub API query uses the `GH_TOKEN` secret (`GH_PAT`) for authentication and is wrapped in error handling (`2>/dev/null || true`) to gracefully degrade on network failures or missing credentials.
- The `repositoryHasIssues` property uses `(value as NSString).boolValue` to parse the string value, which safely converts "true"/"false" strings to booleans.
- Callers treat `nil` as "unknown" and continue showing issue affordances, ensuring the feature degrades gracefully in environments where the API query cannot run.

https://claude.ai/code/session_01GZgE2BWAe2MZSV66LDuvNg