### PR TITLE
Fix history toolbar buttons briefly disappearing on navigation

### DIFF
--- a/LabImporter/Views/Dashboard/DashboardView.swift
+++ b/LabImporter/Views/Dashboard/DashboardView.swift
@@ -50,7 +50,7 @@ struct DashboardView: View {
         .toolbar {
             if showsLibraryToolbarItems {
                 ToolbarItem(placement: .topBarLeading) {
-                    NavigationLink(destination: HistoryView()) {
+                    NavigationLink(destination: HistoryView(initialReports: reports)) {
                         Image(systemName: "doc.text")
                     }
                     .accessibilityLabel("Reports")
@@ -71,7 +71,7 @@ struct DashboardView: View {
             SettingsView(prefs: $prefs, allCodes: allCodeNames)
         }
         .sheet(isPresented: $showHistorySheet) {
-            NavigationStack { HistoryView() }
+            NavigationStack { HistoryView(initialReports: reports) }
         }
         .sheet(item: $trendSheet) { sheet in
             NavigationStack {

--- a/LabImporter/Views/History/HistoryView.swift
+++ b/LabImporter/Views/History/HistoryView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HistoryView: View {
-    @State private var reports: [LabReport] = []
+    @State private var reports: [LabReport]
     @State private var loadError: String?
     @State private var deleteError: String?
     @State private var reportToEdit: LabReport?
@@ -12,6 +12,16 @@ struct HistoryView: View {
     @State private var editMode: EditMode = .inactive
     @State private var selection: Set<UUID> = []
     @State private var showExport = false
+
+    /// Seeds the list with the reports the parent already has in memory so the
+    /// toolbar (Export / Edit) and content render populated on the very first
+    /// frame of the push. `loadReports()` still refreshes from Apple Health in
+    /// `.onAppear`; without this seed the view would mount empty and the
+    /// trailing toolbar buttons would briefly vanish until that async load
+    /// resolved.
+    init(initialReports: [LabReport] = []) {
+        _reports = State(initialValue: initialReports)
+    }
 
     var body: some View {
         Group {

--- a/LabImporter/Views/Home/HomeView.swift
+++ b/LabImporter/Views/Home/HomeView.swift
@@ -234,7 +234,7 @@ struct HomeView: View {
             }
         case .reports:
             NavigationStack {
-                HistoryView()
+                HistoryView(initialReports: reports)
             }
         case .settings:
             SettingsView(prefs: $prefs, allCodes: allCodeNames, isModal: false)


### PR DESCRIPTION
HistoryView mounted with an empty reports array and only populated it
asynchronously in .onAppear, so the trailing toolbar buttons (Export /
Edit) — gated behind !reports.isEmpty — were absent for a frame or two
after the push until the Apple Health load resolved.

Seed the view with the reports the parent already holds in memory via a
new initialReports init parameter so the toolbar and list render
populated on the first frame. loadReports() still refreshes from Apple
Health on appear, so the data stays current.