### PR TITLE
OCR: recognize app's current language instead of fixed de/en

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,10 @@ Config.xcconfig  # BUNDLE_IDENTIFIER = dev.idoodler.$(DEVELOPMENT_TEAM).labimpor
   itself uses a bare "Health" (e.g. the `Save Reports to Health` toggle), mirror
   that and use the bare localized name without the prefix. `Health Records`
   (`Gesundheitsakte`, …) is a *different* Apple feature — leave it alone.
-- OCR recognizes German + English (`["de-DE", "en-US"]`); narrative CDA labels are German.
+- OCR recognizes the app's current language plus English —
+  `OCRService.recognitionLanguages(for:)` uses `Bundle.main.preferredLocalizations`
+  first, then English, filtered to Vision's `supportedRecognitionLanguages()`.
+  Narrative CDA labels are German.
 - Preferences (`labDisplayPrefs`, `patientName`, `hasSeenWelcome`, etc.) are read
   via `@AppStorage`. `LabDisplayPreferences` is `RawRepresentable` over JSON — note
   the deliberate separate `Payload` type to avoid the Codable+RawRepresentable

--- a/LabImporter/Services/OCRService.swift
+++ b/LabImporter/Services/OCRService.swift
@@ -84,7 +84,7 @@ actor OCRService {
             }
 
             request.recognitionLevel = .accurate
-            request.recognitionLanguages = ["de-DE", "en-US"]
+            request.recognitionLanguages = Self.recognitionLanguages(for: request)
             request.usesLanguageCorrection = true
             request.minimumTextHeight = 0.01
 
@@ -95,6 +95,34 @@ actor OCRService {
                 continuation.resume(throwing: error)
             }
         }
+    }
+
+    /// Recognition languages to hand to Vision: the app's current UI language
+    /// first (reports are typically in the language the user runs the app in),
+    /// with English kept as a fallback for Latin-script text. Filtered to the
+    /// codes the current Vision revision can actually recognize so we never pass
+    /// an unsupported code; falls back to English if Vision reports nothing.
+    private static func recognitionLanguages(for request: VNRecognizeTextRequest) -> [String] {
+        let supported = (try? request.supportedRecognitionLanguages()) ?? []
+        guard !supported.isEmpty else { return ["en-US"] }
+
+        // The app's effective language (its preferred localization), then English.
+        let desired = (Bundle.main.preferredLocalizations + ["en"])
+        var ordered: [String] = []
+
+        for identifier in desired {
+            let base = Locale(identifier: identifier).language.languageCode?.identifier
+            // Prefer an exact code, then a script/region-qualified match, then
+            // any code sharing the same base language (e.g. "de" → "de-DE").
+            let match = supported.first { $0.caseInsensitiveCompare(identifier) == .orderedSame }
+                ?? supported.first { $0.hasPrefix(identifier) }
+                ?? supported.first { Locale(identifier: $0).language.languageCode?.identifier == base }
+            if let match, !ordered.contains(match) {
+                ordered.append(match)
+            }
+        }
+
+        return ordered.isEmpty ? supported : ordered
     }
 
     private func render(page: PDFPage) -> UIImage? {

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ After the first manual run succeeds, builds are triggered automatically on the *
 |---|---|
 | Document input | `VisionKit` document scanner (multi-page), `UIDocumentPicker` for PDFs / images, Clipboard, or files opened from other apps (`CFBundleDocumentTypes` + `onOpenURL`) |
 | PDF rendering | `PDFKit` — extracts embedded text or renders pages for OCR |
-| Text extraction | `Vision` — `VNRecognizeTextRequest` (German + English) |
+| Text extraction | `Vision` — `VNRecognizeTextRequest` (app's current language + English fallback) |
 | Lab value parsing | `FoundationModels` — `@Generable` structured output via `LanguageModelSession` |
 | Health import | `HealthKit` — `HKCDADocumentSample` (CDA R2 clinical document) |
 


### PR DESCRIPTION
## What

OCR text recognition was pinned to `["de-DE", "en-US"]`. This replaces that hard-coded pair with `OCRService.recognitionLanguages(for:)`, which derives the recognition languages from the **app's current UI language** (`Bundle.main.preferredLocalizations`) plus an English fallback.

## How

- Builds a desired list: the app's effective localization first, then English.
- Matches each desired language to a Vision code (exact → prefix → same base language, e.g. `de` → `de-DE`), de-duped.
- Filters against `request.supportedRecognitionLanguages()` so an unsupported code is never passed; falls back to the full supported set / `en-US` if Vision reports nothing.

So the app running in French OCRs French + English, in German German + English, etc.

## Notes

- Docs updated to match (`README.md`, `CLAUDE.md`).
- No tests exist in the project; verify by building in Xcode on a supported device and running the import flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)