### PR TITLE
Add information-rich PDF export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,14 @@ Config.xcconfig  # BUNDLE_IDENTIFIER = dev.idoodler.$(DEVELOPMENT_TEAM).labimpor
 
 ### UI patterns
 - All user-facing text uses `String(localized:)` / SwiftUI auto-localization and
-  lives in `Localizable.xcstrings`. Add new strings there; the app ships German + English.
+  lives in `Localizable.xcstrings`. **The app ships 13 languages** — `en`
+  (source), `de`, `es`, `fr`, `it`, `ja`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `uk`,
+  `zh-Hans` — and **every new key must be translated into all of them**, not just
+  English/German. Don't leave a string EN-only (which silently falls back to the
+  key) or EN+DE-only. Preserve format specifiers (`%lld`, `%@`) and follow the
+  Health-app naming convention below in each language. Reuse an existing key
+  verbatim when the same source string already exists (it's already fully
+  translated) rather than adding a duplicate.
 - **Naming the Health app:** never leave "Apple Health" untranslated. Every
   reference to the Health app must use the **on-device localized app name** for
   that language, keeping the **`Apple` brand prefix**. Canonical forms:
@@ -226,7 +233,9 @@ Required secrets: `GH_PAT`, `TEAMID`, `FASTLANE_ISSUER_ID`, `FASTLANE_KEY_ID`,
   4. Optionally raise `CDAMigrator.minimumSupportedVersion` to drop very old
      schemas. Documents below the minimum — and unversioned legacy exports — are
      ignored on read-back by design (no implicit data migration).
-- **New user-facing text:** always `String(localized:)`; add to `Localizable.xcstrings`.
+- **New user-facing text:** always `String(localized:)`; add to
+  `Localizable.xcstrings` and translate the key into **all 13 shipped languages**
+  (see UI patterns) — never EN-only or EN+DE-only.
 - **Before pushing:** make sure `swiftlint lint --strict` passes (the hook enforces it).
 - **No tests exist** in the project today; verify changes by building in Xcode on
   a supported device and exercising the import flow.

--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -23,6 +23,12 @@
 		AABB000000000000000055AA /* FoundationModels.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000037AA /* FoundationModels.framework */; };
 		AABB000000000000000056AA /* PhotosUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AABB000000000000000038AA /* PhotosUI.framework */; };
 		AABB000000000000000057AA /* CDAExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000058AA /* CDAExportService.swift */; };
+		AAED000000000000000010AA /* PDFExportOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED000000000000000011AA /* PDFExportOptions.swift */; };
+		AAED000000000000000012AA /* PDFExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED000000000000000013AA /* PDFExportService.swift */; };
+		AAED000000000000000014AA /* PDFReportPageViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED000000000000000015AA /* PDFReportPageViews.swift */; };
+		AAED000000000000000016AA /* PDFExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED000000000000000017AA /* PDFExportView.swift */; };
+		AAED000000000000000018AA /* PDFReportComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED000000000000000019AA /* PDFReportComposer.swift */; };
+		AAED00000000000000001AAA /* PDFTrendPageViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAED00000000000000001BAA /* PDFTrendPageViews.swift */; };
 		AABB000000000000000060AA /* LabReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000061AA /* LabReport.swift */; };
 		AABB000000000000000064AA /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000065AA /* HistoryView.swift */; };
 		AABB000000000000000066AA /* ReportDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000067AA /* ReportDetailView.swift */; };
@@ -86,6 +92,12 @@
 		AABB000000000000000038AA /* PhotosUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PhotosUI.framework; path = System/Library/Frameworks/PhotosUI.framework; sourceTree = SDKROOT; };
 		AABB000000000000000039AA /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = SOURCE_ROOT; };
 		AABB000000000000000058AA /* CDAExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDAExportService.swift; sourceTree = "<group>"; };
+		AAED000000000000000011AA /* PDFExportOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFExportOptions.swift; sourceTree = "<group>"; };
+		AAED000000000000000013AA /* PDFExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFExportService.swift; sourceTree = "<group>"; };
+		AAED000000000000000015AA /* PDFReportPageViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReportPageViews.swift; sourceTree = "<group>"; };
+		AAED000000000000000017AA /* PDFExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFExportView.swift; sourceTree = "<group>"; };
+		AAED000000000000000019AA /* PDFReportComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReportComposer.swift; sourceTree = "<group>"; };
+		AAED00000000000000001BAA /* PDFTrendPageViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFTrendPageViews.swift; sourceTree = "<group>"; };
 		AABB000000000000000061AA /* LabReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabReport.swift; sourceTree = "<group>"; };
 		AABB000000000000000065AA /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		AABB000000000000000067AA /* ReportDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDetailView.swift; sourceTree = "<group>"; };
@@ -206,6 +218,7 @@
 				AABB000000000000000096AA /* LabCategory.swift */,
 				AABB000000000000000061AA /* LabReport.swift */,
 				AABB000000000000000075AA /* LabDisplayPreferences.swift */,
+				AAED000000000000000011AA /* PDFExportOptions.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -217,6 +230,7 @@
 				AABB000000000000000024AA /* LabParserService.swift */,
 				AABB000000000000000025AA /* HealthKitService.swift */,
 				AABB000000000000000058AA /* CDAExportService.swift */,
+				AAED000000000000000013AA /* PDFExportService.swift */,
 				AABB000000000000000090AA /* LoincDirectory.swift */,
 				AABB0000000000000000D0AA /* CloudSyncService.swift */,
 			);
@@ -234,6 +248,7 @@
 				AABB0000000000000000A5AA /* History */,
 				AABB0000000000000000A6AA /* Settings */,
 				AABB0000000000000000A7AA /* Shared */,
+				AAED0000000000000000E0AA /* Export */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -339,6 +354,17 @@
 				AAFF0000000000000000F201 /* RangeStatusBadge.swift */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		AAED0000000000000000E0AA /* Export */ = {
+			isa = PBXGroup;
+			children = (
+				AAED000000000000000017AA /* PDFExportView.swift */,
+				AAED000000000000000015AA /* PDFReportPageViews.swift */,
+				AAED000000000000000019AA /* PDFReportComposer.swift */,
+				AAED00000000000000001BAA /* PDFTrendPageViews.swift */,
+			);
+			path = Export;
 			sourceTree = "<group>";
 		};
 		AABB0000000000000000A8AA /* Project Files */ = {
@@ -550,6 +576,12 @@
 				AABB000000000000000091AA /* LoincDirectory.swift in Sources */,
 				AABB0000000000000000D1AA /* CloudSyncService.swift in Sources */,
 				AABB000000000000000057AA /* CDAExportService.swift in Sources */,
+				AAED000000000000000010AA /* PDFExportOptions.swift in Sources */,
+				AAED000000000000000012AA /* PDFExportService.swift in Sources */,
+				AAED000000000000000014AA /* PDFReportPageViews.swift in Sources */,
+				AAED000000000000000016AA /* PDFExportView.swift in Sources */,
+				AAED000000000000000018AA /* PDFReportComposer.swift in Sources */,
+				AAED00000000000000001AAA /* PDFTrendPageViews.swift in Sources */,
 				AABB000000000000000046AA /* HomeView.swift in Sources */,
 				AABB000000000000000047AA /* ReviewView.swift in Sources */,
 				AACC000000000000000001AA /* ReviewView+Preview.swift in Sources */,

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -90,6 +90,72 @@
             "state" : "translated",
             "value" : "%lld von %lld ausgewählt"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld de %lld seleccionados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sur %lld sélectionnés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld di %lld selezionati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld件を選択"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld van %lld geselecteerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybrano %lld z %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld de %lld selecionados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрано %lld из %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld / %lld seçildi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вибрано %lld з %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld/%lld"
+          }
         }
       }
     },
@@ -585,6 +651,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2J"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 A"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 A"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 A"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2年"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 jr"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 lata"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 A"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 года"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 Yıl"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 роки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2年"
           }
         }
       }
@@ -1130,6 +1262,72 @@
             "state" : "translated",
             "value" : "Alter %lld"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edad %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Âge %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Età %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld歳"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leeftijd %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiek %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idade %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Возраст %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yaş %lld"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вік %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 岁"
+          }
         }
       }
     },
@@ -1216,6 +1414,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gesamter Zeitraum"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo el tiempo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout l’historique"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto il periodo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全期間"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle tijd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cały okres"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo o período"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "За всё время"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tüm zamanlar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "За весь час"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部时间"
           }
         }
       }
@@ -1913,6 +2177,72 @@
             "state" : "translated",
             "value" : "Darstellung"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aspecto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apparence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aspetto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weergave"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wygląd"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aparência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оформление"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görünüm"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вигляд"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外观"
+          }
         }
       }
     },
@@ -2303,6 +2633,72 @@
             "state" : "translated",
             "value" : "Mittel"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prom"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moy"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gem"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Śr"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Méd"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сред"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ort"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сер"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均值"
+          }
         }
       }
     },
@@ -2464,6 +2860,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schwarzweiß"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blanco y negro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noir et blanc"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bianco e nero"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "白黒"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwart-wit"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Czarno-białe"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preto e branco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чёрно-белый"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siyah Beyaz"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чорно-білий"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黑白"
           }
         }
       }
@@ -3006,6 +3468,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Änderung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Évolution"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変化"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verandering"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zmiana"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Variação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değişim"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зміна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变化"
           }
         }
       }
@@ -3780,6 +4308,72 @@
             "state" : "translated",
             "value" : "Farbe"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カラー"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleur"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kolorowy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цветной"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renkli"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кольоровий"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩色"
+          }
         }
       }
     },
@@ -3789,6 +4383,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Farbmodus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de color"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode couleur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità colore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カラーモード"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleurmodus"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb koloru"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de cor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цветовой режим"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renk Modu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим кольору"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "颜色模式"
           }
         }
       }
@@ -4714,6 +5374,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geburtsdatum"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de nacimiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date de naissance"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di nascita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生年月日"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geboortedatum"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data urodzenia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data de nascimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата рождения"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doğum Tarihi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата народження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出生日期"
           }
         }
       }
@@ -6626,6 +7352,72 @@
             "state" : "translated",
             "value" : "PDF exportieren"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar PDF"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter en PDF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esporta PDF"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFを書き出す"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF exporteren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eksportuj PDF"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportar PDF"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Экспорт PDF"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF’yi Dışa Aktar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Експортувати PDF"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出 PDF"
+          }
         }
       }
     },
@@ -6940,6 +7732,72 @@
             "state" : "translated",
             "value" : "Erstellen"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Générer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genera"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genereren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utwórz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oluştur"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成"
+          }
         }
       }
     },
@@ -6949,6 +7807,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erstellt %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generado %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Généré %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generato %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成日 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gegenereerd %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utworzono %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerado %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создано %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oluşturma %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створено %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成于 %@"
           }
         }
       }
@@ -8329,6 +9253,72 @@
             "state" : "translated",
             "value" : "Enthaltene Kategorien"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Categorías incluidas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catégories incluses"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Categorie incluse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "含めるカテゴリ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opgenomen categorieën"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwzględnione kategorie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Categorias incluídas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включённые категории"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dahil Edilen Kategoriler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включені категорії"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含的类别"
+          }
         }
       }
     },
@@ -8338,6 +9328,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enthaltene Werte"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valores incluidos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valeurs incluses"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valori inclusi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "含める値"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opgenomen waarden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwzględnione wartości"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valores incluídos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включённые значения"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dahil Edilen Değerler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включені значення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含的数值"
           }
         }
       }
@@ -9723,6 +10779,72 @@
             "state" : "translated",
             "value" : "Letzte 2 Jahre"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 2 años"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 dernières années"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 2 anni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去2年"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laatste 2 jaar"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostatnie 2 lata"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 2 anos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 2 года"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son 2 yıl"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останні 2 роки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近 2 年"
+          }
         }
       }
     },
@@ -9732,6 +10854,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Letzte 3 Monate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 3 meses"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 derniers mois"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 3 mesi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去3か月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laatste 3 maanden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostatnie 3 miesiące"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 3 meses"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 3 месяца"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son 3 ay"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останні 3 місяці"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近 3 个月"
           }
         }
       }
@@ -9743,6 +10931,72 @@
             "state" : "translated",
             "value" : "Letzte 6 Monate"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 6 meses"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 derniers mois"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 6 mesi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去6か月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laatste 6 maanden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostatnie 6 miesięcy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 6 meses"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 6 месяцев"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son 6 ay"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останні 6 місяців"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近 6 个月"
+          }
         }
       }
     },
@@ -9752,6 +11006,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Letzte 12 Monate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 derniers mois"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 12 mesi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去12か月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laatste 12 maanden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostatnie 12 miesięcy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 12 месяцев"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son 12 ay"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останні 12 місяців"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近 12 个月"
           }
         }
       }
@@ -9914,6 +11234,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktuelle Werte"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultados recientes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Derniers résultats"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risultati recenti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新の結果"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recente resultaten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Najnowsze wyniki"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultados recentes"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние результаты"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son Sonuçlar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останні результати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新结果"
           }
         }
       }
@@ -11066,6 +12452,72 @@
             "state" : "translated",
             "value" : "Max"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máx"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maks"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Máx"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Макс"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maks"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Макс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大值"
+          }
         }
       }
     },
@@ -11304,6 +12756,72 @@
             "state" : "translated",
             "value" : "Messwerte"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parámetros"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametri"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指標"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parameters"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parâmetros"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показатели"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parametreler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показники"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指标"
+          }
         }
       }
     },
@@ -11390,6 +12908,72 @@
             "state" : "translated",
             "value" : "Min"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mín"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最小"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mín"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мин"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мін"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最小值"
+          }
         }
       }
     },
@@ -11475,6 +13059,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neueste Messung für jeden Wert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura más reciente de cada valor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernière mesure de chaque valeur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Misurazione più recente per ogni valore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各値の最新測定"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meest recente meting per waarde"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Najnowszy odczyt dla każdej wartości"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leitura mais recente de cada valor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее измерение для каждого значения"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Her değer için en son ölçüm"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останнє вимірювання для кожного значення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每项数值的最新读数"
           }
         }
       }
@@ -13009,6 +14659,72 @@
             "state" : "translated",
             "value" : "Außerhalb des Bereichs"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuera de rango"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hors plage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuori intervallo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲外"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buiten bereik"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poza zakresem"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fora da faixa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вне нормы"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aralık dışı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поза нормою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超出范围"
+          }
         }
       }
     },
@@ -13018,6 +14734,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seite %lld von %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página %lld de %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page %lld sur %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %lld di %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lldページ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %lld van %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strona %lld z %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página %lld de %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница %lld из %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayfa %lld / %lld"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сторінка %lld з %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 页，共 %lld 页"
           }
         }
       }
@@ -13256,6 +15038,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erfasster Zeitraum"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Período cubierto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Période couverte"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Periodo coperto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対象期間"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gedekte periode"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Objęty okres"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Período abrangido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Охваченный период"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapsanan Dönem"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Охоплений період"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "涵盖时段"
           }
         }
       }
@@ -14029,6 +15877,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Referenz"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準値"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Norma"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Норма"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Норма"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考范围"
           }
         }
       }
@@ -14952,6 +16866,72 @@
             "state" : "translated",
             "value" : "Ergebnis"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résultat"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risultato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultaat"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wynik"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Результат"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sonuç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Результат"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结果"
+          }
         }
       }
     },
@@ -15724,6 +17704,72 @@
             "state" : "translated",
             "value" : "Abschnitte"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sections"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sezioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セクション"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secties"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sekcje"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seções"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разделы"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bölümler"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розділи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节"
+          }
         }
       }
     },
@@ -15962,6 +18008,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wähle mindestens einen Wert für das PDF aus."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona al menos un valor para incluir en el PDF."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez au moins une valeur à inclure dans le PDF."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona almeno un valore da includere nel PDF."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFに含める値を1つ以上選択してください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecteer minstens één waarde om in de PDF op te nemen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz co najmniej jedną wartość do uwzględnienia w pliku PDF."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecione pelo menos um valor para incluir no PDF."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите хотя бы одно значение для включения в PDF."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF’ye eklemek için en az bir değer seçin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть принаймні одне значення для включення у PDF."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请至少选择一项要包含在 PDF 中的数值。"
           }
         }
       }
@@ -16276,6 +18388,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geschlecht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sexo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sexe"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "性別"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geslacht"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Płeć"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sexo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пол"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinsiyet"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "性别"
           }
         }
       }
@@ -16895,6 +19073,72 @@
             "state" : "translated",
             "value" : "Übersichtsseite"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página de resumen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page de résumé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina di riepilogo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "概要ページ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overzichtspagina"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strona podsumowania"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página de resumo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сводная страница"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Özet Sayfası"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сторінка зведення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要页"
+          }
         }
       }
     },
@@ -17361,6 +19605,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Test"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prueba"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検査"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Badanie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exame"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аналіз"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检验项目"
           }
         }
       }
@@ -17907,6 +20217,72 @@
             "state" : "translated",
             "value" : "Das PDF konnte nicht erstellt werden. Bitte versuche es erneut."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo generar el PDF. Inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le PDF n’a pas pu être généré. Veuillez réessayer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile generare il PDF. Riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFを作成できませんでした。もう一度お試しください。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De PDF kon niet worden gegenereerd. Probeer het opnieuw."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się utworzyć pliku PDF. Spróbuj ponownie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível gerar o PDF. Tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось создать PDF. Повторите попытку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF oluşturulamadı. Lütfen tekrar deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося створити PDF. Спробуйте ще раз."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法生成 PDF。请重试。"
+          }
         }
       }
     },
@@ -18221,6 +20597,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dieser Bericht wurde von LabImporter aus den in Apple Health gespeicherten Daten erstellt. Er dient nur zur persönlichen Information – er ist kein medizinisches Dokument und ersetzt keine professionelle ärztliche Beratung."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este informe fue generado por LabImporter a partir de los datos almacenados en Apple Salud. Es solo para uso personal: no es un documento médico ni sustituye el consejo médico profesional."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce rapport a été généré par LabImporter à partir des données stockées dans Apple Santé. Il est fourni à titre de référence personnelle uniquement — ce n’est pas un document médical et ne remplace pas l’avis d’un professionnel de santé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo referto è stato generato da LabImporter dai dati memorizzati in Apple Salute. È solo per riferimento personale: non è un documento medico e non sostituisce il parere di un professionista sanitario."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このレポートは、Appleヘルスケアに保存されたデータをもとにLabImporterが作成しました。個人的な参考用であり、医療文書ではなく、専門的な医療アドバイスに代わるものではありません。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit rapport is door LabImporter gegenereerd op basis van gegevens uit Apple Gezondheid. Het is alleen ter persoonlijke referentie — het is geen medisch document en vervangt geen professioneel medisch advies."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten raport został wygenerowany przez LabImporter na podstawie danych zapisanych w Apple Zdrowie. Służy wyłącznie do użytku osobistego — nie jest dokumentem medycznym ani nie zastępuje profesjonalnej porady lekarskiej."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este relatório foi gerado pelo LabImporter a partir dos dados armazenados no Apple Saúde. Destina-se apenas a referência pessoal — não é um documento médico nem substitui orientação médica profissional."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот отчёт создан приложением LabImporter на основе данных, сохранённых в Apple Здоровье. Он предназначен только для личного использования — это не медицинский документ и не заменяет профессиональную медицинскую консультацию."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu rapor, Apple Sağlık’ta saklanan verilerden LabImporter tarafından oluşturulmuştur. Yalnızca kişisel başvuru içindir — tıbbi bir belge değildir ve profesyonel tıbbi tavsiyenin yerini tutmaz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цей звіт створено застосунком LabImporter на основі даних, збережених у Apple Здоров’я. Він призначений лише для особистого використання — це не медичний документ і не замінює професійної медичної консультації."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本报告由 LabImporter 根据 Apple 健康中存储的数据生成。仅供个人参考——它不是医疗文件，也不能替代专业医疗建议。"
           }
         }
       }
@@ -18537,6 +20979,72 @@
             "state" : "translated",
             "value" : "Verlaufsdiagramme"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gráficos de tendencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Graphiques de tendance"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grafici di andamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トレンドグラフ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trendgrafieken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykresy trendów"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gráficos de tendência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Графики динамики"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğilim Grafikleri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Графіки динаміки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "趋势图"
+          }
         }
       }
     },
@@ -18546,6 +21054,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verlaufsdiagramme erscheinen für Werte mit mindestens zwei Messungen im gewählten Zeitraum."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los gráficos de tendencia aparecen para los valores con al menos dos lecturas en el intervalo seleccionado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les graphiques de tendance s’affichent pour les valeurs ayant au moins deux mesures dans la période sélectionnée."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I grafici di andamento vengono mostrati per i valori con almeno due misurazioni nell’intervallo selezionato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した期間内に2回以上の測定がある値にトレンドグラフが表示されます。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trendgrafieken verschijnen voor waarden met minstens twee metingen in het geselecteerde bereik."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykresy trendów pojawiają się dla wartości z co najmniej dwoma odczytami w wybranym zakresie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os gráficos de tendência aparecem para valores com pelo menos duas leituras no intervalo selecionado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Графики динамики отображаются для значений, у которых есть минимум два измерения в выбранном периоде."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğilim grafikleri, seçilen aralıkta en az iki ölçümü olan değerler için gösterilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Графіки динаміки показуються для значень, що мають принаймні два вимірювання у вибраному періоді."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "趋势图仅针对在所选范围内至少有两次读数的数值显示。"
           }
         }
       }
@@ -18557,6 +21131,72 @@
             "state" : "translated",
             "value" : "Verlaufszeitraum"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Período de tendencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Période de tendance"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Periodo andamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トレンド期間"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trendperiode"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okres trendu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Período de tendência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Период динамики"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğilim Aralığı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Період динаміки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "趋势时段"
+          }
         }
       }
     },
@@ -18566,6 +21206,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zeitraum für Verläufe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo de tendencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Période de tendance"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo di andamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トレンド期間"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trendperiode"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakres czasu trendu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo de tendência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Период динамики"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eğilim Zaman Aralığı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Період динаміки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "趋势时间范围"
           }
         }
       }

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,6 +1,82 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Page Size" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seitenformat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño de página"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format de page"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato pagina"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページサイズ"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginaformaat"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozmiar strony"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamanho da página"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер страницы"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayfa Boyutu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розмір сторінки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页面尺寸"
+          }
+        }
+      }
+    },
     "" : {
 
     },

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -1,614 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "High" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoch"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alto"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Élevé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alto"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高い"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoog"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wysoki"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alto"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Высокий"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yüksek"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Високий"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "偏高"
-          }
-        }
-      }
-    },
-    "Low" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niedrig"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bajo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bas"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basso"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低い"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laag"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niski"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixo"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Низкий"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Düşük"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Низький"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "偏低"
-          }
-        }
-      }
-    },
-    "In range" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im Normbereich"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En rango"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dans la plage"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nell’intervallo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基準範囲内"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Binnen bereik"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "W normie"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na faixa"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "В норме"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aralıkta"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "У нормі"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "范围内"
-          }
-        }
-      }
-    },
-    "Reference Range" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referenzbereich"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rango de referencia"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage de référence"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervallo di riferimento"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基準範囲"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referentiebereik"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakres referencyjny"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faixa de referência"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Референсный диапазон"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referans Aralığı"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Референсний діапазон"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参考范围"
-          }
-        }
-      }
-    },
-    "Set Reference Range" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referenzbereich festlegen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Establecer rango de referencia"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définir la plage de référence"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta intervallo di riferimento"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基準範囲を設定"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referentiebereik instellen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustaw zakres referencyjny"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir faixa de referência"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задать референсный диапазон"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referans Aralığı Belirle"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задати референсний діапазон"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置参考范围"
-          }
-        }
-      }
-    },
-    "Reference range %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referenzbereich %@"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rango de referencia %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plage de référence %@"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intervallo di riferimento %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基準範囲 %@"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referentiebereik %@"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakres referencyjny %@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faixa de referência %@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Референсный диапазон %@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Referans aralığı %@"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Референсний діапазон %@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参考范围 %@"
-          }
-        }
-      }
-    },
-    "Set the normal range for “%@”. Results outside it are flagged across the app. Leave a field blank for no limit." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normbereich für „%@“ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Define el rango normal de «%@». Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définissez la plage normale de « %@ ». Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta l’intervallo normale per “%@”. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」の基準範囲を設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel het normale bereik voor ‘%@’ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustaw normalny zakres dla „%@”. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina a faixa normal de “%@”. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задайте нормальный диапазон для «%@». Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“%@” için normal aralığı belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задайте нормальний діапазон для «%@». Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置“%@”的正常范围。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
-          }
-        }
-      }
-    },
-    "Set the normal range for “%@” in %@. Results outside it are flagged across the app. Leave a field blank for no limit." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normbereich für „%@“ in %@ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Define el rango normal de «%@» en %@. Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Définissez la plage normale de « %@ » en %@. Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposta l’intervallo normale per “%@” in %@. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」の基準範囲を %@ で設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stel het normale bereik voor ‘%@’ in %@ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ustaw normalny zakres dla „%@” w %@. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina a faixa normal de “%@” em %@. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задайте нормальный диапазон для «%@» в %@. Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“%@” için normal aralığı %@ cinsinden belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Задайте нормальний діапазон для «%@» у %@. Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置“%@”的正常范围（单位：%@）。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
-          }
-        }
-      }
-    },
     "" : {
 
     },
@@ -690,6 +82,16 @@
     },
     "%lld" : {
 
+    },
+    "%lld of %lld selected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld von %lld ausgewählt"
+          }
+        }
+      }
     },
     "%lld reports will be permanently removed from Apple Health." : {
       "localizations" : {
@@ -1173,6 +575,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1年"
+          }
+        }
+      }
+    },
+    "2Y" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2J"
           }
         }
       }
@@ -1711,6 +1123,16 @@
         }
       }
     },
+    "Age %lld" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alter %lld"
+          }
+        }
+      }
+    },
     "All" : {
       "comment" : "Segmented control: trend chart shows the full history",
       "localizations" : {
@@ -1784,6 +1206,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部"
+          }
+        }
+      }
+    },
+    "All time" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamter Zeitraum"
           }
         }
       }
@@ -2474,6 +1906,16 @@
         }
       }
     },
+    "Appearance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Darstellung"
+          }
+        }
+      }
+    },
     "Apple Health Access Required" : {
       "localizations" : {
         "de" : {
@@ -2854,6 +2296,16 @@
         }
       }
     },
+    "Avg" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittel"
+          }
+        }
+      }
+    },
     "Before You Start" : {
       "localizations" : {
         "de" : {
@@ -3002,6 +2454,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生日"
+          }
+        }
+      }
+    },
+    "Black & White" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schwarzweiß"
           }
         }
       }
@@ -3534,6 +2996,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "类别"
+          }
+        }
+      }
+    },
+    "Change" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Änderung"
           }
         }
       }
@@ -4301,6 +3773,26 @@
         }
       }
     },
+    "Color" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbe"
+          }
+        }
+      }
+    },
+    "Color Mode" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbmodus"
+          }
+        }
+      }
+    },
     "Commit" : {
       "localizations" : {
         "de" : {
@@ -4987,82 +4479,6 @@
         }
       }
     },
-    "Nickname" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spitzname"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apodo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Surnom"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soprannome"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ニックネーム"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bijnaam"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pseudonim"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apelido"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Псевдоним"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Takma Ad"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Псевдонім"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "昵称"
-          }
-        }
-      }
-    },
     "Customize" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -5288,6 +4704,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日期"
+          }
+        }
+      }
+    },
+    "Date of Birth" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geburtsdatum"
           }
         }
       }
@@ -7193,6 +6619,16 @@
         }
       }
     },
+    "Export PDF" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF exportieren"
+          }
+        }
+      }
+    },
     "Extracting text on device" : {
       "localizations" : {
         "de" : {
@@ -7493,6 +6929,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "性别"
+          }
+        }
+      }
+    },
+    "Generate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen"
+          }
+        }
+      }
+    },
+    "Generated %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellt %@"
           }
         }
       }
@@ -7873,6 +7329,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏 %@？"
+          }
+        }
+      }
+    },
+    "High" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élevé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高い"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoog"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysoki"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высокий"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yüksek"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Високий"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏高"
           }
         }
       }
@@ -8710,6 +8242,102 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入的化验数值将作为临床 CDA 记录写入 Apple 健康。"
+          }
+        }
+      }
+    },
+    "In range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Normbereich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En rango"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dans la plage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nell’intervallo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲内"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Binnen bereik"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W normie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na faixa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В норме"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aralıkta"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "У нормі"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "范围内"
+          }
+        }
+      }
+    },
+    "Included Categories" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enthaltene Kategorien"
+          }
+        }
+      }
+    },
+    "Included Values" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enthaltene Werte"
           }
         }
       }
@@ -9629,6 +9257,9 @@
         }
       }
     },
+    "LabImporter" : {
+
+    },
     "LabImporter is free and open source. If you find it useful, you can support its development." : {
       "localizations" : {
         "de" : {
@@ -10085,6 +9716,46 @@
         }
       }
     },
+    "Last 2 years" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 2 Jahre"
+          }
+        }
+      }
+    },
+    "Last 3 months" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 3 Monate"
+          }
+        }
+      }
+    },
+    "Last 6 months" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 6 Monate"
+          }
+        }
+      }
+    },
+    "Last 12 months" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 12 Monate"
+          }
+        }
+      }
+    },
     "Last updated %@" : {
       "localizations" : {
         "de" : {
@@ -10233,6 +9904,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最新系统"
+          }
+        }
+      }
+    },
+    "Latest Results" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Werte"
           }
         }
       }
@@ -10997,6 +10678,82 @@
         }
       }
     },
+    "Low" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niedrig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低い"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laag"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niski"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низкий"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Düşük"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низький"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏低"
+          }
+        }
+      }
+    },
     "Make sure your device is running iOS or iPadOS 26 or later." : {
       "localizations" : {
         "de" : {
@@ -11302,6 +11059,16 @@
         }
       }
     },
+    "Max" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max"
+          }
+        }
+      }
+    },
     "Measurement" : {
       "localizations" : {
         "de" : {
@@ -11530,6 +11297,16 @@
         }
       }
     },
+    "Metrics" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messwerte"
+          }
+        }
+      }
+    },
     "Microbiology" : {
       "localizations" : {
         "de" : {
@@ -11602,6 +11379,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "微生物学"
+          }
+        }
+      }
+    },
+    "Min" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Min"
           }
         }
       }
@@ -11682,6 +11469,16 @@
         }
       }
     },
+    "Most recent reading for each value" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neueste Messung für jeden Wert"
+          }
+        }
+      }
+    },
     "Name" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -11755,6 +11552,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名称"
+          }
+        }
+      }
+    },
+    "Nickname" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spitzname"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apodo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surnom"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soprannome"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ニックネーム"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bijnaam"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pseudonim"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apelido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Псевдоним"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Takma Ad"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Псевдонім"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昵称"
           }
         }
       }
@@ -13129,6 +13002,26 @@
         }
       }
     },
+    "Out of Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Außerhalb des Bereichs"
+          }
+        }
+      }
+    },
+    "Page %lld of %lld" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seite %lld von %lld"
+          }
+        }
+      }
+    },
     "Past reports are loaded back from Apple Health so you can review and share them." : {
       "localizations" : {
         "de" : {
@@ -13353,6 +13246,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "患者"
+          }
+        }
+      }
+    },
+    "Period Covered" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erfasster Zeitraum"
           }
         }
       }
@@ -14120,6 +14023,168 @@
         }
       }
     },
+    "Reference" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenz"
+          }
+        }
+      }
+    },
+    "Reference Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango de referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage de référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo di riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakres referencyjny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa de referência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсный диапазон"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans Aralığı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсний діапазон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考范围"
+          }
+        }
+      }
+    },
+    "Reference range %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango de referencia %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plage de référence %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo di riferimento %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakres referencyjny %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa de referência %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсный диапазон %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans aralığı %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Референсний діапазон %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参考范围 %@"
+          }
+        }
+      }
+    },
     "Rename" : {
       "localizations" : {
         "de" : {
@@ -14876,6 +14941,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复"
+          }
+        }
+      }
+    },
+    "Result" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ergebnis"
           }
         }
       }
@@ -15642,6 +15717,16 @@
         }
       }
     },
+    "Sections" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abschnitte"
+          }
+        }
+      }
+    },
     "See how your values change over time with interactive charts." : {
       "localizations" : {
         "de" : {
@@ -15871,6 +15956,244 @@
         }
       }
     },
+    "Select at least one value to include in the PDF." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle mindestens einen Wert für das PDF aus."
+          }
+        }
+      }
+    },
+    "Set Reference Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referenzbereich festlegen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Establecer rango de referencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définir la plage de référence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta intervallo di riferimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基準範囲を設定"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referentiebereik instellen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw zakres referencyjny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definir faixa de referência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задать референсный диапазон"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Referans Aralığı Belirle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задати референсний діапазон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置参考范围"
+          }
+        }
+      }
+    },
+    "Set the normal range for “%@” in %@. Results outside it are flagged across the app. Leave a field blank for no limit." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normbereich für „%@“ in %@ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Define el rango normal de «%@» en %@. Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez la plage normale de « %@ » en %@. Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta l’intervallo normale per “%@” in %@. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」の基準範囲を %@ で設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stel het normale bereik voor ‘%@’ in %@ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw normalny zakres dla „%@” w %@. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina a faixa normal de “%@” em %@. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальный диапазон для «%@» в %@. Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” için normal aralığı %@ cinsinden belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальний діапазон для «%@» у %@. Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置“%@”的正常范围（单位：%@）。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
+          }
+        }
+      }
+    },
+    "Set the normal range for “%@”. Results outside it are flagged across the app. Leave a field blank for no limit." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normbereich für „%@“ festlegen. Werte außerhalb werden in der ganzen App markiert. Lass ein Feld für keine Grenze leer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Define el rango normal de «%@». Los resultados fuera de él se marcan en toda la app. Deja un campo vacío para no poner límite."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définissez la plage normale de « %@ ». Les résultats en dehors sont signalés dans toute l’app. Laissez un champ vide pour aucune limite."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imposta l’intervallo normale per “%@”. I risultati al di fuori vengono segnalati in tutta l’app. Lascia vuoto un campo per nessun limite."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」の基準範囲を設定します。範囲外の結果はアプリ全体で強調表示されます。上限・下限なしの場合は空欄のままにします。"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stel het normale bereik voor ‘%@’ in. Resultaten daarbuiten worden overal in de app gemarkeerd. Laat een veld leeg voor geen limiet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustaw normalny zakres dla „%@”. Wyniki poza nim są oznaczane w całej aplikacji. Zostaw pole puste, aby nie ustawiać limitu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defina a faixa normal de “%@”. Resultados fora dela são sinalizados em todo o app. Deixe um campo em branco para nenhum limite."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальный диапазон для «%@». Результаты вне его отмечаются по всему приложению. Оставьте поле пустым, чтобы не задавать границу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” için normal aralığı belirleyin. Aralık dışındaki sonuçlar uygulama genelinde işaretlenir. Sınır koymamak için bir alanı boş bırakın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задайте нормальний діапазон для «%@». Результати поза ним позначаються в усьому застосунку. Залиште поле порожнім, щоб не встановлювати межу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置“%@”的正常范围。超出范围的结果会在整个 App 中标记。留空某个字段表示不设上限或下限。"
+          }
+        }
+      }
+    },
     "Settings" : {
       "localizations" : {
         "de" : {
@@ -15943,6 +16266,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置"
+          }
+        }
+      }
+    },
+    "Sex" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschlecht"
           }
         }
       }
@@ -16555,6 +16888,16 @@
         }
       }
     },
+    "Summary Page" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersichtsseite"
+          }
+        }
+      }
+    },
     "Support" : {
       "localizations" : {
         "de" : {
@@ -17008,6 +17351,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拍照"
+          }
+        }
+      }
+    },
+    "Test" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test"
           }
         }
       }
@@ -17547,6 +17900,16 @@
         }
       }
     },
+    "The PDF could not be generated. Please try again." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das PDF konnte nicht erstellt werden. Bitte versuche es erneut."
+          }
+        }
+      }
+    },
     "The updated report was saved, but the previous version couldn't be removed from Apple Health. You can delete it from the Reports list." : {
       "localizations" : {
         "de" : {
@@ -17848,6 +18211,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此报告太长，设备端 AI 无法一次性读取。请尝试导入较少的页面，或一次导入一份报告。"
+          }
+        }
+      }
+    },
+    "This report was generated by LabImporter from data stored in Apple Health. It is for personal reference only — it is not a medical document and is not a substitute for professional medical advice." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Bericht wurde von LabImporter aus den in Apple Health gespeicherten Daten erstellt. Er dient nur zur persönlichen Information – er ist kein medizinisches Dokument und ersetzt keine professionelle ärztliche Beratung."
           }
         }
       }
@@ -18157,6 +18530,46 @@
         }
       }
     },
+    "Trend Charts" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlaufsdiagramme"
+          }
+        }
+      }
+    },
+    "Trend charts appear for values with at least two readings in the selected range." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlaufsdiagramme erscheinen für Werte mit mindestens zwei Messungen im gewählten Zeitraum."
+          }
+        }
+      }
+    },
+    "Trend Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlaufszeitraum"
+          }
+        }
+      }
+    },
+    "Trend Time Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitraum für Verläufe"
+          }
+        }
+      }
+    },
     "Trending down" : {
       "localizations" : {
         "de" : {
@@ -18310,7 +18723,6 @@
       }
     },
     "Trends" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/LabImporter/Models/PDFExportOptions.swift
+++ b/LabImporter/Models/PDFExportOptions.swift
@@ -103,6 +103,20 @@ enum PDFPageFormat: String, CaseIterable, Identifiable {
         case .legal:    return "Legal"
         }
     }
+
+    /// A sensible default for the current device. iOS exposes no "paper size"
+    /// setting, so this keys off the device's **Region** (Settings → General →
+    /// Language & Region): the handful of regions that use US Letter paper get
+    /// Letter, everywhere else gets A4. The user can still override in the sheet.
+    static var deviceDefault: PDFPageFormat {
+        // Regions where US Letter (or its near-identical local equivalent) is the
+        // standard office paper size rather than ISO A4.
+        let letterRegions: Set<String> = [
+            "US", "CA", "MX", "PH", "CL", "CO", "CR", "GT", "NI", "PA", "DO", "SV", "VE", "PR"
+        ]
+        let region = Locale.current.region?.identifier ?? ""
+        return letterRegions.contains(region) ? .usLetter : .isoA4
+    }
 }
 
 /// The set of choices that fully describe one export.
@@ -111,7 +125,7 @@ struct PDFExportOptions {
     var selectedCodes: Set<String>
     var timeRange: PDFTimeRange = .year1
     var colorMode: PDFColorMode = .color
-    var pageFormat: PDFPageFormat = .isoA4
+    var pageFormat: PDFPageFormat = .deviceDefault
     /// Cover/summary page with patient details and headline stats.
     var includeSummary = true
     /// Table of the most recent value for every selected metric.

--- a/LabImporter/Models/PDFExportOptions.swift
+++ b/LabImporter/Models/PDFExportOptions.swift
@@ -77,12 +77,41 @@ enum PDFTimeRange: String, CaseIterable, Identifiable {
     }
 }
 
+/// Selectable paper size for the export. All options are at least A4-wide, so
+/// the latest-results table's fixed columns hold across formats; only the page
+/// height (and therefore how much fits per page) varies.
+enum PDFPageFormat: String, CaseIterable, Identifiable {
+    case isoA4, usLetter, legal
+
+    var id: Self { self }
+
+    /// Page dimensions in points (72 dpi, 1 pt == 1/72").
+    var size: CGSize {
+        switch self {
+        case .isoA4:    return CGSize(width: 595.28, height: 841.89)  // 210 × 297 mm
+        case .usLetter: return CGSize(width: 612, height: 792)        // 8.5 × 11 in
+        case .legal:    return CGSize(width: 612, height: 1008)       // 8.5 × 14 in
+        }
+    }
+
+    /// Shown verbatim — A4 / US Letter / Legal are standard international paper
+    /// names, not translated.
+    var label: String {
+        switch self {
+        case .isoA4:    return "A4"
+        case .usLetter: return "US Letter"
+        case .legal:    return "Legal"
+        }
+    }
+}
+
 /// The set of choices that fully describe one export.
 struct PDFExportOptions {
     /// LOINC codes the user chose to include.
     var selectedCodes: Set<String>
     var timeRange: PDFTimeRange = .year1
     var colorMode: PDFColorMode = .color
+    var pageFormat: PDFPageFormat = .isoA4
     /// Cover/summary page with patient details and headline stats.
     var includeSummary = true
     /// Table of the most recent value for every selected metric.
@@ -156,16 +185,35 @@ struct PDFTheme {
 /// A4 is the most internationally portable choice given the app ships across
 /// many European locales.
 enum PDFLayout {
-    static let pageSize = CGSize(width: 595.28, height: 841.89)
     static let margin: CGFloat = 42
-    static var contentWidth: CGFloat { pageSize.width - margin * 2 }
 
-    /// How many latest-results rows fit per page. Sized for the worst case — a
-    /// two-line wrapped value name — so long LOINC names never clip or spill past
-    /// the page. The first page holds fewer rows because it carries the section
-    /// title.
-    static let tableRowsPerPage = 13
-    static let tableRowsFirstPage = 12
-    /// Trend charts stacked per page.
-    static let chartsPerPage = 3
+    /// Usable text width inside the page margins for a given paper size.
+    static func contentWidth(for size: CGSize) -> CGFloat { size.width - margin * 2 }
+
+    // Pagination capacities are derived from the page height so each paper format
+    // uses its available space (Legal fits more rows than A4, US Letter slightly
+    // fewer). Everything is sized for the worst case — a two-line wrapped value
+    // name, or a full-height chart card — so content never clips. The first page
+    // of a section holds fewer items because it also carries the section title.
+    private static let footer: CGFloat = 28
+    private static let runningHeader: CGFloat = 30
+    private static let sectionTitle: CGFloat = 56
+    private static let rowUnit: CGFloat = 50
+    private static let chartUnit: CGFloat = 212
+
+    private static func usableHeight(_ size: CGSize) -> CGFloat {
+        size.height - margin * 2 - footer - runningHeader
+    }
+
+    /// Latest-results rows per page: `(first page, continuation pages)`.
+    static func tableRows(for size: CGSize) -> (first: Int, rest: Int) {
+        let height = usableHeight(size)
+        return (max(1, Int((height - sectionTitle) / rowUnit)), max(1, Int(height / rowUnit)))
+    }
+
+    /// Trend charts per page: `(first page, continuation pages)`.
+    static func charts(for size: CGSize) -> (first: Int, rest: Int) {
+        let height = usableHeight(size)
+        return (max(1, Int((height - sectionTitle) / chartUnit)), max(1, Int(height / chartUnit)))
+    }
 }

--- a/LabImporter/Models/PDFExportOptions.swift
+++ b/LabImporter/Models/PDFExportOptions.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+// User-tunable settings for a PDF export, configured in `PDFExportView` and
+// consumed by `PDFExportService`. Everything here is purely about *presentation*
+// of data the app already holds — a PDF export never reaches Apple Health and is
+// not a clinical document (see the disclaimer stamped on the cover page).
+
+/// How the exported PDF is coloured. Color uses the app's clinical category
+/// palette; monochrome renders a print-friendly black-and-white document where
+/// out-of-range values are conveyed by weight and the High/Low badge rather than
+/// hue, so the report stays legible on a grayscale printer or photocopier.
+enum PDFColorMode: String, CaseIterable, Identifiable {
+    case color
+    case monochrome
+
+    var id: Self { self }
+
+    var label: LocalizedStringKey {
+        switch self {
+        case .color: return "Color"
+        case .monochrome: return "Black & White"
+        }
+    }
+}
+
+/// Time window applied to the trend charts (the latest-results table always
+/// reflects the most recent reading regardless of this). Mirrors the dashboard's
+/// `TrendsView.TrendWindow` but kept standalone so the export module doesn't
+/// depend on a view's nested type.
+enum PDFTimeRange: String, CaseIterable, Identifiable {
+    case month3, month6, year1, year2, all
+
+    var id: Self { self }
+
+    /// Visible span in days, or `nil` for "include everything".
+    var days: Int? {
+        switch self {
+        case .month3: return 92
+        case .month6: return 183
+        case .year1: return 366
+        case .year2: return 731
+        case .all: return nil
+        }
+    }
+
+    var label: LocalizedStringKey {
+        switch self {
+        case .month3: return "3M"
+        case .month6: return "6M"
+        case .year1: return "1Y"
+        case .year2: return "2Y"
+        case .all: return "All"
+        }
+    }
+
+    /// Short label as a plain `String`, for rendering inside the PDF (where a
+    /// `LocalizedStringKey` can't be drawn directly).
+    var shortLabel: String {
+        switch self {
+        case .month3: return String(localized: "3M")
+        case .month6: return String(localized: "6M")
+        case .year1: return String(localized: "1Y")
+        case .year2: return String(localized: "2Y")
+        case .all: return String(localized: "All")
+        }
+    }
+
+    /// Localized long form used in the PDF header (e.g. "Last 12 months").
+    var longLabel: String {
+        switch self {
+        case .month3: return String(localized: "Last 3 months")
+        case .month6: return String(localized: "Last 6 months")
+        case .year1: return String(localized: "Last 12 months")
+        case .year2: return String(localized: "Last 2 years")
+        case .all: return String(localized: "All time")
+        }
+    }
+}
+
+/// The set of choices that fully describe one export.
+struct PDFExportOptions {
+    /// LOINC codes the user chose to include.
+    var selectedCodes: Set<String>
+    var timeRange: PDFTimeRange = .year1
+    var colorMode: PDFColorMode = .color
+    /// Cover/summary page with patient details and headline stats.
+    var includeSummary = true
+    /// Table of the most recent value for every selected metric.
+    var includeLatestResults = true
+    /// One chart per selected metric that has at least two readings in range.
+    var includeTrends = true
+}
+
+/// Resolves the export's colours from its `PDFColorMode`. Deliberately uses
+/// solid colours only — `ImageRenderer` (which rasterises the SwiftUI pages into
+/// the PDF) does not reproduce `.ultraThinMaterial`/`.glassEffect`, so the
+/// on-screen card styling can't be reused for print.
+struct PDFTheme {
+    let mode: PDFColorMode
+
+    var isColor: Bool { mode == .color }
+
+    // MARK: Neutrals
+
+    var pageBackground: Color { .white }
+    var textPrimary: Color { Color(white: 0.12) }
+    var textSecondary: Color { Color(white: 0.45) }
+    var textTertiary: Color { Color(white: 0.6) }
+    var hairline: Color { Color(white: 0.86) }
+    /// Card fills and zebra striping are dropped in monochrome to save ink/toner
+    /// — structure is carried by hairline borders instead.
+    var cardBackground: Color { isColor ? Color(white: 0.975) : .white }
+    var cardStroke: Color { Color(white: 0.82) }
+    /// Subtle zebra fill for alternating table rows; none in monochrome.
+    var rowAlternate: Color { isColor ? Color(white: 0.965) : .clear }
+
+    // MARK: Category / accent
+
+    /// Accent for a clinical category — its palette colour in colour mode, a
+    /// neutral dark gray in monochrome.
+    func color(for category: LabCategory) -> Color {
+        isColor ? category.color : Color(white: 0.32)
+    }
+
+    /// Colour for a value given its range status. In colour mode out-of-range
+    /// values take the status tint; in monochrome they go solid black (the
+    /// High/Low badge and bold weight carry the meaning).
+    func valueColor(for status: RangeStatus?) -> Color {
+        guard let status, status.isOutOfRange else { return textPrimary }
+        return isColor ? status.color : .black
+    }
+
+    /// Colour for a status badge capsule.
+    func statusColor(_ status: RangeStatus) -> Color {
+        isColor ? status.color : Color(white: 0.2)
+    }
+
+    var chartGrid: Color { Color(white: 0.9) }
+
+    /// Gradient painted behind the cover header. Built from up to three of the
+    /// report's dominant category colours (colour mode), or graphite in mono.
+    func headerGradient(from categories: [LabCategory]) -> [Color] {
+        guard isColor else {
+            return [Color(white: 0.22), Color(white: 0.40)]
+        }
+        let colors = categories.prefix(3).map { $0.color }
+        switch colors.count {
+        case 0: return [Color.accentColor, Color.accentColor.opacity(0.7)]
+        case 1: return [colors[0], colors[0].opacity(0.6)]
+        default: return colors
+        }
+    }
+}
+
+/// Fixed page geometry for the export. A4 portrait at 72 dpi (1 pt == 1/72").
+/// A4 is the most internationally portable choice given the app ships across
+/// many European locales.
+enum PDFLayout {
+    static let pageSize = CGSize(width: 595.28, height: 841.89)
+    static let margin: CGFloat = 42
+    static var contentWidth: CGFloat { pageSize.width - margin * 2 }
+
+    /// How many latest-results rows fit per page. Sized for the worst case — a
+    /// two-line wrapped value name — so long LOINC names never clip or spill past
+    /// the page. The first page holds fewer rows because it carries the section
+    /// title.
+    static let tableRowsPerPage = 13
+    static let tableRowsFirstPage = 12
+    /// Trend charts stacked per page.
+    static let chartsPerPage = 3
+}

--- a/LabImporter/Services/PDFExportService.swift
+++ b/LabImporter/Services/PDFExportService.swift
@@ -187,7 +187,7 @@ struct PDFExportService {
         let pages = PDFPageComposer(data: data, options: options, theme: theme).pages()
         guard !pages.isEmpty else { throw PDFExportError.noContent }
 
-        let size = PDFLayout.pageSize
+        let size = options.pageFormat.size
         var mediaBox = CGRect(origin: .zero, size: size)
         let url = Self.outputURL(for: data)
 

--- a/LabImporter/Services/PDFExportService.swift
+++ b/LabImporter/Services/PDFExportService.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+// Builds an information-rich PDF from the reports already loaded from Apple
+// Health. The flow is:
+//
+//   reports + options  →  PDFReportData (pure computation, off the main actor)
+//                      →  [page views]   (PDFPageComposer, main actor)
+//                      →  PDF file       (ImageRenderer → CGPDFContext)
+//
+// Like `CDAExportService` this is a thin, stateless service; unlike it, the
+// render step must run on the main actor because it rasterises SwiftUI views.
+
+// MARK: - Computed model
+
+/// One metric's full picture for the export: its identity, the readings inside
+/// the chosen time window, and the precomputed stats the pages display.
+struct PDFMetric: Identifiable {
+    let code: String
+    let name: String
+    let category: LabCategory
+    let unit: String
+    let referenceRange: ReferenceRange?
+    /// All readings, oldest → newest (used for the "latest" value).
+    let allPoints: [SparkPoint]
+    /// Readings within the selected time window, oldest → newest (charts/stats).
+    let windowPoints: [SparkPoint]
+
+    var id: String { code }
+
+    var latest: SparkPoint? { allPoints.last }
+
+    var latestStatus: RangeStatus? {
+        guard let value = latest?.value, let referenceRange else { return nil }
+        return referenceRange.status(for: value)
+    }
+
+    /// True when there are enough in-window readings to draw a meaningful line.
+    var hasTrend: Bool { windowPoints.count >= 2 }
+
+    var minValue: Double? { windowPoints.map(\.value).min() }
+    var maxValue: Double? { windowPoints.map(\.value).max() }
+    var averageValue: Double? {
+        guard !windowPoints.isEmpty else { return nil }
+        return windowPoints.map(\.value).reduce(0, +) / Double(windowPoints.count)
+    }
+
+    /// Net change across the window (newest − oldest in-window reading).
+    var change: Double? {
+        guard let first = windowPoints.first?.value, let last = windowPoints.last?.value,
+              windowPoints.count >= 2 else { return nil }
+        return last - first
+    }
+}
+
+/// Everything a set of pages needs, assembled once up front.
+struct PDFReportData {
+    let patientName: String
+    let dateOfBirth: Date?
+    let biologicalSexRaw: Int?
+    let authorName: String
+    let earliestDate: Date?
+    let latestDate: Date?
+    let reportCount: Int
+    let totalValueCount: Int
+    let timeRange: PDFTimeRange
+    let metrics: [PDFMetric]
+    let generatedAt: Date
+
+    /// Selected metrics whose most recent reading is outside its reference range.
+    var outOfRangeCount: Int {
+        metrics.filter { $0.latestStatus?.isOutOfRange == true }.count
+    }
+
+    /// Distinct categories among the selected metrics, in canonical order.
+    var categories: [LabCategory] {
+        let present = Set(metrics.map(\.category))
+        return LabCategory.allCases.filter { present.contains($0) }
+    }
+
+    /// Categories ordered by how many selected metrics they contain — drives the
+    /// cover header's gradient so it reflects the report's emphasis.
+    var dominantCategories: [LabCategory] {
+        var counts: [LabCategory: Int] = [:]
+        for metric in metrics { counts[metric.category, default: 0] += 1 }
+        return counts
+            .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key.rawValue < $1.key.rawValue }
+            .map(\.key)
+    }
+}
+
+// MARK: - Service
+
+struct PDFExportService {
+
+    enum PDFExportError: LocalizedError {
+        case noContent
+        case renderingFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .noContent:
+                return String(localized: "Select at least one value to include in the PDF.")
+            case .renderingFailed:
+                return String(localized: "The PDF could not be generated. Please try again.")
+            }
+        }
+    }
+
+    // MARK: Data assembly
+
+    /// Distills the loaded reports into the renderable model. Pure and
+    /// `nonisolated` so it can run before hopping to the main actor to render.
+    nonisolated static func buildData(
+        reports: [LabReport],
+        options: PDFExportOptions,
+        patient: HealthKitService.PatientCharacteristics?,
+        fallbackPatientName: String
+    ) -> PDFReportData {
+        let sorted = reports.sorted { $0.date < $1.date }
+        let cutoff = options.timeRange.days.map { days in
+            Date().addingTimeInterval(-Double(days) * 86_400)
+        }
+
+        // Gather every numeric reading per selected code across all reports.
+        var pointsByCode: [String: [SparkPoint]] = [:]
+        var metaByCode: [String: (name: String, unit: String)] = [:]
+        for report in sorted {
+            for entry in report.entries where options.selectedCodes.contains(entry.code) {
+                guard let value = entry.numericValue else { continue }
+                pointsByCode[entry.code, default: []].append(SparkPoint(date: report.date, value: value))
+                // Keep the most recent name/unit (sorted ascending → last wins).
+                metaByCode[entry.code] = (entry.resolvedName, entry.unit)
+            }
+        }
+
+        let metrics: [PDFMetric] = pointsByCode.compactMap { code, points in
+            guard let meta = metaByCode[code] else { return nil }
+            let windowPoints = cutoff.map { cut in points.filter { $0.date >= cut } } ?? points
+            return PDFMetric(
+                code: code,
+                name: meta.name,
+                category: LabCategory.forCode(code),
+                unit: meta.unit,
+                referenceRange: LabMapping.referenceRange(for: code),
+                allPoints: points,
+                windowPoints: windowPoints
+            )
+        }
+        .sorted { lhs, rhs in
+            // Group by category (canonical order), then by name within a category.
+            if lhs.category != rhs.category {
+                let order = LabCategory.allCases
+                return (order.firstIndex(of: lhs.category) ?? 0) < (order.firstIndex(of: rhs.category) ?? 0)
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+
+        // Prefer the user's configured name; otherwise fall back to the name
+        // stored on the most recent report.
+        let patientName = fallbackPatientName.isEmpty ? (sorted.last?.patientName ?? "") : fallbackPatientName
+        let totalValues = reports.reduce(0) { $0 + $1.entries.count }
+
+        return PDFReportData(
+            patientName: patientName,
+            dateOfBirth: patient?.dateOfBirth,
+            biologicalSexRaw: patient?.biologicalSexRaw,
+            authorName: sorted.last?.authorName ?? "",
+            earliestDate: sorted.first?.date,
+            latestDate: sorted.last?.date,
+            reportCount: reports.count,
+            totalValueCount: totalValues,
+            timeRange: options.timeRange,
+            metrics: metrics,
+            generatedAt: Date()
+        )
+    }
+
+    // MARK: Rendering
+
+    /// Renders the pages to a temporary PDF file and returns its URL for sharing.
+    /// Runs on the main actor because `ImageRenderer` rasterises SwiftUI views.
+    @MainActor
+    func export(data: PDFReportData, options: PDFExportOptions) throws -> URL {
+        guard !data.metrics.isEmpty else { throw PDFExportError.noContent }
+
+        let theme = PDFTheme(mode: options.colorMode)
+        let pages = PDFPageComposer(data: data, options: options, theme: theme).pages()
+        guard !pages.isEmpty else { throw PDFExportError.noContent }
+
+        let size = PDFLayout.pageSize
+        var mediaBox = CGRect(origin: .zero, size: size)
+        let url = Self.outputURL(for: data)
+
+        guard let consumer = CGDataConsumer(url: url as CFURL),
+              let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw PDFExportError.renderingFailed
+        }
+
+        for page in pages {
+            let renderer = ImageRenderer(content: page)
+            renderer.proposedSize = ProposedViewSize(size)
+            var rendered = false
+            renderer.render { _, draw in
+                context.beginPDFPage(nil)
+                draw(context)
+                context.endPDFPage()
+                rendered = true
+            }
+            guard rendered else {
+                context.closePDF()
+                throw PDFExportError.renderingFailed
+            }
+        }
+        context.closePDF()
+        return url
+    }
+
+    private static func outputURL(for data: PDFReportData) -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let datePart = data.latestDate.map { formatter.string(from: $0) } ?? formatter.string(from: data.generatedAt)
+        let name = "LabReport-\(datePart).pdf"
+        return FileManager.default.temporaryDirectory.appendingPathComponent(name)
+    }
+}

--- a/LabImporter/Views/Export/PDFExportView.swift
+++ b/LabImporter/Views/Export/PDFExportView.swift
@@ -84,6 +84,12 @@ struct PDFExportView: View {
                 }
             }
             .pickerStyle(.segmented)
+
+            Picker("Page Size", selection: $options.pageFormat) {
+                ForEach(PDFPageFormat.allCases) { format in
+                    Text(format.label).tag(format)
+                }
+            }
         }
     }
 

--- a/LabImporter/Views/Export/PDFExportView.swift
+++ b/LabImporter/Views/Export/PDFExportView.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+
+/// Configuration sheet for a PDF export: pick the colour treatment, which
+/// sections to include, the trend time range, and exactly which values appear.
+/// On generate it builds the PDF off the loaded reports and hands the file to a
+/// share sheet.
+struct PDFExportView: View {
+    let reports: [LabReport]
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("labDisplayPrefs") private var prefs = LabDisplayPreferences()
+    @AppStorage("patientName") private var patientName = ""
+
+    @State private var options: PDFExportOptions
+    @State private var patient: HealthKitService.PatientCharacteristics?
+    @State private var shareURL: IdentifiedURL?
+    @State private var isGenerating = false
+    @State private var errorMessage: String?
+
+    /// A selectable metric: a distinct LOINC code that has at least one numeric
+    /// reading across the loaded reports.
+    private struct Available: Identifiable {
+        let code: String
+        let name: String
+        let category: LabCategory
+        var id: String { code }
+    }
+
+    init(reports: [LabReport]) {
+        self.reports = reports
+        let codes = Self.availableCodes(in: reports)
+        _options = State(initialValue: PDFExportOptions(selectedCodes: Set(codes)))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                appearanceSection
+                sectionsSection
+                if options.includeTrends { timeRangeSection }
+                valuesSection
+            }
+            .navigationTitle("Export PDF")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(role: .close) { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if isGenerating {
+                        ProgressView()
+                    } else {
+                        Button {
+                            generate()
+                        } label: {
+                            Image(systemName: "checkmark")
+                        }
+                        .accessibilityLabel(Text("Generate"))
+                        .disabled(options.selectedCodes.isEmpty)
+                    }
+                }
+            }
+            .task {
+                patient = try? await HealthKitService.shared.readPatientCharacteristics()
+            }
+            .alert("Export Error", isPresented: .constant(errorMessage != nil)) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+            .sheet(item: $shareURL) { item in
+                PDFShareSheet(url: item.url)
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var appearanceSection: some View {
+        Section("Appearance") {
+            Picker("Color Mode", selection: $options.colorMode) {
+                ForEach(PDFColorMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var sectionsSection: some View {
+        Section {
+            Toggle("Summary Page", isOn: $options.includeSummary)
+            Toggle("Latest Results", isOn: $options.includeLatestResults)
+            Toggle("Trend Charts", isOn: $options.includeTrends)
+        } header: {
+            Text("Sections")
+        } footer: {
+            Text("Trend charts appear for values with at least two readings in the selected range.")
+        }
+    }
+
+    private var timeRangeSection: some View {
+        Section("Trend Time Range") {
+            Picker("Time Range", selection: $options.timeRange) {
+                ForEach(PDFTimeRange.allCases) { range in
+                    Text(range.label).tag(range)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var valuesSection: some View {
+        Section {
+            ForEach(available) { item in
+                Button {
+                    toggle(item.code)
+                } label: {
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(item.category.color)
+                            .frame(width: 9, height: 9)
+                        Text(item.name)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        if options.selectedCodes.contains(item.code) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
+            }
+        } header: {
+            HStack {
+                Text("Included Values")
+                Spacer()
+                Button(allSelected ? "Deselect All" : "Select All") {
+                    options.selectedCodes = allSelected ? [] : Set(available.map(\.code))
+                }
+                .font(.caption.weight(.medium))
+                .textCase(nil)
+            }
+        } footer: {
+            Text("\(options.selectedCodes.count) of \(available.count) selected")
+        }
+    }
+
+    // MARK: - Derived data
+
+    private var available: [Available] {
+        var seen = Set<String>()
+        var result: [Available] = []
+        for report in reports {
+            for entry in report.entries where entry.numericValue != nil && seen.insert(entry.code).inserted {
+                result.append(Available(code: entry.code, name: entry.resolvedName,
+                                        category: LabCategory.forCode(entry.code)))
+            }
+        }
+        // Mirror the dashboard order: pinned first, then the user's explicit
+        // order, then alphabetical — so the export list matches what they see.
+        let pinned = prefs.pinnedSet
+        var orderMap: [String: Int] = [:]
+        for (index, code) in prefs.orderedCodes.enumerated() where orderMap[code] == nil {
+            orderMap[code] = index
+        }
+        return result.sorted { lhs, rhs in
+            let lPin = pinned.contains(lhs.code)
+            let rPin = pinned.contains(rhs.code)
+            if lPin != rPin { return lPin }
+            let lOrd = orderMap[lhs.code] ?? Int.max
+            let rOrd = orderMap[rhs.code] ?? Int.max
+            if lOrd != rOrd { return lOrd < rOrd }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    private var allSelected: Bool {
+        !available.isEmpty && options.selectedCodes.count == available.count
+    }
+
+    /// Distinct LOINC codes with numeric data — the default selection.
+    private static func availableCodes(in reports: [LabReport]) -> [String] {
+        var seen = Set<String>()
+        var codes: [String] = []
+        for report in reports {
+            for entry in report.entries where entry.numericValue != nil && seen.insert(entry.code).inserted {
+                codes.append(entry.code)
+            }
+        }
+        return codes
+    }
+
+    // MARK: - Actions
+
+    private func toggle(_ code: String) {
+        if options.selectedCodes.contains(code) {
+            options.selectedCodes.remove(code)
+        } else {
+            options.selectedCodes.insert(code)
+        }
+    }
+
+    private func generate() {
+        isGenerating = true
+        let reports = reports
+        let options = options
+        let patient = patient
+        let fallbackName = patientName
+        Task {
+            let data = PDFExportService.buildData(reports: reports, options: options,
+                                                  patient: patient, fallbackPatientName: fallbackName)
+            do {
+                let url = try await MainActor.run { try PDFExportService().export(data: data, options: options) }
+                shareURL = IdentifiedURL(url: url)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isGenerating = false
+        }
+    }
+}
+
+// MARK: - Share sheet
+
+/// `UIActivityViewController` wrapper for sharing the generated PDF. Mirrors the
+/// popover anchoring used elsewhere so it stays valid on iPad.
+struct PDFShareSheet: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        if let popover = controller.popoverPresentationController {
+            popover.sourceView = controller.view
+            popover.permittedArrowDirections = []
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {
+        if let popover = controller.popoverPresentationController, let source = popover.sourceView {
+            popover.sourceRect = CGRect(x: source.bounds.midX, y: source.bounds.midY, width: 0, height: 0)
+        }
+    }
+}

--- a/LabImporter/Views/Export/PDFReportComposer.swift
+++ b/LabImporter/Views/Export/PDFReportComposer.swift
@@ -16,6 +16,8 @@ struct PDFPageComposer {
     let options: PDFExportOptions
     let theme: PDFTheme
 
+    private var size: CGSize { options.pageFormat.size }
+
     func pages() -> [AnyView] {
         var blocks: [Block] = []
         if options.includeSummary { blocks.append(.cover) }
@@ -43,40 +45,47 @@ struct PDFPageComposer {
             rows.append(contentsOf: metrics.map { LatestRow.metric($0) })
         }
         guard !rows.isEmpty else { return [] }
-
-        // The first page holds fewer rows (it carries the section title); later
-        // pages use the full budget.
-        var blocks: [Block] = []
-        var index = 0
-        var isFirst = true
-        while index < rows.count {
-            let size = isFirst ? PDFLayout.tableRowsFirstPage : PDFLayout.tableRowsPerPage
-            let end = Swift.min(index + size, rows.count)
-            blocks.append(.latest(rows: Array(rows[index..<end]), showTitle: isFirst))
-            index = end
-            isFirst = false
-        }
-        return blocks
+        let capacity = PDFLayout.tableRows(for: size)
+        return paginate(rows, first: capacity.first, rest: capacity.rest)
+            .map { Block.latest(rows: $0.items, showTitle: $0.isFirst) }
     }
 
     private func trendBlocks() -> [Block] {
         let trendMetrics = data.metrics.filter(\.hasTrend)
         guard !trendMetrics.isEmpty else { return [] }
-        return trendMetrics.chunked(into: PDFLayout.chartsPerPage).enumerated().map { index, chunk in
-            .trends(metrics: chunk, showTitle: index == 0)
+        let capacity = PDFLayout.charts(for: size)
+        return paginate(trendMetrics, first: capacity.first, rest: capacity.rest)
+            .map { Block.trends(metrics: $0.items, showTitle: $0.isFirst) }
+    }
+
+    /// Splits items across pages: the first page holds `first` items (it carries
+    /// the section title), later pages hold `rest`.
+    private func paginate<T>(_ items: [T], first: Int, rest: Int) -> [(items: [T], isFirst: Bool)] {
+        var result: [(items: [T], isFirst: Bool)] = []
+        var index = 0
+        var isFirst = true
+        while index < items.count {
+            let size = isFirst ? first : rest
+            let end = Swift.min(index + size, items.count)
+            result.append((Array(items[index..<end]), isFirst))
+            index = end
+            isFirst = false
         }
+        return result
     }
 
     private func view(for block: Block, pageNumber: Int, total: Int) -> AnyView {
         switch block {
         case .cover:
-            return AnyView(PDFCoverPage(data: data, theme: theme, pageNumber: pageNumber, totalPages: total))
+            return AnyView(PDFCoverPage(data: data, theme: theme, pageSize: size,
+                                        pageNumber: pageNumber, totalPages: total))
         case let .latest(rows, showTitle):
             return AnyView(PDFLatestResultsPage(rows: rows, showTitle: showTitle, patientName: data.patientName,
-                                                theme: theme, pageNumber: pageNumber, totalPages: total))
+                                                theme: theme, pageSize: size,
+                                                pageNumber: pageNumber, totalPages: total))
         case let .trends(metrics, showTitle):
             return AnyView(PDFTrendsPage(metrics: metrics, showTitle: showTitle, range: data.timeRange,
-                                         patientName: data.patientName, theme: theme,
+                                         patientName: data.patientName, theme: theme, pageSize: size,
                                          pageNumber: pageNumber, totalPages: total))
         }
     }
@@ -97,10 +106,11 @@ enum LatestRow: Identifiable {
 
 // MARK: - Page scaffold
 
-/// Shared page chrome: fixed A4 geometry, white background, optional running
+/// Shared page chrome: fixed page geometry, white background, optional running
 /// header, and a footer with the page number. Content fills the space between.
 struct PDFPageScaffold<Content: View>: View {
     let theme: PDFTheme
+    let pageSize: CGSize
     let pageNumber: Int
     let totalPages: Int
     var runningTitle: String?
@@ -118,7 +128,7 @@ struct PDFPageScaffold<Content: View>: View {
             footer
         }
         .padding(PDFLayout.margin)
-        .frame(width: PDFLayout.pageSize.width, height: PDFLayout.pageSize.height, alignment: .topLeading)
+        .frame(width: pageSize.width, height: pageSize.height, alignment: .topLeading)
         .background(theme.pageBackground)
         .environment(\.colorScheme, .light)
     }
@@ -215,13 +225,6 @@ enum PDFFormat {
     }
 }
 
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        guard size > 0 else { return [self] }
-        return stride(from: 0, to: count, by: size).map { Array(self[$0..<Swift.min($0 + size, count)]) }
-    }
-}
-
 /// A minimal wrapping HStack for the cover legend — `ImageRenderer` supports the
 /// `Layout` protocol, so this lays category chips out across lines without
 /// relying on a fixed column count.
@@ -230,7 +233,7 @@ struct FlowLayout: Layout {
     var lineSpacing: CGFloat = 8
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
-        let maxWidth = proposal.width ?? PDFLayout.contentWidth
+        let maxWidth = proposal.width ?? PDFLayout.contentWidth(for: PDFPageFormat.isoA4.size)
         var rows: [[CGSize]] = [[]]
         var lineWidth: CGFloat = 0
         for subview in subviews {

--- a/LabImporter/Views/Export/PDFReportComposer.swift
+++ b/LabImporter/Views/Export/PDFReportComposer.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+// Infrastructure shared by the PDF page views: the page composer that paginates
+// content, the page scaffold (fixed A4 geometry + header/footer), and small
+// reusable pieces. These are *print* views — solid fills only (no
+// materials/glass, which `ImageRenderer` drops) and a forced light colour scheme
+// — so the output renders identically regardless of the device's appearance.
+
+// MARK: - Composer
+
+/// Turns a `PDFReportData` + options into an ordered list of page views,
+/// handling pagination of the latest-results table and the trend charts.
+@MainActor
+struct PDFPageComposer {
+    let data: PDFReportData
+    let options: PDFExportOptions
+    let theme: PDFTheme
+
+    func pages() -> [AnyView] {
+        var blocks: [Block] = []
+        if options.includeSummary { blocks.append(.cover) }
+        if options.includeLatestResults { blocks += latestBlocks() }
+        if options.includeTrends { blocks += trendBlocks() }
+
+        let total = blocks.count
+        return blocks.enumerated().map { index, block in
+            view(for: block, pageNumber: index + 1, total: total)
+        }
+    }
+
+    private enum Block {
+        case cover
+        case latest(rows: [LatestRow], showTitle: Bool)
+        case trends(metrics: [PDFMetric], showTitle: Bool)
+    }
+
+    private func latestBlocks() -> [Block] {
+        var rows: [LatestRow] = []
+        let grouped = Dictionary(grouping: data.metrics, by: \.category)
+        for category in data.categories {
+            guard let metrics = grouped[category] else { continue }
+            rows.append(.category(category, count: metrics.count))
+            rows.append(contentsOf: metrics.map { LatestRow.metric($0) })
+        }
+        guard !rows.isEmpty else { return [] }
+
+        // The first page holds fewer rows (it carries the section title); later
+        // pages use the full budget.
+        var blocks: [Block] = []
+        var index = 0
+        var isFirst = true
+        while index < rows.count {
+            let size = isFirst ? PDFLayout.tableRowsFirstPage : PDFLayout.tableRowsPerPage
+            let end = Swift.min(index + size, rows.count)
+            blocks.append(.latest(rows: Array(rows[index..<end]), showTitle: isFirst))
+            index = end
+            isFirst = false
+        }
+        return blocks
+    }
+
+    private func trendBlocks() -> [Block] {
+        let trendMetrics = data.metrics.filter(\.hasTrend)
+        guard !trendMetrics.isEmpty else { return [] }
+        return trendMetrics.chunked(into: PDFLayout.chartsPerPage).enumerated().map { index, chunk in
+            .trends(metrics: chunk, showTitle: index == 0)
+        }
+    }
+
+    private func view(for block: Block, pageNumber: Int, total: Int) -> AnyView {
+        switch block {
+        case .cover:
+            return AnyView(PDFCoverPage(data: data, theme: theme, pageNumber: pageNumber, totalPages: total))
+        case let .latest(rows, showTitle):
+            return AnyView(PDFLatestResultsPage(rows: rows, showTitle: showTitle, patientName: data.patientName,
+                                                theme: theme, pageNumber: pageNumber, totalPages: total))
+        case let .trends(metrics, showTitle):
+            return AnyView(PDFTrendsPage(metrics: metrics, showTitle: showTitle, range: data.timeRange,
+                                         patientName: data.patientName, theme: theme,
+                                         pageNumber: pageNumber, totalPages: total))
+        }
+    }
+}
+
+/// A row in the latest-results table: either a category heading or a metric.
+enum LatestRow: Identifiable {
+    case category(LabCategory, count: Int)
+    case metric(PDFMetric)
+
+    var id: String {
+        switch self {
+        case let .category(category, _): return "cat-\(category.rawValue)"
+        case let .metric(metric): return "val-\(metric.code)"
+        }
+    }
+}
+
+// MARK: - Page scaffold
+
+/// Shared page chrome: fixed A4 geometry, white background, optional running
+/// header, and a footer with the page number. Content fills the space between.
+struct PDFPageScaffold<Content: View>: View {
+    let theme: PDFTheme
+    let pageNumber: Int
+    let totalPages: Int
+    var runningTitle: String?
+    var patientName: String = ""
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let runningTitle {
+                runningHeader(runningTitle)
+                    .padding(.bottom, 16)
+            }
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            footer
+        }
+        .padding(PDFLayout.margin)
+        .frame(width: PDFLayout.pageSize.width, height: PDFLayout.pageSize.height, alignment: .topLeading)
+        .background(theme.pageBackground)
+        .environment(\.colorScheme, .light)
+    }
+
+    private func runningHeader(_ title: String) -> some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(theme.textSecondary)
+                Spacer()
+                if !patientName.isEmpty {
+                    Text(patientName)
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.textTertiary)
+                }
+            }
+            Rectangle().fill(theme.hairline).frame(height: 0.5)
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 6) {
+            Rectangle().fill(theme.hairline).frame(height: 0.5)
+            HStack {
+                Text("LabImporter")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(theme.textTertiary)
+                Spacer()
+                Text("Page \(pageNumber) of \(totalPages)")
+                    .font(.system(size: 9))
+                    .foregroundStyle(theme.textTertiary)
+            }
+        }
+        .padding(.top, 10)
+    }
+}
+
+// MARK: - Shared small views
+
+struct PDFSectionHeader: View {
+    let title: String
+    var subtitle: String?
+    let theme: PDFTheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(theme.textPrimary)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        }
+    }
+}
+
+struct PDFStatusBadge: View {
+    let status: RangeStatus
+    let theme: PDFTheme
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: status.symbolName)
+                .font(.system(size: 7, weight: .bold))
+            Text(status.label)
+                .font(.system(size: 8, weight: .semibold))
+        }
+        .foregroundStyle(theme.statusColor(status))
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        // Colour mode: a soft tinted capsule. Monochrome: no fill (saves toner),
+        // just an outline so the badge still reads.
+        .background(theme.statusColor(status).opacity(theme.isColor ? 0.14 : 0), in: Capsule())
+        .overlay {
+            if !theme.isColor {
+                Capsule().stroke(theme.statusColor(status), lineWidth: 0.5)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+enum PDFFormat {
+    /// Whole numbers without decimals, otherwise up to four significant figures —
+    /// matching the value formatting used across the app's trend screens.
+    static func value(_ value: Double) -> String {
+        value.truncatingRemainder(dividingBy: 1) == 0
+            ? String(format: "%.0f", value)
+            : String(format: "%.4g", value)
+    }
+}
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: count, by: size).map { Array(self[$0..<Swift.min($0 + size, count)]) }
+    }
+}
+
+/// A minimal wrapping HStack for the cover legend — `ImageRenderer` supports the
+/// `Layout` protocol, so this lays category chips out across lines without
+/// relying on a fixed column count.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    var lineSpacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? PDFLayout.contentWidth
+        var rows: [[CGSize]] = [[]]
+        var lineWidth: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if lineWidth + size.width > maxWidth, !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                lineWidth = 0
+            }
+            rows[rows.count - 1].append(size)
+            lineWidth += size.width + spacing
+        }
+        let height = rows.reduce(CGFloat(0)) { partial, row in
+            partial + (row.map(\.height).max() ?? 0) + lineSpacing
+        } - (rows.isEmpty ? 0 : lineSpacing)
+        return CGSize(width: maxWidth, height: max(height, 0))
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        var posX = bounds.minX
+        var posY = bounds.minY
+        var lineHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if posX + size.width > bounds.maxX, posX > bounds.minX {
+                posX = bounds.minX
+                posY += lineHeight + lineSpacing
+                lineHeight = 0
+            }
+            subview.place(at: CGPoint(x: posX, y: posY), proposal: ProposedViewSize(size))
+            posX += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+        }
+    }
+}

--- a/LabImporter/Views/Export/PDFReportPageViews.swift
+++ b/LabImporter/Views/Export/PDFReportPageViews.swift
@@ -8,11 +8,12 @@ import SwiftUI
 struct PDFCoverPage: View {
     let data: PDFReportData
     let theme: PDFTheme
+    let pageSize: CGSize
     let pageNumber: Int
     let totalPages: Int
 
     var body: some View {
-        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages) {
+        PDFPageScaffold(theme: theme, pageSize: pageSize, pageNumber: pageNumber, totalPages: totalPages) {
             VStack(alignment: .leading, spacing: 22) {
                 banner
                 patientCard
@@ -204,11 +205,12 @@ struct PDFLatestResultsPage: View {
     let showTitle: Bool
     let patientName: String
     let theme: PDFTheme
+    let pageSize: CGSize
     let pageNumber: Int
     let totalPages: Int
 
     var body: some View {
-        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages,
+        PDFPageScaffold(theme: theme, pageSize: pageSize, pageNumber: pageNumber, totalPages: totalPages,
                         runningTitle: String(localized: "Lab Report"), patientName: patientName) {
             VStack(alignment: .leading, spacing: 14) {
                 if showTitle {

--- a/LabImporter/Views/Export/PDFReportPageViews.swift
+++ b/LabImporter/Views/Export/PDFReportPageViews.swift
@@ -1,0 +1,318 @@
+import SwiftUI
+
+// The cover/summary page and the latest-results table page of the export. Trend
+// pages live in `PDFTrendPageViews.swift`; shared chrome in `PDFReportComposer.swift`.
+
+// MARK: - Cover page
+
+struct PDFCoverPage: View {
+    let data: PDFReportData
+    let theme: PDFTheme
+    let pageNumber: Int
+    let totalPages: Int
+
+    var body: some View {
+        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages) {
+            VStack(alignment: .leading, spacing: 22) {
+                banner
+                patientCard
+                statsRow
+                if !data.categories.isEmpty { legend }
+                Spacer(minLength: 0)
+                disclaimer
+            }
+        }
+    }
+
+    // In colour mode the banner is a filled gradient (built from the report's
+    // dominant category colours) with white text. In monochrome the fill is
+    // dropped to save toner — dark text with a baseline rule instead.
+    private var bannerForeground: Color { theme.isColor ? .white : theme.textPrimary }
+    private var bannerSecondary: Color { theme.isColor ? .white.opacity(0.85) : theme.textSecondary }
+
+    private var banner: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                if theme.isColor { Circle().fill(Color.white.opacity(0.22)) }
+                Image(systemName: "heart.text.square.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(bannerForeground)
+            }
+            .frame(width: 64, height: 64)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Lab Report")
+                    .font(.system(size: 30, weight: .bold))
+                    .foregroundStyle(bannerForeground)
+                Text("Generated \(data.generatedAt.formatted(date: .long, time: .shortened))")
+                    .font(.system(size: 12))
+                    .foregroundStyle(bannerSecondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(theme.isColor
+                 ? EdgeInsets(top: 24, leading: 24, bottom: 24, trailing: 24)
+                 : EdgeInsets(top: 4, leading: 0, bottom: 16, trailing: 0))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            if theme.isColor {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(LinearGradient(colors: theme.headerGradient(from: data.dominantCategories),
+                                         startPoint: .topLeading, endPoint: .bottomTrailing))
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !theme.isColor { Rectangle().fill(theme.hairline).frame(height: 1) }
+        }
+    }
+
+    private var patientCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(metaItems, id: \.label) { item in
+                HStack(spacing: 10) {
+                    Image(systemName: item.icon)
+                        .font(.system(size: 12))
+                        .foregroundStyle(theme.textTertiary)
+                        .frame(width: 18)
+                    Text(item.label)
+                        .font(.system(size: 12))
+                        .foregroundStyle(theme.textSecondary)
+                    Spacer()
+                    Text(item.value)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(theme.textPrimary)
+                }
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.cardBackground, in: RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(theme.cardStroke, lineWidth: 0.5))
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 12) {
+            statTile(value: "\(data.reportCount)", label: String(localized: "Reports"), emphasised: false)
+            statTile(value: "\(data.metrics.count)", label: String(localized: "Metrics"), emphasised: false)
+            statTile(value: "\(data.outOfRangeCount)",
+                     label: String(localized: "Out of Range"),
+                     emphasised: data.outOfRangeCount > 0)
+            statTile(value: data.timeRange.shortLabel, label: String(localized: "Trend Range"), emphasised: false)
+        }
+    }
+
+    private func statTile(value: String, label: String, emphasised: Bool) -> some View {
+        VStack(spacing: 6) {
+            Text(value)
+                .font(.system(size: 24, weight: .bold).monospacedDigit())
+                .foregroundStyle(emphasised ? theme.valueColor(for: .high) : theme.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundStyle(theme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+        .background(theme.cardBackground, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(theme.cardStroke, lineWidth: 0.5))
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Included Categories")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.textSecondary)
+            FlowLayout(spacing: 8, lineSpacing: 8) {
+                ForEach(data.categories, id: \.self) { category in
+                    HStack(spacing: 6) {
+                        Circle().fill(theme.color(for: category)).frame(width: 8, height: 8)
+                        Text(category.displayName)
+                            .font(.system(size: 11))
+                            .foregroundStyle(theme.textPrimary)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(theme.color(for: category).opacity(theme.isColor ? 0.1 : 0),
+                                in: Capsule())
+                    .overlay(Capsule().stroke(theme.cardStroke, lineWidth: 0.5))
+                }
+            }
+        }
+    }
+
+    private var disclaimer: some View {
+        // swiftlint:disable:next line_length
+        Text("This report was generated by LabImporter from data stored in Apple Health. It is for personal reference only — it is not a medical document and is not a substitute for professional medical advice.")
+            .font(.system(size: 9))
+            .foregroundStyle(theme.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private struct MetaItem { let icon: String; let label: String; let value: String }
+
+    private var metaItems: [MetaItem] {
+        var items: [MetaItem] = []
+        if !data.patientName.isEmpty {
+            items.append(MetaItem(icon: "person.fill", label: String(localized: "Patient"), value: data.patientName))
+        }
+        if let dob = data.dateOfBirth {
+            items.append(MetaItem(icon: "calendar", label: String(localized: "Date of Birth"), value: dobValue(dob)))
+        }
+        if let sex = sexLabel {
+            items.append(MetaItem(icon: "figure.stand", label: String(localized: "Sex"), value: sex))
+        }
+        if !data.authorName.isEmpty {
+            items.append(MetaItem(icon: "cross.case.fill", label: String(localized: "Author"), value: data.authorName))
+        }
+        if let range = dateRangeValue {
+            items.append(MetaItem(icon: "clock.arrow.circlepath", label: String(localized: "Period Covered"), value: range))
+        }
+        return items
+    }
+
+    private func dobValue(_ dob: Date) -> String {
+        let dateString = dob.formatted(date: .long, time: .omitted)
+        if let years = Calendar.current.dateComponents([.year], from: dob, to: data.generatedAt).year, years >= 0 {
+            return "\(dateString) (\(String(localized: "Age \(years)")))"
+        }
+        return dateString
+    }
+
+    private var sexLabel: String? {
+        switch data.biologicalSexRaw {
+        case 1: return String(localized: "Female")
+        case 2: return String(localized: "Male")
+        case 3: return String(localized: "Other")
+        default: return nil
+        }
+    }
+
+    private var dateRangeValue: String? {
+        guard let earliest = data.earliestDate, let latest = data.latestDate else { return nil }
+        let fromText = earliest.formatted(date: .abbreviated, time: .omitted)
+        let toText = latest.formatted(date: .abbreviated, time: .omitted)
+        return fromText == toText ? fromText : "\(fromText) – \(toText)"
+    }
+}
+
+// MARK: - Latest results page
+
+struct PDFLatestResultsPage: View {
+    let rows: [LatestRow]
+    let showTitle: Bool
+    let patientName: String
+    let theme: PDFTheme
+    let pageNumber: Int
+    let totalPages: Int
+
+    var body: some View {
+        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages,
+                        runningTitle: String(localized: "Lab Report"), patientName: patientName) {
+            VStack(alignment: .leading, spacing: 14) {
+                if showTitle {
+                    PDFSectionHeader(title: String(localized: "Latest Results"),
+                                     subtitle: String(localized: "Most recent reading for each value"),
+                                     theme: theme)
+                }
+                tableHeader
+                VStack(spacing: 0) {
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                        rowView(row, zebra: index.isMultiple(of: 2))
+                    }
+                }
+            }
+        }
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: 8) {
+            Text("Test").frame(maxWidth: .infinity, alignment: .leading)
+            Text("Result").frame(width: 96, alignment: .trailing)
+            Text("Reference").frame(width: 92, alignment: .trailing)
+            Text("Date").frame(width: 66, alignment: .trailing)
+        }
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(theme.textTertiary)
+        .textCase(.uppercase)
+        .padding(.horizontal, 8)
+        .padding(.bottom, 4)
+        .overlay(alignment: .bottom) { Rectangle().fill(theme.hairline).frame(height: 0.5) }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: LatestRow, zebra: Bool) -> some View {
+        switch row {
+        case let .category(category, count):
+            categoryRow(category, count: count)
+        case let .metric(metric):
+            metricRow(metric, zebra: zebra)
+        }
+    }
+
+    private func categoryRow(_ category: LabCategory, count: Int) -> some View {
+        HStack(spacing: 8) {
+            Circle().fill(theme.color(for: category)).frame(width: 9, height: 9)
+            Text(category.displayName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.textPrimary)
+            Spacer()
+            Text("\(count)")
+                .font(.system(size: 10).monospacedDigit())
+                .foregroundStyle(theme.textTertiary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.top, 12)
+        .padding(.bottom, 5)
+    }
+
+    private func metricRow(_ metric: PDFMetric, zebra: Bool) -> some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(metric.name)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.textPrimary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(metric.code)
+                    .font(.system(size: 8))
+                    .foregroundStyle(theme.textTertiary)
+                    .textCase(.uppercase)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 4) {
+                if let status = metric.latestStatus, status.isOutOfRange {
+                    PDFStatusBadge(status: status, theme: theme)
+                }
+                Text(resultText(metric))
+                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(theme.valueColor(for: metric.latestStatus))
+                    .lineLimit(1)
+            }
+            .frame(width: 96, alignment: .trailing)
+
+            Text(metric.referenceRange?.formatted() ?? "—")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(theme.textSecondary)
+                .frame(width: 92, alignment: .trailing)
+                .lineLimit(1)
+
+            Text(metric.latest?.date.formatted(.dateTime.year(.twoDigits).month(.defaultDigits).day()) ?? "—")
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundStyle(theme.textSecondary)
+                .frame(width: 66, alignment: .trailing)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(zebra ? theme.rowAlternate : Color.clear)
+    }
+
+    private func resultText(_ metric: PDFMetric) -> String {
+        guard let value = metric.latest?.value else { return "—" }
+        let number = PDFFormat.value(value)
+        return metric.unit.isEmpty ? number : "\(number) \(metric.unit)"
+    }
+}

--- a/LabImporter/Views/Export/PDFTrendPageViews.swift
+++ b/LabImporter/Views/Export/PDFTrendPageViews.swift
@@ -11,11 +11,12 @@ struct PDFTrendsPage: View {
     let range: PDFTimeRange
     let patientName: String
     let theme: PDFTheme
+    let pageSize: CGSize
     let pageNumber: Int
     let totalPages: Int
 
     var body: some View {
-        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages,
+        PDFPageScaffold(theme: theme, pageSize: pageSize, pageNumber: pageNumber, totalPages: totalPages,
                         runningTitle: String(localized: "Lab Report"), patientName: patientName) {
             VStack(alignment: .leading, spacing: 14) {
                 if showTitle {

--- a/LabImporter/Views/Export/PDFTrendPageViews.swift
+++ b/LabImporter/Views/Export/PDFTrendPageViews.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import Charts
+
+// The trend-chart pages of the export: one card per selected metric that has at
+// least two readings inside the chosen time window, each with a static chart,
+// reference-range guides, and a min/max/avg/change summary.
+
+struct PDFTrendsPage: View {
+    let metrics: [PDFMetric]
+    let showTitle: Bool
+    let range: PDFTimeRange
+    let patientName: String
+    let theme: PDFTheme
+    let pageNumber: Int
+    let totalPages: Int
+
+    var body: some View {
+        PDFPageScaffold(theme: theme, pageNumber: pageNumber, totalPages: totalPages,
+                        runningTitle: String(localized: "Lab Report"), patientName: patientName) {
+            VStack(alignment: .leading, spacing: 14) {
+                if showTitle {
+                    PDFSectionHeader(title: String(localized: "Trends"),
+                                     subtitle: range.longLabel, theme: theme)
+                }
+                ForEach(metrics) { metric in
+                    PDFTrendCard(metric: metric, theme: theme)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}
+
+struct PDFTrendCard: View {
+    let metric: PDFMetric
+    let theme: PDFTheme
+
+    private var accent: Color { theme.color(for: metric.category) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            chart
+            statsRow
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.cardBackground, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(theme.cardStroke, lineWidth: 0.5))
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Circle().fill(accent).frame(width: 9, height: 9)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(metric.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.textPrimary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(metric.code)
+                    .font(.system(size: 8))
+                    .foregroundStyle(theme.textTertiary)
+                    .textCase(.uppercase)
+            }
+            Spacer(minLength: 8)
+            if let status = metric.latestStatus, status.isOutOfRange {
+                PDFStatusBadge(status: status, theme: theme)
+            }
+            if let latest = metric.latest {
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text(PDFFormat.value(latest.value))
+                        .font(.system(size: 14, weight: .bold).monospacedDigit())
+                        .foregroundStyle(theme.valueColor(for: metric.latestStatus))
+                    if !metric.unit.isEmpty {
+                        Text(metric.unit)
+                            .font(.system(size: 9))
+                            .foregroundStyle(theme.textSecondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var chart: some View {
+        Chart {
+            if let range = metric.referenceRange {
+                if let low = range.low {
+                    RuleMark(y: .value(String(localized: "Low"), low))
+                        .foregroundStyle(theme.statusColor(.low).opacity(0.5))
+                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [4, 3]))
+                }
+                if let high = range.high {
+                    RuleMark(y: .value(String(localized: "High"), high))
+                        .foregroundStyle(theme.statusColor(.high).opacity(0.5))
+                        .lineStyle(StrokeStyle(lineWidth: 0.75, dash: [4, 3]))
+                }
+            }
+            ForEach(metric.windowPoints) { point in
+                // The area fill is colour-mode only — in monochrome it would just
+                // be a gray wash that wastes toner, so the line carries the trend.
+                if theme.isColor {
+                    AreaMark(x: .value(String(localized: "Date"), point.date),
+                             y: .value(metric.unit, point.value))
+                        .foregroundStyle(LinearGradient(colors: [accent.opacity(0.22), accent.opacity(0.03)],
+                                                        startPoint: .top, endPoint: .bottom))
+                }
+                LineMark(x: .value(String(localized: "Date"), point.date),
+                         y: .value(metric.unit, point.value))
+                    .foregroundStyle(accent)
+                    .lineStyle(StrokeStyle(lineWidth: 1.5))
+                PointMark(x: .value(String(localized: "Date"), point.date),
+                          y: .value(metric.unit, point.value))
+                    .foregroundStyle(pointColor(point.value))
+                    .symbolSize(16)
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                AxisGridLine().foregroundStyle(theme.chartGrid)
+                AxisValueLabel(format: .dateTime.month(.abbreviated).year(.twoDigits))
+                    .font(.system(size: 7))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        }
+        .chartYAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                AxisGridLine().foregroundStyle(theme.chartGrid)
+                AxisValueLabel()
+                    .font(.system(size: 7))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        }
+        .frame(height: 118)
+    }
+
+    private func pointColor(_ value: Double) -> Color {
+        if let status = metric.referenceRange?.status(for: value), status.isOutOfRange {
+            return theme.statusColor(status)
+        }
+        return accent
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 0) {
+            stat(String(localized: "Min"), metric.minValue)
+            divider
+            stat(String(localized: "Max"), metric.maxValue)
+            divider
+            stat(String(localized: "Avg"), metric.averageValue)
+            divider
+            changeStat
+        }
+    }
+
+    private var divider: some View {
+        Rectangle().fill(theme.hairline).frame(width: 0.5, height: 22)
+    }
+
+    private func stat(_ label: String, _ value: Double?) -> some View {
+        VStack(spacing: 2) {
+            Text(value.map { PDFFormat.value($0) } ?? "—")
+                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .foregroundStyle(theme.textPrimary)
+            Text(label)
+                .font(.system(size: 8))
+                .foregroundStyle(theme.textTertiary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var changeStat: some View {
+        VStack(spacing: 2) {
+            HStack(spacing: 2) {
+                if let change = metric.change, change != 0 {
+                    Image(systemName: change > 0 ? "arrow.up.right" : "arrow.down.right")
+                        .font(.system(size: 8, weight: .bold))
+                }
+                Text(changeText)
+                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
+            }
+            .foregroundStyle(theme.textPrimary)
+            Text("Change")
+                .font(.system(size: 8))
+                .foregroundStyle(theme.textTertiary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var changeText: String {
+        guard let change = metric.change else { return "—" }
+        let prefix = change > 0 ? "+" : ""
+        return prefix + PDFFormat.value(change)
+    }
+}

--- a/LabImporter/Views/History/HistoryView.swift
+++ b/LabImporter/Views/History/HistoryView.swift
@@ -11,6 +11,7 @@ struct HistoryView: View {
     // Multi-select state: drives the list's checkmarks while editing.
     @State private var editMode: EditMode = .inactive
     @State private var selection: Set<UUID> = []
+    @State private var showExport = false
 
     var body: some View {
         Group {
@@ -31,6 +32,9 @@ struct HistoryView: View {
         .navigationBarBackButtonHidden(editMode.isEditing)
         .toolbar { toolbarContent }
         .onAppear { Task { await loadReports() } }
+        .sheet(isPresented: $showExport) {
+            PDFExportView(reports: reports)
+        }
         .sheet(item: $reportToEdit, onDismiss: { Task { await loadReports() } }, content: { report in
             NavigationStack {
                 ReviewView(
@@ -79,15 +83,22 @@ struct HistoryView: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
+            if !reports.isEmpty && !editMode.isEditing {
+                Button {
+                    showExport = true
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel(Text("Export PDF"))
+            }
+        }
+
+        ToolbarItem(placement: .topBarTrailing) {
             if !reports.isEmpty {
                 Button {
                     withAnimation { toggleEditing() }
                 } label: {
-                    if editMode.isEditing {
-                        Image(systemName: "checkmark")
-                    } else {
-                        Text("Edit")
-                    }
+                    Image(systemName: editMode.isEditing ? "checkmark" : "checklist")
                 }
                 .accessibilityLabel(editMode.isEditing ? Text("Done") : Text("Edit"))
             }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Because the parsing runs on Apple Intelligence, LabImporter needs a compatible d
 - **Customise** — pin metrics to the top, reorder, or hide them from the dashboard
 - **iCloud sync (opt-in)** — optionally roam your dashboard layout (card order, pins, hidden metrics, custom names, and reference ranges) across your devices; your lab values always stay in Apple Health and never sync
 - **Share** — export any report as a CDA file to send to a doctor or another app
-- **13 languages** — fully localized in English, German, Spanish, French, Italian, Japanese, Dutch, Polish, Portuguese (Brazil), Russian, Turkish, Ukrainian, and Simplified Chinese
+- **PDF export** — generate an information-rich PDF report (cover summary, latest-results table, and trend charts), choosing which values and time range to include, in color or black & white
+- **13 languages** — fully localized in 🇬🇧 English · 🇩🇪 German · 🇪🇸 Spanish · 🇫🇷 French · 🇮🇹 Italian · 🇯🇵 Japanese · 🇳🇱 Dutch · 🇵🇱 Polish · 🇧🇷 Portuguese (Brazil) · 🇷🇺 Russian · 🇹🇷 Turkish · 🇺🇦 Ukrainian · 🇨🇳 Simplified Chinese
 - **Privacy-first** — all data lives in Apple Health on your device; no account or server required
 
 ---

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Because the parsing runs on Apple Intelligence, LabImporter needs a compatible d
 - **Customise** — pin metrics to the top, reorder, or hide them from the dashboard
 - **iCloud sync (opt-in)** — optionally roam your dashboard layout (card order, pins, hidden metrics, custom names, and reference ranges) across your devices; your lab values always stay in Apple Health and never sync
 - **Share** — export any report as a CDA file to send to a doctor or another app
-- **PDF export** — generate an information-rich PDF report (cover summary, latest-results table, and trend charts), choosing which values and time range to include, in color or black & white
+- **PDF export** — generate an information-rich PDF report (cover summary, latest-results table, and trend charts), choosing which values and time range to include, in color or black & white, on A4, US Letter, or Legal paper (defaulting to your region's size)
 - **13 languages** — fully localized in 🇬🇧 English · 🇩🇪 German · 🇪🇸 Spanish · 🇫🇷 French · 🇮🇹 Italian · 🇯🇵 Japanese · 🇳🇱 Dutch · 🇵🇱 Polish · 🇧🇷 Portuguese (Brazil) · 🇷🇺 Russian · 🇹🇷 Turkish · 🇺🇦 Ukrainian · 🇨🇳 Simplified Chinese
 - **Privacy-first** — all data lives in Apple Health on your device; no account or server required
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Because the parsing runs on Apple Intelligence, LabImporter needs a compatible d
 - **Customise** — pin metrics to the top, reorder, or hide them from the dashboard
 - **iCloud sync (opt-in)** — optionally roam your dashboard layout (card order, pins, hidden metrics, custom names, and reference ranges) across your devices; your lab values always stay in Apple Health and never sync
 - **Share** — export any report as a CDA file to send to a doctor or another app
+- **13 languages** — fully localized in English, German, Spanish, French, Italian, Japanese, Dutch, Polish, Portuguese (Brazil), Russian, Turkish, Ukrainian, and Simplified Chinese
 - **Privacy-first** — all data lives in Apple Health on your device; no account or server required
 
 ---


### PR DESCRIPTION
## What

Adds a PDF export for saved lab reports, reachable from a share button in the **Reports** screen toolbar. A configuration sheet lets the user choose:

- **Which values** to include (checklist, defaults to all, with Select/Deselect All; ordered like the dashboard)
- **Trend time range** — 3M / 6M / 1Y / 2Y / All
- **Sections** — summary page, latest-results table, trend charts (toggle independently)
- **Color or Black & White** treatment
- **Page size** — A4 / US Letter / Legal, defaulting to the device region's paper size

## The PDF

1. **Cover page** — banner (colour derived from the report's dominant LOINC value categories), patient details (name, DOB + age, sex, lab, period covered — from HealthKit characteristics + reports), headline stats (reports, metrics, out-of-range count, trend range), category legend, and a medical disclaimer.
2. **Latest results** — most recent reading per value, grouped by clinical category, with reference range, out-of-range badge, and date. Paginates automatically.
3. **Trends** — one chart per value with ≥2 readings in the window (reusing the app's Swift Charts styling + reference-range guides), plus min / max / avg / change stats.

Each page has a running header and "Page x of y" footer.

## How

- Renders via `ImageRenderer` → `CGPDFContext`, one print-styled SwiftUI page per page (solid fills only, since `ImageRenderer` doesn't reproduce materials/glass).
- Mirrors the existing `CDAExportService` pattern: stateless service, temp-file URL, `UIActivityViewController` share sheet.
- Page geometry and pagination are parameterised by the chosen format — capacity (rows/charts per page) is derived from page height, sized for the worst case (two-line value name / full chart card) so content never clips. Legal fits more per page, US Letter slightly fewer.
- New files: `Models/PDFExportOptions.swift`, `Services/PDFExportService.swift`, and `Views/Export/` (`PDFExportView`, `PDFReportComposer`, `PDFReportPageViews`, `PDFTrendPageViews`); all registered in the project.

## Notable details

- **Black & White mode drops all ink-heavy fills** (gradient banner, card/zebra backgrounds, chart area fills, badge/legend fills), keeping only hairline borders — to save toner.
- **Long LOINC names** wrap to two lines in the table and chart headers; pagination accounts for this so names never clip.
- **Page-size default from region** — `Locale.current.region` picks US Letter for Letter-paper regions (US, Canada, Mexico, …), A4 elsewhere; user can override.
- Header gradient reflects the actual value categories in the report.
- Toolbar uses the native `Button(role: .close)` and a checkmark confirm icon; the Reports Edit button is now a pictogram.
- **Fully localized into all 13 shipped languages** (not EN/DE only). The cover disclaimer uses each locale's on-device Health app name (Apple Salud / Apple Santé / Appleヘルスケア / …). Paper-size names (A4 / US Letter / Legal) are shown verbatim.
- CLAUDE.md and README updated: documented the always-translate-all-languages rule and the supported-languages list, and added the PDF export feature with page-size options.

## Testing

- `xcodebuild` (iOS Simulator) build succeeds.
- `swiftlint lint --strict` passes project-wide.
- Note: on-device parsing needs Apple Intelligence hardware, so the rendered PDF output is best eyeballed on a real device.