### PR TITLE
Fix trend scrub callout: track the finger on all time ranges, Health-style readout

### DIFF
--- a/LabImporter/Views/Dashboard/TrendsView.swift
+++ b/LabImporter/Views/Dashboard/TrendsView.swift
@@ -271,6 +271,15 @@ extension TrendsView {
                 RuleMark(x: .value(String(localized: "Date"), selected.date))
                     .foregroundStyle(.secondary.opacity(0.5))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                    // The callout must be an annotation, not a chartOverlay: with a
+                    // scrolled finite window the proxy's position(forX:) is offset by
+                    // the scroll amount, so an overlay drifts away from the finger.
+                    // `.fit(to: .plot)` keeps it inside the visible plot at the edges
+                    // without padding the scale (which would resize the graph).
+                    .annotation(position: .top, spacing: 0,
+                                overflowResolution: .init(x: .fit(to: .plot), y: .fit(to: .plot))) {
+                        scrubCallout(selected)
+                    }
 
                 PointMark(
                     x: .value(String(localized: "Date"), selected.date),
@@ -290,20 +299,6 @@ extension TrendsView {
         .chartXVisibleDomain(length: visibleDomainSeconds)
         .chartScrollPosition(x: $scrollPositionX)
         .chartXSelection(value: $selectedDate)
-        .chartOverlay { proxy in
-            GeometryReader { geo in
-                if let selected = selectedDataPoint,
-                   let plotFrame = proxy.plotFrame.map({ geo[$0] }),
-                   let xPos = proxy.position(forX: selected.date) {
-                    scrubCallout(selected)
-                        .position(
-                            x: clampedX(xPos, in: plotFrame),
-                            y: plotFrame.minY + 22
-                        )
-                        .allowsHitTesting(false)
-                }
-            }
-        }
         .onChange(of: selectedDataPoint?.date) { _, newDate in
             if newDate != nil { selectionFeedback.selectionChanged() }
         }
@@ -413,11 +408,6 @@ extension TrendsView {
         } else {
             scrollPositionX = last.addingTimeInterval(-visibleDomainSeconds * 0.95)
         }
-    }
-
-    private func clampedX(_ xPos: CGFloat, in frame: CGRect) -> CGFloat {
-        let halfBubble: CGFloat = 60
-        return min(max(xPos, frame.minX + halfBubble), frame.maxX - halfBubble)
     }
 
     private func formatValue(_ value: Double) -> String {

--- a/LabImporter/Views/Dashboard/TrendsView.swift
+++ b/LabImporter/Views/Dashboard/TrendsView.swift
@@ -344,7 +344,10 @@ extension TrendsView {
         .fixedSize()
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
-        .glassEffect(.regular, in: Capsule())
+        // Not .glassEffect: the scrollable plot renders annotations into its own
+        // layer, so glass has no backdrop to sample and turns dark. A material
+        // resolves correctly there.
+        .background(.regularMaterial, in: Capsule())
         .overlay(
             Capsule()
                 .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)

--- a/LabImporter/Views/Dashboard/TrendsView.swift
+++ b/LabImporter/Views/Dashboard/TrendsView.swift
@@ -233,6 +233,45 @@ struct TrendsView: View {
 
 extension TrendsView {
     private var trendChart: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            chartHeader
+            chartBody
+        }
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+        )
+    }
+
+    /// Fixed readout above the plot, Apple-Health style: while scrubbing it
+    /// shows the value under the finger, otherwise the latest reading. Living
+    /// outside the scrollable plot, it needs no scroll-offset math and no
+    /// edge clamping, and never covers the data under the finger.
+    @ViewBuilder
+    private var chartHeader: some View {
+        if let point = selectedDataPoint ?? dataPoints.last {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(point.date.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(formatValue(point.value))
+                        .font(.title2.weight(.semibold))
+                        .contentTransition(.numericText())
+                    if !point.unit.isEmpty {
+                        Text(point.unit)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .animation(.snappy(duration: 0.2), value: point.date)
+        }
+    }
+
+    private var chartBody: some View {
         Chart {
             if let range = referenceRange {
                 if let low = range.low {
@@ -271,15 +310,6 @@ extension TrendsView {
                 RuleMark(x: .value(String(localized: "Date"), selected.date))
                     .foregroundStyle(.secondary.opacity(0.5))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
-                    // The callout must be an annotation, not a chartOverlay: with a
-                    // scrolled finite window the proxy's position(forX:) is offset by
-                    // the scroll amount, so an overlay drifts away from the finger.
-                    // `.fit(to: .plot)` keeps it inside the visible plot at the edges
-                    // without padding the scale (which would resize the graph).
-                    .annotation(position: .top, spacing: 0,
-                                overflowResolution: .init(x: .fit(to: .plot), y: .fit(to: .plot))) {
-                        scrubCallout(selected)
-                    }
 
                 PointMark(
                     x: .value(String(localized: "Date"), selected.date),
@@ -316,43 +346,6 @@ extension TrendsView {
             }
         }
         .frame(minHeight: 260)
-        .padding()
-        .overlay(alignment: .topLeading) { unitBadge }
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
-        .overlay(
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-        )
-    }
-
-    private func scrubCallout(_ point: DataPoint) -> some View {
-        VStack(alignment: .center, spacing: 1) {
-            Text(point.date.formatted(date: .abbreviated, time: .omitted))
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-            HStack(alignment: .firstTextBaseline, spacing: 3) {
-                Text(formatValue(point.value))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
-                if !point.unit.isEmpty {
-                    Text(point.unit)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        .fixedSize()
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        // Not .glassEffect: the scrollable plot renders annotations into its own
-        // layer, so glass has no backdrop to sample and turns dark. A material
-        // resolves correctly there.
-        .background(.regularMaterial, in: Capsule())
-        .overlay(
-            Capsule()
-                .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
-        )
-        .shadow(color: Color.black.opacity(0.2), radius: 8, x: 0, y: 3)
     }
 
     private var selectedPointBubble: some View {
@@ -373,18 +366,6 @@ extension TrendsView {
 // MARK: - Helpers
 
 extension TrendsView {
-    /// Static unit caption pinned to the card (`chartYAxisLabel` rides the scrollable plot).
-    @ViewBuilder
-    var unitBadge: some View {
-        if !currentUnit.isEmpty {
-            Text(currentUnit)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(valueColor.opacity(0.8))
-                .padding(EdgeInsets(top: 8, leading: 12, bottom: 0, trailing: 0))
-                .allowsHitTesting(false)
-        }
-    }
-
     var windowPicker: some View {
         Picker("Time Range", selection: $window) {
             ForEach(TrendWindow.allCases) { option in


### PR DESCRIPTION
## Problem

In `TrendsView`, the value bubble while scrubbing the trend chart didn't stay attached to the finger on any time range other than **All**. The callout was positioned via `chartOverlay` using `ChartProxy.position(forX:)`, which returns a coordinate in the full scrollable chart content rather than the visible window — on All the content exactly fits the visible domain (zero scroll offset), so it happened to line up, but on 3M/6M/1Y the chart is scrolled and the callout drifted by the scroll offset.

## Fix

Replaced the floating callout pill with a fixed, Apple-Health-style readout at the top of the chart card:

- **Idle:** shows the latest reading (date + value + unit).
- **Scrubbing:** swaps to the point under the finger, with a `numericText` content transition. The dashed rule mark and glowing point still track the selection inside the plot.

Because the readout lives outside the scrollable plot, it needs no scroll-offset math or edge clamping, never covers the data under the finger, and avoids the dark-glass artifact (Liquid Glass has no backdrop to sample when rendered inside the scrollable plot's layer — an intermediate annotation-based approach surfaced this).

Also removed the now-redundant standalone unit badge, since the readout always shows the unit. No new localizable strings were needed (date/number/unit only).

## Testing

- `swiftlint lint --strict` passes.
- Please verify on device: scrub in 3M/6M/1Y (including after scrolling back in time) and confirm the readout tracks the selection and animates back to the latest value on release.

https://claude.ai/code/session_015BvFgG7sB6a4tKfrmUgLaV

---
_Generated by [Claude Code](https://claude.ai/code/session_015BvFgG7sB6a4tKfrmUgLaV)_