### PR TITLE
Fix Release archive build: extend #if DEBUG to cover all Dashboard previews

### DIFF
--- a/LabImporter/Views/Dashboard/DashboardView.swift
+++ b/LabImporter/Views/Dashboard/DashboardView.swift
@@ -425,7 +425,6 @@ private extension DashboardView {
         )
     }
 }
-#endif
 
 #Preview("Few values") {
     NavigationStack {
@@ -474,3 +473,4 @@ private extension DashboardView {
         )
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- The dashboard redesign (b5842c9) closed the `#if DEBUG` guard in `DashboardView.swift` after only the first `#Preview`, leaving three later previews referencing DEBUG-only `PreviewSampleData` fixtures (`pairValueReport`, `soleValueReport`, `soleValueTrend`) unguarded.
- Release archives (Fastlane/TestFlight, run [30828009768](https://github.com/idoodler-s-Diabetes-Management/LabImporter/actions/runs/30828009768)) compile without `DEBUG`, so those symbols don't exist and `CompileSwift` fails with `** ARCHIVE FAILED **`.
- Fix: move the `#endif` to the end of the file so it covers all previews.

## Test plan
- [x] `xcodebuild -configuration Release -destination 'generic/platform=iOS' build` now succeeds (previously failed with the same 3 errors seen in CI)
- [x] `xcodebuild -configuration Debug` still builds and runs on device