### PR TITLE
Feature a hero card when the dashboard has only one tracked value

### DIFF
--- a/LabImporter.xcodeproj/project.pbxproj
+++ b/LabImporter.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		AABB000000000000000066AA /* ReportDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000067AA /* ReportDetailView.swift */; };
 		AABB000000000000000068AA /* TrendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000069AA /* TrendsView.swift */; };
 		AABB000000000000000070AA /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000071AA /* DashboardView.swift */; };
+		AABB0000000000000000CB01 /* CategoryBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000CB02 /* CategoryBackground.swift */; };
+		AABB0000000000000000HM01 /* HeroMetricCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0000000000000000HM02 /* HeroMetricCard.swift */; };
 		AABB000000000000000072AA /* ImportLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000073AA /* ImportLandingView.swift */; };
 		AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000075AA /* LabDisplayPreferences.swift */; };
 		AABB000000000000000077AA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AABB000000000000000076AA /* Localizable.xcstrings */; };
@@ -142,6 +144,8 @@
 		AABB0000000000000000C1DE /* CodePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePickerSheet.swift; sourceTree = "<group>"; };
 		AABB0000000000000000C3DE /* UnsupportedDeviceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedDeviceView.swift; sourceTree = "<group>"; };
 		AABB0000000000000000CC02 /* MetricCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricCard.swift; sourceTree = "<group>"; };
+		AABB0000000000000000CB02 /* CategoryBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryBackground.swift; sourceTree = "<group>"; };
+		AABB0000000000000000HM02 /* HeroMetricCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroMetricCard.swift; sourceTree = "<group>"; };
 		AABB0000000000000000D0AA /* CloudSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncService.swift; sourceTree = "<group>"; };
 		AASP000000000000000002AA /* SpotlightIndexService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightIndexService.swift; sourceTree = "<group>"; };
 		AASP000000000000000004AA /* SpotlightOptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightOptInView.swift; sourceTree = "<group>"; };
@@ -328,6 +332,8 @@
 			children = (
 				AABB000000000000000071AA /* DashboardView.swift */,
 				AABB0000000000000000CC02 /* MetricCard.swift */,
+				AABB0000000000000000CB02 /* CategoryBackground.swift */,
+				AABB0000000000000000HM02 /* HeroMetricCard.swift */,
 				AAFF0000000000000000F401 /* ValueDescriptionCard.swift */,
 				AAFF0000000000000000F501 /* TrendWindow.swift */,
 				AABB000000000000000069AA /* TrendsView.swift */,
@@ -619,6 +625,8 @@
 				AABB000000000000000068AA /* TrendsView.swift in Sources */,
 				AABB000000000000000070AA /* DashboardView.swift in Sources */,
 				AABB0000000000000000CC01 /* MetricCard.swift in Sources */,
+				AABB0000000000000000CB01 /* CategoryBackground.swift in Sources */,
+				AABB0000000000000000HM01 /* HeroMetricCard.swift in Sources */,
 				AABB000000000000000072AA /* ImportLandingView.swift in Sources */,
 				AABB0000000000000000C0AA /* MorphingCategoryBackground.swift in Sources */,
 				AABB000000000000000074AA /* LabDisplayPreferences.swift in Sources */,

--- a/LabImporter/Localizable.xcstrings
+++ b/LabImporter/Localizable.xcstrings
@@ -21919,6 +21919,154 @@
         }
       }
     },
+    "Last measured %@" : {
+      "localizations" : {
+        "bg" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последно измерено %@"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últim mesurament %@"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naposledy naměřeno %@"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sidst målt %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zuletzt gemessen %@"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Τελευταία μέτρηση %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última medición %@"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viimeksi mitattu %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernière mesure le %@"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zadnje mjerenje %@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utolsó mérés: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima misurazione il %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終測定日: %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laatst gemeten op %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ostatni pomiar %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última medição em %@"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última medição a %@"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima măsurătoare %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее измерение %@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naposledy namerané %@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senast uppmätt %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Son ölçüm: %@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останнє вимірювання %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近测量时间：%@"
+          }
+        }
+      }
+    },
     "Last updated %@" : {
       "localizations" : {
         "bg" : {
@@ -45020,6 +45168,154 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你可以稍后在“设置”中开启或关闭 iCloud 同步。"
+          }
+        }
+      }
+    },
+    "Your only tracked value" : {
+      "localizations" : {
+        "bg" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Единствената проследявана стойност"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El teu únic valor seguit"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaše jediná sledovaná hodnota"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din eneste sporede værdi"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein einziger erfasster Wert"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η μοναδική σας παρακολουθούμενη τιμή"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu único valor registrado"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainoa seuraamasi arvo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre seule valeur suivie"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaša jedina praćena vrijednost"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Az egyetlen nyomon követett érték"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il tuo unico valore monitorato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在記録している唯一の項目"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je enige bijgehouden waarde"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twoja jedyna śledzona wartość"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu único valor acompanhado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O seu único valor monitorizado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Singura ta valoare monitorizată"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Единственный отслеживаемый показатель"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaša jediná sledovaná hodnota"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ditt enda spårade värde"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Takip ettiğiniz tek değer"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Єдиний показник, який ви відстежуєте"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您唯一记录的数值"
           }
         }
       }

--- a/LabImporter/Views/Dashboard/CategoryBackground.swift
+++ b/LabImporter/Views/Dashboard/CategoryBackground.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+// MARK: - CategoryBackground
+
+/// A soft, low-opacity wash of the dashboard's metric category colors — a subtle
+/// tint behind the content in the spirit of the Health app. Falls back to a
+/// gentle accent tint when there are no metrics yet.
+struct CategoryBackground: View {
+    let colors: [Color]
+
+    private let anchors: [UnitPoint] = [.topLeading, .topTrailing, .bottomLeading]
+
+    var body: some View {
+        ZStack {
+            ForEach(Array(palette.enumerated()), id: \.offset) { index, color in
+                RadialGradient(
+                    colors: [color.opacity(0.16), .clear],
+                    center: anchors[index % anchors.count],
+                    startRadius: 0,
+                    endRadius: 480
+                )
+            }
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+    }
+
+    private var palette: [Color] {
+        colors.isEmpty ? [Color.accentColor.opacity(0.6)] : colors
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Multiple Categories") {
+    CategoryBackground(colors: [LabCategory.glycemic.color, LabCategory.lipids.color, LabCategory.renal.color])
+}
+
+#Preview("Fallback") {
+    CategoryBackground(colors: [])
+}
+
+#Preview("Dark") {
+    CategoryBackground(colors: [LabCategory.glycemic.color, LabCategory.lipids.color, LabCategory.renal.color])
+        .preferredColorScheme(.dark)
+}
+#endif

--- a/LabImporter/Views/Dashboard/DashboardView.swift
+++ b/LabImporter/Views/Dashboard/DashboardView.swift
@@ -34,9 +34,13 @@ struct DashboardView: View {
         ScrollView {
             VStack(spacing: 20) {
                 greeting
-                metricSections
-                if showsFewValuesHint {
-                    fewValuesHint
+                if let onlyMetric = soleMetric {
+                    heroCard(for: onlyMetric)
+                } else {
+                    metricSections
+                    if showsFewValuesHint {
+                        fewValuesHint
+                    }
                 }
                 footer
             }
@@ -198,13 +202,30 @@ struct DashboardView: View {
         }
     }
 
+    // MARK: - Hero card
+
+    /// The dashboard's single metric, when that's all the user has. Rather than
+    /// stranding one small grid card above a generic "import more" filler, the
+    /// dashboard leads with a large featured card for that value instead.
+    private var soleMetric: MetricData? {
+        sortedMetrics.count == 1 ? sortedMetrics.first : nil
+    }
+
+    private func heroCard(for metric: MetricData) -> some View {
+        HeroMetricCard(
+            metric: metric,
+            onSelectTrend: { trendSheet = TrendSheet(code: metric.entry.code) },
+            importMenu: { importMenuItems }
+        )
+    }
+
     // MARK: - Few-values hint
 
-    /// With only one or two metrics there are no sparklines yet and the grid
-    /// leaves the screen mostly empty, so a gentle card explains why and offers a
-    /// one-tap path to import another report and start building trends.
+    /// A single metric gets the dedicated `heroCard` treatment instead (see
+    /// `soleMetric`), so this hint only fires for exactly two metrics: still too
+    /// few for a balanced grid, but past the point of featuring just one.
     private var showsFewValuesHint: Bool {
-        (1...2).contains(sortedMetrics.count)
+        sortedMetrics.count == 2
     }
 
     private var fewValuesHint: some View {
@@ -334,30 +355,6 @@ struct DashboardView: View {
         return result
     }
 
-    // MARK: - Code names for order sheet
-
-    private var allCodeNames: [CodeName] {
-        var seen = Set<String>()
-        var result: [CodeName] = []
-        for report in reports {
-            for entry in report.entries where seen.insert(entry.code).inserted {
-                result.append(CodeName(code: entry.code, name: entry.resolvedName))
-            }
-        }
-        return result
-    }
-
-    // MARK: - Pin helpers
-
-    private func togglePin(_ code: String) {
-        var updated = prefs
-        if updated.pinnedCodes.contains(code) {
-            updated.pinnedCodes.removeAll { $0 == code }
-        } else {
-            updated.pinnedCodes.append(code)
-        }
-        prefs = updated
-    }
 }
 
 // MARK: - Greeting
@@ -389,33 +386,28 @@ private extension DashboardView {
     }
 }
 
-// MARK: - CategoryBackground
+// MARK: - Code names & pin helpers
 
-/// A soft, low-opacity wash of the dashboard's metric category colors — a subtle
-/// tint behind the content in the spirit of the Health app. Falls back to a
-/// gentle accent tint when there are no metrics yet.
-struct CategoryBackground: View {
-    let colors: [Color]
-
-    private let anchors: [UnitPoint] = [.topLeading, .topTrailing, .bottomLeading]
-
-    var body: some View {
-        ZStack {
-            ForEach(Array(palette.enumerated()), id: \.offset) { index, color in
-                RadialGradient(
-                    colors: [color.opacity(0.16), .clear],
-                    center: anchors[index % anchors.count],
-                    startRadius: 0,
-                    endRadius: 480
-                )
+private extension DashboardView {
+    var allCodeNames: [CodeName] {
+        var seen = Set<String>()
+        var result: [CodeName] = []
+        for report in reports {
+            for entry in report.entries where seen.insert(entry.code).inserted {
+                result.append(CodeName(code: entry.code, name: entry.resolvedName))
             }
         }
-        .ignoresSafeArea()
-        .allowsHitTesting(false)
+        return result
     }
 
-    private var palette: [Color] {
-        colors.isEmpty ? [Color.accentColor.opacity(0.6)] : colors
+    func togglePin(_ code: String) {
+        var updated = prefs
+        if updated.pinnedCodes.contains(code) {
+            updated.pinnedCodes.removeAll { $0 == code }
+        } else {
+            updated.pinnedCodes.append(code)
+        }
+        prefs = updated
     }
 }
 
@@ -438,16 +430,31 @@ struct CategoryBackground: View {
 #Preview("Few values") {
     NavigationStack {
         DashboardView(
-            reports: [LabReport(
-                id: UUID(),
-                date: Date(timeIntervalSince1970: 1_780_000_000),
-                patientName: "Max Mustermann",
-                authorName: "Laborzentrum München",
-                entries: [
-                    LabReport.Entry(id: UUID(), code: "4548-4", name: "HbA1c",
-                                    displayValue: "5.4", numericValue: 5.4, unit: "%")
-                ]
-            )],
+            reports: [.pairValueReport],
+            onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
+            scannerAvailable: true,
+            clipboardAvailable: false,
+            isProcessing: false
+        )
+    }
+}
+
+#Preview("Single Value") {
+    NavigationStack {
+        DashboardView(
+            reports: [.soleValueReport()],
+            onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
+            scannerAvailable: true,
+            clipboardAvailable: false,
+            isProcessing: false
+        )
+    }
+}
+
+#Preview("Single Value · Trend") {
+    NavigationStack {
+        DashboardView(
+            reports: .soleValueTrend,
             onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
             scannerAvailable: true,
             clipboardAvailable: false,

--- a/LabImporter/Views/Dashboard/DashboardView.swift
+++ b/LabImporter/Views/Dashboard/DashboardView.swift
@@ -454,7 +454,7 @@ private extension DashboardView {
 #Preview("Single Value · Trend") {
     NavigationStack {
         DashboardView(
-            reports: .soleValueTrend,
+            reports: LabReport.soleValueTrend,
             onScan: {}, onPickFile: {}, onPaste: {}, onManual: {},
             scannerAvailable: true,
             clipboardAvailable: false,

--- a/LabImporter/Views/Dashboard/HeroMetricCard.swift
+++ b/LabImporter/Views/Dashboard/HeroMetricCard.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+// MARK: - HeroMetricCard
+
+/// A large, featured presentation for a metric used when it's the *only* value
+/// on the dashboard — see `DashboardView.soleMetric`. In that state a small grid
+/// card plus a generic "import more" filler leaves the screen sparse and buries
+/// the one thing the user actually has, so this leads with it instead: a bigger
+/// number, the category icon, and (once there's a second reading) a taller
+/// sparkline. With just one reading there's no trend to draw yet, so the card
+/// explains that and offers the same import entry points inline.
+struct HeroMetricCard<ImportMenu: View>: View {
+    let metric: MetricData
+    /// Invoked when the card is tapped to open the full trend sheet. Only wired
+    /// up while there's a trend to show (`history.count > 1`) — with a single
+    /// reading the card isn't a button, so its "Import Report" menu isn't
+    /// nested inside another tappable control.
+    let onSelectTrend: () -> Void
+    @ViewBuilder let importMenu: () -> ImportMenu
+
+    private var hasTrend: Bool { metric.history.count > 1 }
+
+    private var category: LabCategory { LabCategory.forCode(metric.entry.code) }
+
+    private var referenceRange: ReferenceRange? {
+        LabMapping.referenceRange(for: metric.entry.code)
+    }
+
+    private var rangeStatus: RangeStatus? {
+        LabMapping.rangeStatus(for: metric.entry.numericValue, code: metric.entry.code)
+    }
+
+    private var valueForeground: Color {
+        guard let rangeStatus, rangeStatus.isOutOfRange else { return .primary }
+        return rangeStatus.color
+    }
+
+    var body: some View {
+        if hasTrend {
+            Button(action: onSelectTrend) { card }
+                .buttonStyle(.plain)
+        } else {
+            card
+        }
+    }
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            valueRow
+            if hasTrend {
+                MetricSparklineChart(history: metric.history, categoryColor: category.color, referenceRange: referenceRange)
+                    .frame(height: 130)
+            }
+            if let date = metric.history.last?.date {
+                Text("Last measured \(date.formatted(date: .abbreviated, time: .omitted))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if !hasTrend {
+                importPrompt
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 24))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: category.icon)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 40, height: 40)
+                .background(category.color.gradient, in: Circle())
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(metric.entry.resolvedName)
+                    .font(.headline)
+                Text("Your only tracked value")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var valueRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(metric.entry.displayValue)
+                .font(.system(size: 44, weight: .bold))
+                .foregroundStyle(valueForeground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            if !metric.entry.unit.isEmpty {
+                Text(metric.entry.unit)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            if let rangeStatus {
+                RangeStatusBadge(status: rangeStatus, range: referenceRange, unit: metric.entry.unit)
+            }
+        }
+    }
+
+    private var importPrompt: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Divider()
+            Text("Import at least two reports containing this value to see a trend.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Menu {
+                importMenu()
+            } label: {
+                Label("Import Report", systemImage: "plus")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private let sampleNoTrend = MetricData(
+    entry: LabReport.soleValueReport().entries[0],
+    history: [SparkPoint(date: .now, value: 5.4)]
+)
+
+private let sampleWithTrend = MetricData(
+    entry: LabReport.soleValueReport().entries[0],
+    history: LabReport.soleValueTrend.map { report in
+        SparkPoint(date: report.date, value: report.entries[0].numericValue ?? 0)
+    }
+)
+
+@ViewBuilder
+private var sampleImportMenu: some View {
+    Button("Scan Document") {}
+    Button("Choose File") {}
+    Button("Paste from Clipboard") {}
+    Button("Create Report Manually") {}
+}
+
+#Preview("No Trend") {
+    HeroMetricCard(metric: sampleNoTrend, onSelectTrend: {}, importMenu: { sampleImportMenu })
+        .padding()
+}
+
+#Preview("With Trend") {
+    HeroMetricCard(metric: sampleWithTrend, onSelectTrend: {}, importMenu: { sampleImportMenu })
+        .padding()
+}
+
+#Preview("Dark") {
+    HeroMetricCard(metric: sampleWithTrend, onSelectTrend: {}, importMenu: { sampleImportMenu })
+        .padding()
+        .preferredColorScheme(.dark)
+}
+#endif

--- a/LabImporter/Views/Dashboard/HeroMetricCard.swift
+++ b/LabImporter/Views/Dashboard/HeroMetricCard.swift
@@ -20,6 +20,8 @@ struct HeroMetricCard<ImportMenu: View>: View {
 
     private var hasTrend: Bool { metric.history.count > 1 }
 
+    private var trend: MetricTrend? { MetricTrend(history: metric.history) }
+
     private var category: LabCategory { LabCategory.forCode(metric.entry.code) }
 
     private var referenceRange: ReferenceRange? {
@@ -72,12 +74,7 @@ struct HeroMetricCard<ImportMenu: View>: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            Image(systemName: category.icon)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 40, height: 40)
-                .background(category.color.gradient, in: Circle())
-                .accessibilityHidden(true)
+            dockIcon
             VStack(alignment: .leading, spacing: 1) {
                 Text(metric.entry.resolvedName)
                     .font(.headline)
@@ -87,6 +84,29 @@ struct HeroMetricCard<ImportMenu: View>: View {
             }
             Spacer(minLength: 0)
         }
+    }
+
+    /// The category-colored circle at the card's top-left. Once there's a
+    /// trend to show, it doubles as the trend indicator (a directional arrow,
+    /// matching the grid's `MetricCard` dock); with a single reading there's
+    /// no direction yet, so it falls back to the category icon.
+    @ViewBuilder
+    private var dockIcon: some View {
+        if let trend {
+            dockCircle(systemName: trend.symbol, weight: .heavy)
+                .accessibilityLabel(trend.accessibilityLabel)
+        } else {
+            dockCircle(systemName: category.icon, weight: .semibold)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func dockCircle(systemName: String, weight: Font.Weight) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 17, weight: weight))
+            .foregroundStyle(.white)
+            .frame(width: 40, height: 40)
+            .background(category.color.gradient, in: Circle())
     }
 
     private var valueRow: some View {

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -25,9 +25,13 @@ enum MetricTrend {
         guard history.count > 1 else { return nil }
         let latest = history[history.count - 1].value
         let previous = history[history.count - 2].value
-        if latest > previous { self = .rising }
-        else if latest < previous { self = .falling }
-        else { self = .steady }
+        if latest > previous {
+            self = .rising
+        } else if latest < previous {
+            self = .falling
+        } else {
+            self = .steady
+        }
     }
 
     var symbol: String {

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -15,6 +15,38 @@ struct MetricData: Identifiable {
     let history: [SparkPoint]
 }
 
+/// Direction of a metric's latest reading relative to the previous one, shared
+/// by the grid's `MetricCard` and the single-metric `HeroMetricCard`. `nil`
+/// when there's no prior value to compare against.
+enum MetricTrend {
+    case rising, falling, steady
+
+    init?(history: [SparkPoint]) {
+        guard history.count > 1 else { return nil }
+        let latest = history[history.count - 1].value
+        let previous = history[history.count - 2].value
+        if latest > previous { self = .rising }
+        else if latest < previous { self = .falling }
+        else { self = .steady }
+    }
+
+    var symbol: String {
+        switch self {
+        case .rising: return "arrow.up.right"
+        case .falling: return "arrow.down.right"
+        case .steady: return "arrow.right"
+        }
+    }
+
+    var accessibilityLabel: Text {
+        switch self {
+        case .rising: return Text("Trending up")
+        case .falling: return Text("Trending down")
+        case .steady: return Text("No change")
+        }
+    }
+}
+
 // MARK: - MetricCard
 
 struct MetricCard: View {
@@ -42,37 +74,7 @@ struct MetricCard: View {
         return .primary
     }
 
-    /// Direction of the latest reading relative to the previous one, used to show
-    /// a small trend arrow in the overview. `nil` when there is no prior value to
-    /// compare against.
-    private enum Trend {
-        case rising, falling, steady
-
-        var symbol: String {
-            switch self {
-            case .rising: return "arrow.up.right"
-            case .falling: return "arrow.down.right"
-            case .steady: return "arrow.right"
-            }
-        }
-
-        var accessibilityLabel: Text {
-            switch self {
-            case .rising: return Text("Trending up")
-            case .falling: return Text("Trending down")
-            case .steady: return Text("No change")
-            }
-        }
-    }
-
-    private var trend: Trend? {
-        guard metric.history.count > 1 else { return nil }
-        let latest = metric.history[metric.history.count - 1].value
-        let previous = metric.history[metric.history.count - 2].value
-        if latest > previous { return .rising }
-        if latest < previous { return .falling }
-        return .steady
-    }
+    private var trend: MetricTrend? { MetricTrend(history: metric.history) }
 
     /// The colored category "dock" at the card's top-left. When a trend is
     /// available it doubles as the trend indicator and hosts a directional

--- a/LabImporter/Views/Dashboard/MetricCard.swift
+++ b/LabImporter/Views/Dashboard/MetricCard.swift
@@ -135,7 +135,11 @@ struct MetricCard: View {
             }
 
             if metric.history.count > 1 {
-                sparkline
+                MetricSparklineChart(history: metric.history, categoryColor: categoryColor, referenceRange: referenceRange)
+                    // Grow to absorb the card's remaining vertical space instead of
+                    // leaving a fixed-height chart with blank padding beneath it.
+                    // `minHeight` keeps a sensible floor when a card's row is short.
+                    .frame(minHeight: 44, maxHeight: .infinity)
             } else {
                 Spacer(minLength: 44)
             }
@@ -148,10 +152,20 @@ struct MetricCard: View {
                 .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
         )
     }
+}
 
-    private var sparkline: some View {
+// MARK: - MetricSparklineChart
+
+/// The line+area+point sparkline shared by the grid's `MetricCard` and the
+/// dashboard's single-metric hero card. Callers control size via `.frame`.
+struct MetricSparklineChart: View {
+    let history: [SparkPoint]
+    let categoryColor: Color
+    let referenceRange: ReferenceRange?
+
+    var body: some View {
         Chart {
-            ForEach(metric.history) { point in
+            ForEach(history) { point in
                 LineMark(
                     x: .value("Date", point.date),
                     y: .value("Value", point.value)
@@ -195,9 +209,52 @@ struct MetricCard: View {
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
-        // Grow to absorb the card's remaining vertical space instead of leaving a
-        // fixed-height chart with blank padding beneath it. `minHeight` keeps a
-        // sensible floor when a card's row is short.
-        .frame(minHeight: 44, maxHeight: .infinity)
     }
 }
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Sparkline") {
+    MetricSparklineChart(
+        history: [
+            SparkPoint(date: Date(timeIntervalSince1970: 1_700_000_000), value: 6.5),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_710_000_000), value: 6.3),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_720_000_000), value: 6.2)
+        ],
+        categoryColor: LabCategory.glycemic.color,
+        referenceRange: ReferenceRange(low: 4.0, high: 5.6)
+    )
+    .frame(height: 120)
+    .padding()
+}
+
+#Preview("Sparkline · No Range") {
+    MetricSparklineChart(
+        history: [
+            SparkPoint(date: Date(timeIntervalSince1970: 1_700_000_000), value: 6.5),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_710_000_000), value: 6.3),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_720_000_000), value: 6.2)
+        ],
+        categoryColor: LabCategory.glycemic.color,
+        referenceRange: nil
+    )
+    .frame(height: 120)
+    .padding()
+}
+
+#Preview("Sparkline · Dark") {
+    MetricSparklineChart(
+        history: [
+            SparkPoint(date: Date(timeIntervalSince1970: 1_700_000_000), value: 6.5),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_710_000_000), value: 6.3),
+            SparkPoint(date: Date(timeIntervalSince1970: 1_720_000_000), value: 6.2)
+        ],
+        categoryColor: LabCategory.glycemic.color,
+        referenceRange: ReferenceRange(low: 4.0, high: 5.6)
+    )
+    .frame(height: 120)
+    .padding()
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/LabImporter/Views/Shared/PreviewSampleData.swift
+++ b/LabImporter/Views/Shared/PreviewSampleData.swift
@@ -59,6 +59,48 @@ extension LabReport {
     }
 }
 
+extension LabReport {
+    /// A single-entry report (just HbA1c) — used by dashboard/hero-card previews
+    /// that exercise the "only one tracked value" state.
+    static func soleValueReport(value: Double = 5.4, daysAgo: Double = 0) -> LabReport {
+        let day: TimeInterval = 86_400
+        let anchor = Date(timeIntervalSince1970: 1_780_000_000)
+        return LabReport(
+            id: UUID(),
+            date: anchor.addingTimeInterval(-daysAgo * day),
+            patientName: "Max Mustermann",
+            authorName: "Laborzentrum München",
+            entries: [
+                Entry(id: UUID(), code: "4548-4", name: "HbA1c",
+                      displayValue: String(format: "%.1f", value), numericValue: value, unit: "%")
+            ]
+        )
+    }
+
+    /// Two readings of the sole tracked value, ~90 days apart, so the hero
+    /// card's sparkline has a real trend to draw.
+    static var soleValueTrend: [LabReport] {
+        [soleValueReport(value: 5.9, daysAgo: 92), soleValueReport(value: 5.4, daysAgo: 0)]
+    }
+
+    /// Two entries in one report — the dashboard's "few values" hint preview
+    /// state: not enough metrics for a balanced grid, but more than one.
+    static var pairValueReport: LabReport {
+        LabReport(
+            id: UUID(),
+            date: Date(timeIntervalSince1970: 1_780_000_000),
+            patientName: "Max Mustermann",
+            authorName: "Laborzentrum München",
+            entries: [
+                Entry(id: UUID(), code: "4548-4", name: "HbA1c",
+                      displayValue: "5.4", numericValue: 5.4, unit: "%"),
+                Entry(id: UUID(), code: "2093-3", name: "Cholesterol",
+                      displayValue: "180", numericValue: 180, unit: "mg/dL")
+            ]
+        )
+    }
+}
+
 extension LabValue {
     /// A short, mixed set for review/edit previews: a few ordinary values, one
     /// fuzzily-resolved suggestion to confirm, and one value with no LOINC code


### PR DESCRIPTION
Replace the small grid card + generic "import more" filler with a
large HeroMetricCard: bigger number, category icon, range badge, and
(once a second reading exists) a taller sparkline with a "Last
measured" date. With a single reading it explains why there's no
trend yet and offers the same import entry points inline.

Extracts MetricSparklineChart out of MetricCard so both the grid card
and the hero card share the same chart rendering, and moves
CategoryBackground into its own file to keep DashboardView under the
SwiftLint file-length limit.